### PR TITLE
Htcondor in wheel breaking on apple computers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ def runSetup():
             'cwl': cwl_reqs,
             'wdl': wdl_reqs,
             'htcondor': htcondor_reqs,
-            'all': all_reqs},
+            'all:sys_platform!="darwin"': all_reqs},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for

--- a/setup.py
+++ b/setup.py
@@ -83,18 +83,17 @@ def runSetup():
     htcondor_reqs = [
         htcondor]
 
+    # htcondor is not supported by apple
+    # this is tricky to conditionally support in 'all' due
+    # to how wheels work, so it is not included in all and
+    # must be explicitly installed as an extra
     all_reqs = \
         mesos_reqs + \
         aws_reqs + \
         azure_reqs + \
         encryption_reqs + \
         google_reqs + \
-        cwl_reqs + \
-        htcondor_reqs
-
-    # htcondor is not supported by apple
-    if sys.platform != 'linux' and sys.platform != 'linux2':
-        all_reqs.remove(htcondor)
+        cwl_reqs
 
     # remove the subprocess32 backport if not python2
     if not sys.version_info[0] == 2:
@@ -111,15 +110,15 @@ def runSetup():
         license="Apache License v2.0",
         install_requires=core_reqs,
         extras_require={
-            'mesos:sys_platform!="darwin"': mesos_reqs,
+            'mesos': mesos_reqs,
             'aws': aws_reqs,
             'azure': azure_reqs,
             'encryption': encryption_reqs,
             'google': google_reqs,
             'cwl': cwl_reqs,
             'wdl': wdl_reqs,
-            'htcondor': htcondor_reqs,
-            'all:sys_platform!="darwin"': all_reqs},
+            'htcondor:sys_platform!="darwin"': htcondor_reqs,
+            'all': all_reqs},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ def runSetup():
         license="Apache License v2.0",
         install_requires=core_reqs,
         extras_require={
-            'mesos': mesos_reqs,
+            'mesos:sys_platform!="darwin"': mesos_reqs,
             'aws': aws_reqs,
             'azure': azure_reqs,
             'encryption': encryption_reqs,


### PR DESCRIPTION
`pip install toil[all]` doesn't work on apple right now.

Toil's wheels are built on a linux machine, which means that they include the `htcondor` apple-incompatible extra when pip installed on apple computers (but not when built from source, since it checks for this when `setup.py` is run).

There is a conditional statement in setuptools to address this, but it would conditionally make using the `all` extra unusable on apple computers (which is kind of already the current behavior).  So I've opted to go for the simpler solution and omit `htcondor` from the `all` extra.