### PR TITLE
Stop FileJobStore DEBUG messages from sneaking out once for every job

### DIFF
--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -32,6 +32,8 @@ import logging
 import shutil
 from threading import Thread
 
+logging.basicConfig()
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -115,6 +117,7 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
     :param bool redirectOutputToLogFile: Redirect standard out and standard error to a log file
     """
     logging.basicConfig()
+    setLogLevel(config.logLevel)
 
     ##########################################
     #Create the worker killer, if requested
@@ -154,8 +157,6 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
         for e in environment["PYTHONPATH"].split(':'):
             if e != '':
                 sys.path.append(e)
-
-    setLogLevel(config.logLevel)
 
     toilWorkflowDir = Toil.getWorkflowDir(config.workflowID, config.workDir)
 


### PR DESCRIPTION
This has been driving me freaking batty.

The previous behavior caused messages like this:
```
DEBUG:toil.jobStores.fileJobStore:Path to job store directory is '/Users/joel/cactus/jobStore'.
```
to be printed once per job run, regardless of log level setting. This was especially frustrating in single-machine mode, where these end up being output hundreds of times, crowding out any useful output.

The issue turned out to be that `toil/test/__init__.py` tries to run `logging.basicConfig()` hardcoded with level `DEBUG`, and something in `worker.py` was transitively importing `runningOnEC2` from a module under `toil.test`. Ensuring that `logging.basicConfig()` is run much earlier in the imports in worker.py fixes the problem. (Or we could remove the hardcoded `DEBUG` config from `toil.test`, but that might bite us later if it turns off debug output for some tests.)