### PR TITLE
Prevent worker from checking for nonexistant file (resolves #2300)

### DIFF
--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -451,7 +451,7 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
     # Now our file handles are in exactly the state they were in before.
 
     #Copy back the log file to the global dir, if needed
-    if workerFailed:
+    if workerFailed and redirectOutputToLogFile:
         jobGraph.logJobStoreFileID = jobStore.getEmptyFileStoreID(jobGraph.jobStoreID)
         jobGraph.chainedJobs = listOfJobs
         with jobStore.updateFileStream(jobGraph.logJobStoreFileID) as w:


### PR DESCRIPTION
Worker.py will try to read redirected stdout/err logs which are not always created. This PR will prevent this read from happening unless these outputs were redirected.