### PR TITLE
Simple change to logic to correctly filter AWS security groups

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -549,7 +549,7 @@ class AWSProvisioner(AbstractProvisioner):
                     web.authorize(ip_protocol='udp', from_port=0, to_port=65535, src_group=web)
         out = []
         for sg in self._ctx.ec2.get_all_security_groups():
-            if sg.name == self.clusterName and vpcId is None or sg.vpc_id == vpcId:
+            if sg.name == self.clusterName and (vpcId is None or sg.vpc_id == vpcId):
                 out.append(sg)
         return out
 


### PR DESCRIPTION
At end of function that creates the cluster security group, there is
some logic that loops through the EC2 security groups to find the
one that is named for the cluster, and also is in the specified VPC,
if a VPC was specified. The security group is then returned and
applied to the EC2 instance in the calling function. The logic
however, was not correct, and results in getting all the security
groups. Usually this is not an issue, but if there are a lot of
security groups, this can be a problem with AWS limits on the
number of security groups per EC2 instance or network interface.

(resolves #1714)