### PR TITLE
Enable support for specifying zone in all environment variables. Resolves #2319 and# 2295

### DIFF
--- a/src/toil/provisioners/azure/__init__.py
+++ b/src/toil/provisioners/azure/__init__.py
@@ -11,17 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import os
-
-def getAzureZone(defaultZone=None):
-    """
-    Find an appropriate azure zone.
-
-    Look for an environment variable or return a default as provided.
-
-    :param defaultZone: The zone specified in the leader metadata.
-    :return zone:  The zone.
-    """
-
-    return os.environ.get('TOIL_AZURE_ZONE') or defaultZone

--- a/src/toil/provisioners/azure/azureProvisioner.py
+++ b/src/toil/provisioners/azure/azureProvisioner.py
@@ -30,7 +30,6 @@ from toil.provisioners import NoSuchClusterException
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.network import NetworkManagementClient
-from toil.provisioners.azure import getAzureZone
 
 
 logger = logging.getLogger(__name__)
@@ -76,8 +75,6 @@ class AzureProvisioner(AnsibleDriver):
         credentials = ServicePrincipalCredentials(client_id=client_id, secret=secret, tenant=tenant)
         self._azureComputeClient = ComputeManagementClient(credentials, subscription)
         self._azureNetworkClient = NetworkManagementClient(credentials, subscription)
-
-        self._zone = getAzureZone() or zone
         self._onLeader = False
         if not clusterName:
             # If no clusterName, Toil must be running on the leader.

--- a/src/toil/utils/__init__.py
+++ b/src/toil/utils/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from toil import version
+import os
 import logging
 
 logger = logging.getLogger(__name__)
@@ -11,19 +12,25 @@ def addBasicProvisionerOptions(parser):
     parser.add_argument('-p', "--provisioner", dest='provisioner', choices=['aws', 'azure', 'gce'], required=False, default="aws",
                         help="The provisioner for cluster auto-scaling. Only aws is currently "
                              "supported")
-    try:
-        from toil.provisioners.aws import getCurrentAWSZone
-        currentZone = getCurrentAWSZone()
-    except ImportError:
-        currentZone = None
-    zoneString = currentZone if currentZone else 'No zone could be determined'
-    parser.add_argument('-z', '--zone', dest='zone', required=False, default=currentZone,
-                        help="The AWS availability zone of the master. This parameter can also be "
-                             "set via the TOIL_AWS_ZONE environment variable, or by the ec2_region_name "
-                             "parameter in your .boto file, or derived from the instance metadata if "
-                             "using this utility on an existing EC2 instance. "
-                             "Currently: %s" % zoneString)
+    parser.add_argument('-z', '--zone', dest='zone', required=False, default=None,
+                        help="The availability zone of the master. This parameter can also be set via the 'TOIL_X_ZONE' "
+                             "environment variable, where X is AWS, GCE, or AZURE, or by the ec2_region_name parameter "
+                             "in your .boto file, or derived from the instance metadata if using this utility on an "
+                             "existing EC2 instance.")
     parser.add_argument("clusterName", help="The name that the cluster will be identifiable by. "
                                             "Must be lowercase and may not contain the '_' "
                                             "character.")
     return parser
+
+def getZoneFromEnv(provisioner):
+    """
+    Find the zone specified in an environment variable.
+
+    The user can specify zones in environment variables in leiu of writing them at the commandline every time.
+    Given a provisioner, this method will look for the stored value and return it.
+
+    :param str provisioner: One of the supported provisioners ('azure', 'aws', 'gce')
+    :rtype: str
+    :return: None or the value stored in a 'TOIL_X_ZONE' environment variable.
+    """
+    return os.environ.get('TOIL_' + provisioner.upper() + '_ZONE')

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -16,7 +16,7 @@ Launches a toil leader instance with the specified provisioner
 """
 import logging
 from toil.lib.bioio import parseBasicOptions, getBasicOptionParser
-from toil.utils import addBasicProvisionerOptions
+from toil.utils import addBasicProvisionerOptions, getZoneFromEnv
 from toil.provisioners import clusterFactory
 from toil.provisioners.aws import checkValidNodeTypes
 from toil import applianceSelf
@@ -133,6 +133,9 @@ def main():
         owner = config.owner
     elif config.keyPairName:
         owner = config.keyPairName
+
+    # Check to see if the user specified a zone. If not, see if one is stored in an environment variable.
+    config.zone = config.zone or getZoneFromEnv(config.provisioner)
 
     cluster = clusterFactory(provisioner=config.provisioner,
                              clusterName=config.clusterName,


### PR DESCRIPTION
Change where default zone is determined, allow environment vars for all provisioners.

Previously, if the user specified an value in TOIL_AZURE_ZONE that value would override the vlaue input on the commandline. This fix also happens to address the overall issue of not supporting this feature for all provisioners.