### PR TITLE
Fix 2162 (at least partially) by refactoring stream writes in the fileJobStore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,10 @@ def runSetup():
         requests,
         docker,
         dateutil,
-        subprocess32]
+        subprocess32,
+        psutil]
 
     mesos_reqs = [
-        psutil,
         protobuf]
     aws_reqs = [
         boto,

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,10 @@ def runSetup():
         requests,
         docker,
         dateutil,
-        subprocess32,
-        psutil]
+        subprocess32]
 
     mesos_reqs = [
+        psutil,
         protobuf]
     aws_reqs = [
         boto,

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -537,7 +537,7 @@ class CachingFileStore(FileStore):
         # If the file is from the scope of local temp dir
         if absLocalFileName.startswith(self.localTempDir):
             # If the job store is of type FileJobStore and the job store and the local temp dir
-            # are on the same file system, then we want to hard link the files istead of copying
+            # are on the same file system, then we want to hard link the files instead of copying
             # barring the case where the file being written was one that was previously read
             # from the file store. In that case, you want to copy to the file store so that
             # the two have distinct nlink counts.

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -364,6 +364,15 @@ class FileJobStore(AbstractJobStore):
 
     @contextmanager
     def writeFileStream(self, jobStoreID=None):
+        fd, absPath = self._getTempFile(jobStoreID)
+        relPath = self._getRelativePath(absPath)
+        with open(absPath, 'wb') as f:
+            logger.debug('Write file stream {}'.format(relPath))
+            yield f, relPath
+        os.close(fd)  # Close the os level file descriptor
+        return
+                
+    
         # Record the name of the job/function writing the file in the file name
         try:
             # It ought to be third-to-last on the stack, above us and the context manager stuff

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -617,8 +617,14 @@ class FileJobStore(AbstractJobStore):
         if jobStoreID != None:
             # Make a temporary file within the job's directory
             self._checkJobStoreId(jobStoreID)
-            return tempfile.mkstemp(suffix=".tmp",
-                                dir=os.path.join(self._getAbsPath(jobStoreID), "g"))
+            fd, name = tempfile.mkstemp(suffix=".tmp",
+                                        dir=os.path.join(self._getAbsPath(jobStoreID), "g"))
+            logger.error('Open temp file {} as fd {}'.format(name, fd))
+            traceback.print_stack()
+            return fd, name
         else:
             # Make a temporary file within the temporary file structure
-            return tempfile.mkstemp(prefix="tmp", suffix=".tmp", dir=self._getTempSharedDir())
+            fd, name = tempfile.mkstemp(prefix="tmp", suffix=".tmp", dir=self._getTempSharedDir())
+            logger.error('Open temp file {} as fd {}'.format(name, fd))
+            traceback.print_stack()
+            return fd, name

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -71,6 +71,9 @@ class FileJobStore(AbstractJobStore):
         # Directory where temporary files go
         self.tempFilesDir = os.path.join(self.jobStoreDir, 'tmp')
         self.linkImports = None
+        
+    def __repr__(self):
+        return 'FileJobStore({})'.format(self.jobStoreDir)
 
     def initialize(self, config):
         try:
@@ -162,6 +165,7 @@ class FileJobStore(AbstractJobStore):
                 else:
                     # Remove the given directory
                     shutil.rmtree(path, False, handle_error)
+                assert(not os.path.exists(path))
                 return
             except OSError:
                 logger.error('Unable to remove path: {}.  Retrying in {} seconds.'.format(path, delay))
@@ -169,7 +173,14 @@ class FileJobStore(AbstractJobStore):
                 delay *= 2
 
         # Final attempt, pass any Exceptions up to caller.
-        shutil.rmtree(path, False, handle_error)
+        if not os.path.isdir(path):
+            # Remove the given normal file
+            os.remove(path)
+        else:
+            # Remove the given directory
+            shutil.rmtree(path)
+            
+        assert(not os.path.exists(path))
 
     def destroy(self):
         if os.path.exists(self.jobStoreDir):

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -108,7 +108,7 @@ class FileJobStore(AbstractJobStore):
                 shutil.rmtree(path)
                 break
             except OSError:
-                logger.error('Unable to remove path: {}.  Retrying in {} seconds.'.format(path, delay))
+                logger.debug('Unable to remove path: {}.  Retrying in {} seconds.'.format(path, delay))
                 time.sleep(delay)
                 delay *= 2
 


### PR DESCRIPTION
I've backed out the code that I wrote to diagnose what is holding a file open and try to kill it or close the file descriptor, but this at least solves the immediate problem I was having in that issue and somehow stops the file descriptor from leaking in the first place.

It's not a general solution to misbehaving user code, which can still do bad things like start a subprocess attached to a file stream in the job store and leave it running when the Toil job exits.