### PR TITLE
Require a jobstore to be specified when a provisioner is. (Resolves #2262)

### DIFF
--- a/docs/gettingStarted/quickStart.rst
+++ b/docs/gettingStarted/quickStart.rst
@@ -473,7 +473,7 @@ Also!  Remember to use the :ref:`destroyCluster` command when finished to destro
 
 #. Now run the CWL workflow::
 
-      (venv) $ toil-cwl-runner /tmp/example.cwl /tmp/example-job.yaml
+      (venv) $ toil-cwl-runner --provisioner aws --jobStore aws:us-west-2a:any-name /tmp/example.cwl /tmp/example-job.yaml
 
    ..  tip::
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -1068,8 +1068,7 @@ def main(args=None, stdout=sys.stdout):
             'Please specify a jobstore with the --jobStore option when specifying a provisioner.')
 
     if options.jobStore and not options.provisioner:
-        raise NoSuchJobStoreException(
-            'Please specify a provisioner with the --provisioner option when specifying a jobstore.')
+        raise RuntimeError('Please specify a provisioner with the --provisioner option when specifying a jobstore.')
 
     use_container = not options.no_container
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -1067,9 +1067,6 @@ def main(args=None, stdout=sys.stdout):
         raise NoSuchJobStoreException(
             'Please specify a jobstore with the --jobStore option when specifying a provisioner.')
 
-    if options.jobStore and not options.provisioner:
-        raise RuntimeError('Please specify a provisioner with the --provisioner option when specifying a jobstore.')
-
     use_container = not options.no_container
 
     if options.logLevel:

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -50,6 +50,7 @@ import cwltool.resolver
 import cwltool.stdfsaccess
 import cwltool.command_line_tool
 
+from toil.jobStores.abstractJobStore import NoSuchJobStoreException
 from cwltool.loghandler import _logger as cwllogger
 from cwltool.loghandler import defaultStreamHandler
 from cwltool.pathmapper import (PathMapper, adjustDirObjs, adjustFileObjs,
@@ -1061,6 +1062,14 @@ def main(args=None, stdout=sys.stdout):
 
     # we use workdir as jobStore:
     options = parser.parse_args([workdir] + args)
+
+    if options.provisioner and not options.jobStore:
+        raise NoSuchJobStoreException(
+            'Please specify a jobstore with the --jobStore option when specifying a provisioner.')
+
+    if options.jobStore and not options.provisioner:
+        raise NoSuchJobStoreException(
+            'Please specify a provisioner with the --provisioner option when specifying a jobstore.')
 
     use_container = not options.no_container
 


### PR DESCRIPTION
This PR would add two if statements in cwlToil's main function that check to see if the user specified these options appropriately. Additionally, it shows the proper usage of these options in update documentation.