### PR TITLE
Add Mesos port forwarding and the ability to use a SOCKS proxy with toil ssh-cluster

### DIFF
--- a/src/toil/provisioners/node.py
+++ b/src/toil/provisioners/node.py
@@ -216,8 +216,13 @@ class Node(object):
             kwargs['sshOptions'] = ['-oUserKnownHostsFile=/dev/null', '-oStrictHostKeyChecking=no'] \
                                  + kwargs.get('sshOptions', [])
         sshOptions = kwargs.pop('sshOptions', None)
-        # Forward port 3000 for grafana dashboard
-        commandTokens.extend(['-L', '3000:localhost:3000', '-L', '9090:localhost:9090'])
+        # Forward ports:
+        # 3000 for Grafana dashboard
+        # 9090 for Prometheus dashboard
+        # 5050 for Mesos dashboard (although to talk to agents you will need a proxy)
+        commandTokens.extend(['-L', '3000:localhost:3000', \
+                              '-L', '9090:localhost:9090', \
+                              '-L', '5050:localhost:5050'])
         if sshOptions:
             # add specified options to ssh command
             assert isinstance(sshOptions, list)

--- a/src/toil/utils/toilSshCluster.py
+++ b/src/toil/utils/toilSshCluster.py
@@ -27,12 +27,15 @@ logger = logging.getLogger(__name__)
 def main():
     parser = getBasicOptionParser()
     parser = addBasicProvisionerOptions(parser)
-    parser.add_argument("--insecure", dest='insecure', action='store_true', required=False,
+    parser.add_argument("--insecure", action='store_true',
                         help="Temporarily disable strict host key checking.")
+    parser.add_argument("--sshOption", dest='sshOptions', default=[], action='append',
+                        help="Pass an additional option to the SSH command.")
     parser.add_argument('args', nargs=argparse.REMAINDER)
     config = parseBasicOptions(parser)
     cluster = clusterFactory(provisioner=config.provisioner,
                              clusterName=config.clusterName,
                              zone=config.zone)
     command = config.args if config.args else ['bash']
-    cluster.getLeader().sshAppliance(*command, strict=not config.insecure, tty=sys.stdin.isatty())
+    cluster.getLeader().sshAppliance(*command, strict=not config.insecure, tty=sys.stdin.isatty(),
+                                     sshOptions=config.sshOptions)


### PR DESCRIPTION
To debug workflows, it is helpflu to have access to the Mesos dashboard.

This adds a port forward for port 5050 for the Mesos dashboard, along with the other dashboards that get forwarded with `toil ssh-cluster`.

I'm also adding another option to `toil ssh-cluster` so you can pass options through to SSH. This allows you to do something like `--sshOption=-D8080` to get a SOCKS proxy, so you can talk to the actual nodes in the cluster by IP address. (You have to use the = syntax because of https://bugs.python.org/issue9334) This is important if you want to use the full capabilities of the Mesos dahsboard, which include peeking at the stdout and stderr of the running executors, and will hopefully be useful for debugging. But to use it, you have to point your browser at the resulting proxy, so I haven't added a real proxy feature to `toil ssh-cluster`.