### PR TITLE
Issues/2319 env vals override

### DIFF
--- a/docs/running/cloud/clusterUtils.rst
+++ b/docs/running/cloud/clusterUtils.rst
@@ -205,11 +205,11 @@ exist yet, Toil will create it for you.
                         cluster auto-scaling.  Both aws and google's gce are
                         currently supported.
   --zone ZONE           -z ZONE also accepted.  The availability zone of the leader. This
-                        parameter can also be set via the TOIL_AWS_ZONE or TOIL_AZURE_ZONE
-                        environment variable, or by the ec2_region_name
+                        parameter can also be set via the TOIL_AWS_ZONE or TOIL_AZURE_ZONE, or TOIL_GCE_ZONE
+                        environment variables, or by the ec2_region_name
                         parameter in your .boto file if using AWS, or derived from the
                         instance metadata if using this utility on an existing
-                        EC2 instance. Currently: us-west-2a
+                        EC2 instance.
   --leaderNodeType LEADERNODETYPE
                         Non-preemptable node type to use for the cluster
                         leader.

--- a/src/toil/provisioners/azure/__init__.py
+++ b/src/toil/provisioners/azure/__init__.py
@@ -11,17 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import os
-
-def getAzureZone(defaultZone=None):
-    """
-    Find an appropriate azure zone.
-
-    Look for an environment variable or return a default as provided.
-
-    :param defaultZone: The zone specified in the leader metadata.
-    :return zone:  The zone.
-    """
-
-    return os.environ.get('TOIL_AZURE_ZONE') or defaultZone

--- a/src/toil/provisioners/azure/azureProvisioner.py
+++ b/src/toil/provisioners/azure/azureProvisioner.py
@@ -33,7 +33,6 @@ from toil.provisioners import NoSuchClusterException
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.network import NetworkManagementClient
-from toil.provisioners.azure import getAzureZone
 
 
 logger = logging.getLogger(__name__)
@@ -79,8 +78,6 @@ class AzureProvisioner(AnsibleDriver):
         credentials = ServicePrincipalCredentials(client_id=client_id, secret=secret, tenant=tenant)
         self._azureComputeClient = ComputeManagementClient(credentials, subscription)
         self._azureNetworkClient = NetworkManagementClient(credentials, subscription)
-
-        self._zone = getAzureZone() or zone
         self._onLeader = False
         if not clusterName:
             # If no clusterName, Toil must be running on the leader.
@@ -102,7 +99,7 @@ class AzureProvisioner(AnsibleDriver):
         metadata = json.loads(dataStr)
 
         # set values from the leader meta-data
-        self._zone = self._zone or getAzureZone(metadata['compute']['location'])
+        self._zone = metadata['compute']['location']
         self.clusterName = metadata['compute']['resourceGroupName']
         tagsStr = metadata['compute']['tags']
         tags = dict(item.split(":") for item in tagsStr.split(";"))

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -59,7 +59,7 @@ class AbstractAWSAutoscaleTest(ToilTest):
     def createClusterUtil(self, args=None):
         if args is None:
             args = []
-        callCommand = ['toil', 'launch-cluster', '-p=aws', '--keyPairName=%s' % self.keyName,
+        callCommand = ['toil', 'launch-cluster', '-p=aws', '-z=us-west-2a','--keyPairName=%s' % self.keyName,
                        '--leaderNodeType=%s' % self.leaderInstanceType, self.clusterName]
         callCommand = callCommand + args if args else callCommand
         subprocess.check_call(callCommand)

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -109,7 +109,7 @@ class UtilsTest(ToilTest):
             # launch master with same name
             system([self.toilMain, 'launch-cluster', '-t', 'key1=value1', '-t', 'key2=value2', '--tag', 'key3=value3',
                     '--leaderNodeType=m3.medium', '--keyPairName=' + keyName, clusterName,
-                    '--provisioner=aws', '--logLevel=DEBUG'])
+                    '--provisioner=aws', '--zone=us-west-2a','--logLevel=DEBUG'])
 
             cluster = clusterFactory(provisioner='aws', clusterName=clusterName)
             leader = cluster.getLeader()

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -95,7 +95,7 @@ class UtilsTest(ToilTest):
         try:
             # --provisioner flag should default to aws, so we're not explicitly
             # specifying that here
-            system([self.toilMain, 'launch-cluster', '--leaderNodeType=t2.micro',
+            system([self.toilMain, 'launch-cluster', '--leaderNodeType=t2.micro', '--zone=us-west-2a',
                     '--keyPairName=' + keyName, clusterName])
         finally:
             system([self.toilMain, 'destroy-cluster', '--provisioner=aws', clusterName])

--- a/src/toil/utils/__init__.py
+++ b/src/toil/utils/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from toil import version
 import logging
-
+import os
 logger = logging.getLogger(__name__)
 
 
@@ -11,19 +11,26 @@ def addBasicProvisionerOptions(parser):
     parser.add_argument('-p', "--provisioner", dest='provisioner', choices=['aws', 'azure', 'gce'], required=False, default="aws",
                         help="The provisioner for cluster auto-scaling. Only aws is currently "
                              "supported")
-    try:
-        from toil.provisioners.aws import getCurrentAWSZone
-        currentZone = getCurrentAWSZone()
-    except ImportError:
-        currentZone = None
-    zoneString = currentZone if currentZone else 'No zone could be determined'
-    parser.add_argument('-z', '--zone', dest='zone', required=False, default=currentZone,
-                        help="The AWS availability zone of the master. This parameter can also be "
-                             "set via the TOIL_AWS_ZONE environment variable, or by the ec2_region_name "
-                             "parameter in your .boto file, or derived from the instance metadata if "
-                             "using this utility on an existing EC2 instance. "
-                             "Currently: %s" % zoneString)
+    parser.add_argument('-z', '--zone', dest='zone', required=False, default=None,
+                        help="The availability zone of the master. This parameter can also be set via the 'TOIL_X_ZONE' "
+                             "environment variable, where X is AWS, GCE, or AZURE, or by the ec2_region_name parameter "
+                             "in your .boto file, or derived from the instance metadata if using this utility on an "
+                             "existing EC2 instance.")
     parser.add_argument("clusterName", help="The name that the cluster will be identifiable by. "
                                             "Must be lowercase and may not contain the '_' "
                                             "character.")
     return parser
+
+
+def getZoneFromEnv(provisioner):
+    """
+    Find the zone specified in an environment variable.
+
+    The user can specify zones in environment variables in leiu of writing them at the commandline every time.
+    Given a provisioner, this method will look for the stored value and return it.
+    :param str provisioner: One of the supported provisioners ('azure', 'aws', 'gce')
+    :rtype: str
+    :return: None or the value stored in a 'TOIL_X_ZONE' environment variable.
+    """
+
+    return os.environ.get('TOIL_' + provisioner.upper() + '_ZONE')

--- a/src/toil/utils/__init__.py
+++ b/src/toil/utils/__init__.py
@@ -26,7 +26,7 @@ def getZoneFromEnv(provisioner):
     """
     Find the zone specified in an environment variable.
 
-    The user can specify zones in environment variables in leiu of writing them at the commandline every time.
+    The user can specify zones in environment variables in lieu of writing them at the commandline every time.
     Given a provisioner, this method will look for the stored value and return it.
     :param str provisioner: One of the supported provisioners ('azure', 'aws', 'gce')
     :rtype: str

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -16,7 +16,7 @@ Launches a toil leader instance with the specified provisioner
 """
 import logging
 from toil.lib.bioio import parseBasicOptions, getBasicOptionParser
-from toil.utils import addBasicProvisionerOptions
+from toil.utils import addBasicProvisionerOptions, getZoneFromEnv
 from toil.provisioners import clusterFactory
 from toil.provisioners.aws import checkValidNodeTypes
 from toil import applianceSelf
@@ -133,6 +133,13 @@ def main():
         owner = config.owner
     elif config.keyPairName:
         owner = config.keyPairName
+
+    # Check to see if the user specified a zone. If not, see if one is stored in an environment variable.
+    config.zone = config.zone or getZoneFromEnv(config.provisioner)
+
+    if not config.zone:
+        raise RuntimeError('Please provide a value for --zone or set a default in the TOIL_' +
+                           config.provisioner.upper() + '_ZONE enviroment variable.')
 
     cluster = clusterFactory(provisioner=config.provisioner,
                              clusterName=config.clusterName,


### PR DESCRIPTION
Reopening of previous fix. Specifies zone options explicitly in AWS tests.