### PR TITLE
Issues/2122 add azure environ var

### DIFF
--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -52,6 +52,8 @@ There are several environment variables that affect the way Toil runs.
 |                        | deleted until all associated nodes have been       |
 |                        | terminated.                                        |
 +------------------------+----------------------------------------------------+
+| TOIL_AZURE_ZONE        | The default region for provisioning instances.     |
++------------------------+----------------------------------------------------+
 | TOIL_SLURM_ARGS        | Arguments for sbatch for the slurm batch system.   |
 |                        | Do not pass CPU or memory specifications here.     |
 |                        | Instead, define resource requirements for the job. |

--- a/docs/gettingStarted/quickStart.rst
+++ b/docs/gettingStarted/quickStart.rst
@@ -525,8 +525,8 @@ Also!  Remember to use the :ref:`destroyCluster` command when finished to destro
 
         **A Helpful Tip**
 
-        When using AWS, setting the environment variable eliminates having to specify the ``--zone`` option for each command.
-        This will be supported for GCE and Azure in the future. ::
+        When using AWS or Azure, setting the environment variable eliminates having to specify the ``--zone`` option
+        for each command. This will be supported for GCEin the future. ::
 
             (venv) $ export TOIL_AWS_ZONE=us-west-2c
 

--- a/docs/running/cloud/azure.rst
+++ b/docs/running/cloud/azure.rst
@@ -105,3 +105,23 @@ After :ref:`prepareAzure` all you will need to do is specify the job store name 
 For example to run the sort example with Azure job store you would run ::
 
     $ python sort.py azure:<my-azure-account-name>:my-azure-jobstore
+
+Details about Launching a Cluster in Azure
+------------------------------------------
+
+Using the provisioner to launch a Toil leader instance is simple using the ``launch-cluster`` command. For example,
+to launch a cluster named "my-cluster" with a Standard_A2 leader in the westus zone, run ::
+
+    (venv) $ toil launch-cluster my-cluster --provisioner azure --leaderNodeType Standard_A2 --zone westus --keyPairName <your-AWS-key-pair-name>
+
+The cluster name is used to uniquely identify your cluster and will be used to
+populate the instance's ``Name`` tag. In addition, the Toil provisioner will
+automatically tag your cluster with an ``Owner`` tag that corresponds to your
+keypair name to facilitate cost tracking.
+
+The ``--zone`` parameter specifies which availability zone to launch the cluster in.
+Alternatively, you can specify this option via the ``TOIL_AZURE_ZONE`` environment variable.
+
+For more information on options try: ::
+
+    (venv) $ toil launch-cluster --help

--- a/docs/running/cloud/clusterUtils.rst
+++ b/docs/running/cloud/clusterUtils.rst
@@ -204,12 +204,12 @@ exist yet, Toil will create it for you.
                         -p CLOUDPROVIDER also accepted.  The provisioner for
                         cluster auto-scaling.  Both aws and google's gce are
                         currently supported.
-  --zone ZONE           -z ZONE also accepted.  The AWS availability zone of the master. This
-                        parameter can also be set via the TOIL_AWS_ZONE
+  --zone ZONE           -z ZONE also accepted.  The availability zone of the leader. This
+                        parameter can also be set via the TOIL_AWS_ZONE or TOIL_AZURE_ZONE
                         environment variable, or by the ec2_region_name
-                        parameter in your .boto file, or derived from the
+                        parameter in your .boto file if using AWS, or derived from the
                         instance metadata if using this utility on an existing
-                        EC2 instance. Currently: us-west-1a
+                        EC2 instance. Currently: us-west-2a
   --leaderNodeType LEADERNODETYPE
                         Non-preemptable node type to use for the cluster
                         leader.

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -287,9 +287,6 @@ def parseBasicOptions(parser):
     if options.provisioner == 'azure':
         if os.environ.get('TOIL_AZURE_ZONE'):
             options.zone = os.environ.get('TOIL_AZURE_ZONE')
-    elif options.provisioner == 'gce':
-        if os.environ.get('TOIL_AZURE_ZONE'):
-            options.zone = os.environ.get('TOIL_AZURE_ZONE')
 
     #Set up the temp dir root
     if options.tempDirRoot == "None": # FIXME: Really, a string containing the word None?

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -283,6 +283,14 @@ def parseBasicOptions(parser):
 
     setLoggingFromOptions(options)
 
+    # Look for a default zone.
+    if options.provisioner == 'azure':
+        if os.environ.get('TOIL_AZURE_ZONE'):
+            options.zone = os.environ.get('TOIL_AZURE_ZONE')
+    elif options.provisioner == 'gce':
+        if os.environ.get('TOIL_AZURE_ZONE'):
+            options.zone = os.environ.get('TOIL_AZURE_ZONE')
+
     #Set up the temp dir root
     if options.tempDirRoot == "None": # FIXME: Really, a string containing the word None?
         options.tempDirRoot = tempfile.gettempdir()

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -284,7 +284,7 @@ def parseBasicOptions(parser):
     setLoggingFromOptions(options)
 
     # Look for a default zone.
-    if options.provisioner == 'azure':
+    if hasattr(options, 'provisioner') and options.provisioner == 'azure':
         if os.environ.get('TOIL_AZURE_ZONE'):
             options.zone = os.environ.get('TOIL_AZURE_ZONE')
 

--- a/src/toil/provisioners/azure/azureProvisioner.py
+++ b/src/toil/provisioners/azure/azureProvisioner.py
@@ -211,8 +211,7 @@ class AzureProvisioner(AnsibleDriver):
         try:
             self.callPlaybook(self.playbook['check-cluster'], ansibleArgs, wait=True)
         except RuntimeError:
-            logger.info("The cluster could not be created. Try deleting the cluster if it already exits.")
-            raise
+            raise RuntimeError("The cluster could not be created. Try deleting the cluster if it already exits.")
 
     def destroyCluster(self):
         nodes = self._getNodes()


### PR DESCRIPTION
This is a redo of PR #2264 which was closed to a force-push related incident.

There was no support for setting a default Azure zone via an environment variable. This was addressed as well as updating documentation to reflect the change. Incidentally, an the helpfulness of an error message I encountered was increased.