### PR TITLE
Improve documentation around fileID (resolves #2278)

### DIFF
--- a/docs/developingWorkflows/developing.rst
+++ b/docs/developingWorkflows/developing.rst
@@ -569,7 +569,7 @@ multiple jobs' output values::
 FileID
 ------
 
-This object is a small wrapper around Python's builtin string class. It is used to
+The :class:`toil.fileStore.FileID` class is a small wrapper around Python's builtin string class. It is used to
 represent a file's ID in the file store, and has a ``size`` attribute that is the
 file's size in bytes. This object is returned by ``importFile`` and ``writeGlobalFile``.
 

--- a/docs/developingWorkflows/toilAPIFilestore.rst
+++ b/docs/developingWorkflows/toilAPIFilestore.rst
@@ -7,3 +7,6 @@ The FileStore is an abstraction of a Toil run's shared storage.
 
 .. autoclass:: toil.fileStore::FileStore
    :members:
+
+.. autoclass:: toil.fileStore::FileID
+   :members:

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -1838,9 +1838,10 @@ class NonCachingFileStore(FileStore):
 
 class FileID(str):
     """
-    A class to wrap the job store file id returned by writeGlobalFile and any attributes we may want
-    to add to it.
+    A small wrapper around Python's builtin string class. It is used to represent a file's ID in the file store, and
+    has a size attribute that is the file's size in bytes. This object is returned by importFile and writeGlobalFile.
     """
+
     def __new__(cls, fileStoreID, *args):
         return super(FileID, cls).__new__(cls, fileStoreID)
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -288,7 +288,7 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
         :param str sharedFileName: Optional name to assign to the imported file within the job store
 
         :return: The jobStoreFileId of the imported file or None if sharedFileName was given
-        :rtype: FileID or None
+        :rtype: toil.fileStore.FileID or None
         """
         # Note that the helper method _importFile is used to read from the source and write to
         # destination (which is the current job store in this case). To implement any
@@ -313,7 +313,7 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
         :param str sharedFileName: Optional name to assign to the imported file within the job store
 
         :return The jobStoreFileId of imported file or None if sharedFileName was given
-        :rtype: FileID or None
+        :rtype: toil.fileStore.FileID or None
         """
         if sharedFileName is None:
             with self.writeFileStream() as (writable, jobStoreFileID):


### PR DESCRIPTION
It was pointed out that there was no documentation around accessing the size of a file stored in a jobstore. There was a little blurb about FileID's in general in the "Developing Workflows" section but I can see how it could be improved. This PR adds the FileID class to the "Filestore API" section as well as a link between this and the previously mentioned blurb. @adamnovak @joelarmstrong did you miss the blurb or not feel it was a sufficient description? Let me know if you have any feedback that I can use to improve this documentation.