### PR TITLE
Toil Status no longer raises if no jobstore present.

### DIFF
--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -253,7 +253,6 @@ def main():
         jobStore = Toil.resumeJobStore(config.jobStore)
     except NoSuchJobStoreException:
         print('No job store found.')
-        exit(0)
 
     ##########################################
     # Gather the jobs to report

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -30,6 +30,7 @@ import sys
 from toil.lib.bioio import getBasicOptionParser
 from toil.lib.bioio import parseBasicOptions
 from toil.common import Toil, jobStoreLocatorHelp, Config
+from toil.jobStores.abstractJobStore import NoSuchJobStoreException
 from toil.job import JobException
 from toil.version import version
 
@@ -248,7 +249,11 @@ def main():
 
     config = Config()
     config.setOptions(options)
-    jobStore = Toil.resumeJobStore(config.jobStore)
+    try:
+        jobStore = Toil.resumeJobStore(config.jobStore)
+    except NoSuchJobStoreException:
+        print('No job store found.')
+        exit(0)
 
     ##########################################
     # Gather the jobs to report


### PR DESCRIPTION
This allows the status to be queried as a rough API without raising an exception if the jobstore folder has not been created yet.