### PR TITLE
Grid engine job creation fix

### DIFF
--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -92,7 +92,6 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
             """
             with self.runningJobsLock:
                 self.runningJobs.remove(jobID)
-            del self.allocatedCpus[jobID]
             del self.batchJobIDs[jobID]
 
         def createJobs(self, newJob):
@@ -107,8 +106,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
             if newJob is not None:
                 self.waitingJobs.append(newJob)
             # Launch jobs as necessary:
-            while len(self.waitingJobs) > 0 and len(self.runningJobs) < int(self.boss.config.maxLocalJobs) \
-                    and len(self.runningJobs) < int(self.boss.maxCores):
+            while len(self.waitingJobs) > 0 and len(self.runningJobs) < int(self.boss.config.maxLocalJobs):
                 activity = True
                 jobID, cpu, memory, command = self.waitingJobs.pop(0)
 

--- a/src/toil/batchSystems/htcondor.py
+++ b/src/toil/batchSystems/htcondor.py
@@ -43,7 +43,7 @@ class HTCondorBatchSystem(AbstractGridEngineBatchSystem):
                 self.waitingJobs.append(newJob)
 
             # Queue jobs as necessary:
-            while len(self.waitingJobs) > 0:
+            while len(self.waitingJobs) > 0 and len(self.runningJobs) < int(self.boss.config.maxLocalJobs):
                 activity = True
                 jobID, cpu, memory, disk, jobName, command = self.waitingJobs.pop(0)
 
@@ -63,9 +63,6 @@ class HTCondorBatchSystem(AbstractGridEngineBatchSystem):
 
                 # Add to queue of queued ("running") jobs
                 self.runningJobs.add(jobID)
-
-                # Add to allocated resources
-                self.allocatedCpus[jobID] = int(math.ceil(cpu))
 
             return activity
 


### PR DESCRIPTION
This Pr will change how the abstract grid engine batch system will decide whether or not to continue making jobs. Currently it the --maxLocalJobs option is not being respected. This fixes the issue by checking if the number of running jobs is less than the value set by the user. When it exceeds that number it stops.