### PR TITLE
Fix mixing up S3 with Google Cloud Storage in docs

### DIFF
--- a/docs/running/introduction.rst
+++ b/docs/running/introduction.rst
@@ -42,7 +42,7 @@ Toil currently supports the following cloud storage systems as job stores:
 
  - :ref:`awsJobStore`: An AWS S3 bucket formatted as "aws:<zone>:<bucketname>" where only numbers, letters, and dashes are allowed in the bucket name.  Example: `aws:us-west-2:my-aws-jobstore-name`.
  - :ref:`azureJobStore`: Experimental.
- - :ref:`googleJobStore`: An AWS S3 bucket formatted as "aws:<zone>:<bucketname>" where only numbers, letters, and dashes are allowed in the bucket name.  Example: `gce:us-west2-2a:my-google-jobstore-name`.
+ - :ref:`googleJobStore`: A Google Cloud Storage bucket formatted as "gce:<zone>:<bucketname>" where only numbers, letters, and dashes are allowed in the bucket name.  Example: `gce:us-west2-a:my-google-jobstore-name`.
 
 These use cloud buckets to house all of the files. This is useful if there are several different
 worker machines all running jobs that need to access the job store.


### PR DESCRIPTION
Also, haven't tested this, but is

```
gce:us-west2-2a:my-google-jobstore-name
```

still the correct format for specifying Google Cloud Storage buckets?