### PR TITLE
Issues/2266 break up test job store test

### DIFF
--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -230,8 +230,6 @@ class AbstractJobStoreTest(object):
             self._testPerJobFiles(master, worker, jobNodeOnMaster)        # Test per-job files: Create empty file on master
             self._testStatsAndLogging(master, worker, jobOnMaster)        # Test stats and loggingAdd
 
-
-        # Added
         def _testChangingAndPersistingJobs(self, childJobs, master, worker):
             for childJob in childJobs:
                 childJob.logJobStoreFileID = str(uuid.uuid4())
@@ -243,7 +241,6 @@ class AbstractJobStoreTest(object):
                 self.assertEquals(master.load(childJob.jobStoreID), childJob)
                 self.assertEquals(worker.load(childJob.jobStoreID), childJob)
 
-        # Added
         def _testJobDeletions(self, childJobs, master, worker):
             for childJob in childJobs:
                 self.assertTrue(master.exists(childJob.jobStoreID))
@@ -261,7 +258,6 @@ class AbstractJobStoreTest(object):
             except NoSuchFileException:
                 pass
 
-        # Added
         def _testPerJobFiles(self, master, worker, jobNodeOnMaster):
             # First recreate job
             jobOnMaster = master.create(jobNodeOnMaster)
@@ -322,7 +318,6 @@ class AbstractJobStoreTest(object):
                 except NoSuchFileException:
                     pass
 
-        # Added
         def _testStatsAndLogging(self, master, worker, jobOnMaster):
             # Test stats and logging
             #
@@ -358,7 +353,6 @@ class AbstractJobStoreTest(object):
             self.assertFalse(master.exists(jobOnMaster.jobStoreID))
             # TODO: Who deletes the shared files?
 
-        # Added
         def _testSharedFiles(self, master, worker):
             with master.writeSharedFileStream('foo') as f:
                 f.write('bar')
@@ -374,7 +368,6 @@ class AbstractJobStoreTest(object):
             self.assertUrl(master.getSharedPublicUrl('nonEncrypted'))
             self.assertRaises(NoSuchFileException, master.getSharedPublicUrl, 'missing')
 
-        # Added
         def _testExistanceAndAttributes(self, master, jobOnMaster, masterRequirements):
             self.assertTrue(master.exists(jobOnMaster.jobStoreID))
             self.assertEquals(jobOnMaster.command, 'master1')
@@ -388,7 +381,6 @@ class AbstractJobStoreTest(object):
             self.assertEquals(jobOnMaster.predecessorNumber, 0)
             self.assertEquals(jobOnMaster.predecessorsFinished, set())
             self.assertEquals(jobOnMaster.logJobStoreFileID, None)
-
 
         def testBatchCreate(self):
             master = self.master

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -133,46 +133,30 @@ class AbstractJobStoreTest(object):
         def test(self):
             """
             This is a front-to-back test of the "happy" path in a job store, i.e. covering things
-            that occur in the dat to day life of a job store. The purist might insist that this be
+            that occur in the day to day life of a job store. The purist might insist that this be
             split up into several cases and I agree wholeheartedly.
             """
             master = self.master
 
             # Test initial state
-            #
             self.assertFalse(master.exists('foo'))
             self.assertRaises(NoSuchJobException, master.load, 'foo')
 
             # Create parent job and verify its existence/properties
-            #
             masterRequirements = dict(memory=12, cores=34, disk=35, preemptable=True)
             jobNodeOnMaster = JobNode(command='master1',
                                       requirements=masterRequirements,
                                       jobName='test1', unitName='onMaster',
                                       jobStoreID=None, predecessorNumber=0)
             jobOnMaster = master.create(jobNodeOnMaster)
-            self.assertTrue(master.exists(jobOnMaster.jobStoreID))
-            self.assertEquals(jobOnMaster.command, 'master1')
-            self.assertEquals(jobOnMaster.memory, masterRequirements['memory'])
-            self.assertEquals(jobOnMaster.cores, masterRequirements['cores'])
-            self.assertEquals(jobOnMaster.disk, masterRequirements['disk'])
-            self.assertEquals(jobOnMaster.preemptable, masterRequirements['preemptable'])
-            self.assertEquals(jobOnMaster.jobName, 'test1')
-            self.assertEquals(jobOnMaster.unitName, 'onMaster')
-            self.assertEquals(jobOnMaster.stack, [])
-            self.assertEquals(jobOnMaster.predecessorNumber, 0)
-            self.assertEquals(jobOnMaster.predecessorsFinished, set())
-            self.assertEquals(jobOnMaster.logJobStoreFileID, None)
-
-            
-
+            self.testExistanceAndAttributes(master, jobOnMaster, masterRequirements)
 
             # Create a second instance of the job store, simulating a worker ...
-            #
             worker = self._createJobStore()
             worker.resume()
             self.assertEquals(worker.config, self.config)
             self.assertIsNot(worker.config, self.config)
+
             # ... and load the parent job there.
             jobOnWorker = worker.load(jobOnMaster.jobStoreID)
             self.assertEquals(jobOnMaster, jobOnWorker)
@@ -185,8 +169,10 @@ class AbstractJobStoreTest(object):
             # unneeded files
             jobOnWorker.filesToDelete = ['1', '2']
             worker.update(jobOnWorker)
+
             # Check jobs to delete persisted
             self.assertEquals(master.load(jobOnWorker.jobStoreID).filesToDelete, ['1', '2'])
+
             # Create children
             childRequirements1 = dict(memory=23, cores=45, disk=46, preemptable=True)
             jobNodeOnChild1 = JobNode(command='child1',
@@ -200,14 +186,15 @@ class AbstractJobStoreTest(object):
                                       jobStoreID=None)
             child1 = worker.create(jobNodeOnChild1)
             child2 = worker.create(jobNodeOnChild2)
+
             # Update parent
             jobOnWorker.stack.append((child1, child2))
             jobOnWorker.filesToDelete = []
             worker.update(jobOnWorker)
 
             # Check equivalence between master and worker
-            #
             self.assertNotEquals(jobOnWorker, jobOnMaster)
+
             # Reload parent job on master
             jobOnMaster = master.load(jobOnMaster.jobStoreID)
             self.assertEquals(jobOnWorker, jobOnMaster)
@@ -215,18 +202,10 @@ class AbstractJobStoreTest(object):
             self.assertEquals(master.load(child1.jobStoreID), child1)
             self.assertEquals(master.load(child2.jobStoreID), child2)
 
-            # Test changing and persisting job state across multiple jobs
-            #
             childJobs = [worker.load(childNode.jobStoreID) for childNode in jobOnMaster.stack[-1]]
-            for childJob in childJobs:
-                childJob.logJobStoreFileID = str(uuid.uuid4())
-                childJob.remainingRetryCount = 66
-                self.assertNotEquals(childJob, master.load(childJob.jobStoreID))
-            for childJob in childJobs:
-                worker.update(childJob)
-            for childJob in childJobs:
-                self.assertEquals(master.load(childJob.jobStoreID), childJob)
-                self.assertEquals(worker.load(childJob.jobStoreID), childJob)
+
+            # Test changing and persisting job state across multiple jobs
+            self.testChangingAndPersistingJobs(childJobs, master, worker)
 
             # Test job iterator - the results of the iterator are effected by eventual
             # consistency. We cannot guarantee all jobs will appear but we can assert that all
@@ -237,14 +216,32 @@ class AbstractJobStoreTest(object):
             self.assertTrue(set(childJobs + [jobOnMaster]) >= set(master.jobs()))
 
             # Test job deletions
-            #
             # First delete parent, this should have no effect on the children
             self.assertTrue(master.exists(jobOnMaster.jobStoreID))
             self.assertTrue(worker.exists(jobOnMaster.jobStoreID))
             master.delete(jobOnMaster.jobStoreID)
             self.assertFalse(master.exists(jobOnMaster.jobStoreID))
             self.assertFalse(worker.exists(jobOnMaster.jobStoreID))
+            self.testJobDeletions(childJobs, master, worker)
 
+            self.testSharedFiles(master,worker)                         # Test shared files: Write shared file on master
+            self.testPerJobFiles(master,worker, jobNodeOnMaster)        # Test per-job files: Create empty file on master
+            self.testStatsAndLogging(master, worker, jobOnMaster)       # Test stats and logging
+
+        # Added
+        def testChangingAndPersistingJobs(self, childJobs, master, worker):
+            for childJob in childJobs:
+                childJob.logJobStoreFileID = str(uuid.uuid4())
+                childJob.remainingRetryCount = 66
+                self.assertNotEquals(childJob, master.load(childJob.jobStoreID))
+            for childJob in childJobs:
+                worker.update(childJob)
+            for childJob in childJobs:
+                self.assertEquals(master.load(childJob.jobStoreID), childJob)
+                self.assertEquals(worker.load(childJob.jobStoreID), childJob)
+
+        # Added
+        def testJobDeletions(self, childJobs, master, worker):
             for childJob in childJobs:
                 self.assertTrue(master.exists(childJob.jobStoreID))
                 self.assertTrue(worker.exists(childJob.jobStoreID))
@@ -261,24 +258,8 @@ class AbstractJobStoreTest(object):
             except NoSuchFileException:
                 pass
 
-            # Test shared files: Write shared file on master, ...
-            #
-            with master.writeSharedFileStream('foo') as f:
-                f.write('bar')
-            # ... read that file on worker, ...
-            with worker.readSharedFileStream('foo') as f:
-                self.assertEquals('bar', f.read())
-            # ... and read it again on master.
-            with master.readSharedFileStream('foo') as f:
-                self.assertEquals('bar', f.read())
-
-            with master.writeSharedFileStream('nonEncrypted', isProtected=False) as f:
-                f.write('bar')
-            self.assertUrl(master.getSharedPublicUrl('nonEncrypted'))
-            self.assertRaises(NoSuchFileException, master.getSharedPublicUrl, 'missing')
-
-            # Test per-job files: Create empty file on master, ...
-            #
+        # Added
+        def testPerJobFiles(self, master, worker, jobNodeOnMaster):
             # First recreate job
             jobOnMaster = master.create(jobNodeOnMaster)
             fileOne = worker.getEmptyFileStoreID(jobOnMaster.jobStoreID)
@@ -338,6 +319,8 @@ class AbstractJobStoreTest(object):
                 except NoSuchFileException:
                     pass
 
+        # Added
+        def testStatsAndLogging(self, master, worker, jobOnMaster):
             # Test stats and logging
             #
             stats = None
@@ -371,6 +354,38 @@ class AbstractJobStoreTest(object):
             master.delete(jobOnMaster.jobStoreID)
             self.assertFalse(master.exists(jobOnMaster.jobStoreID))
             # TODO: Who deletes the shared files?
+
+        # Added
+        def testSharedFiles(self,master, worker):
+            with master.writeSharedFileStream('foo') as f:
+                f.write('bar')
+            # ... read that file on worker, ...
+            with worker.readSharedFileStream('foo') as f:
+                self.assertEquals('bar', f.read())
+            # ... and read it again on master.
+            with master.readSharedFileStream('foo') as f:
+                self.assertEquals('bar', f.read())
+
+            with master.writeSharedFileStream('nonEncrypted', isProtected=False) as f:
+                f.write('bar')
+            self.assertUrl(master.getSharedPublicUrl('nonEncrypted'))
+            self.assertRaises(NoSuchFileException, master.getSharedPublicUrl, 'missing')
+
+        # Added
+        def testExistanceAndAttributes(self, master, jobOnMaster, masterRequirements):
+            self.assertTrue(master.exists(jobOnMaster.jobStoreID))
+            self.assertEquals(jobOnMaster.command, 'master1')
+            self.assertEquals(jobOnMaster.memory, masterRequirements['memory'])
+            self.assertEquals(jobOnMaster.cores, masterRequirements['cores'])
+            self.assertEquals(jobOnMaster.disk, masterRequirements['disk'])
+            self.assertEquals(jobOnMaster.preemptable, masterRequirements['preemptable'])
+            self.assertEquals(jobOnMaster.jobName, 'test1')
+            self.assertEquals(jobOnMaster.unitName, 'onMaster')
+            self.assertEquals(jobOnMaster.stack, [])
+            self.assertEquals(jobOnMaster.predecessorNumber, 0)
+            self.assertEquals(jobOnMaster.predecessorsFinished, set())
+            self.assertEquals(jobOnMaster.logJobStoreFileID, None)
+
 
         def testBatchCreate(self):
             master = self.master


### PR DESCRIPTION
Simplifies the test() method by creating and utilizing helper functions.
Addresses #2259 