### PR TITLE
Add a coverage analysis of tests by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test_offline: check_venv check_build_reqs
 # The auto-deployment test needs the docker appliance
 test: check_venv check_build_reqs docker
 	TOIL_APPLIANCE_SELF=$(docker_registry)/$(docker_base_name):$(docker_tag) \
-	    $(python) -m pytest $(pytest_args_local) $(tests)
+	    $(python) -m pytest --cov=toil $(pytest_args_local) $(tests)
 
 # For running integration tests locally in series (uses the -s argument for pyTest)
 integration_test_local: check_venv check_build_reqs sdist push_docker

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ def runSetup():
     docker = 'docker==2.5.1'
     subprocess32 = 'subprocess32<=3.5.2'
     dateutil = 'python-dateutil'
+    pytest = 'pytest==3.7.4'
+    pytest_cov = 'pytest-cov==2.5.1'
 
     core_reqs = [
         dill,
@@ -54,7 +56,9 @@ def runSetup():
         docker,
         dateutil,
         psutil,
-        subprocess32]
+        subprocess32,
+        pytest,
+        pytest_cov]
 
     mesos_reqs = [
         psutil,


### PR DESCRIPTION
This PR will add `pytest` and `pytest-cov` to the core requirements of toil to enable an analysis of our test coverage. It also changes the `Makefile` to enable this by default:
```
Name                                                     Stmts   Miss  Cover
----------------------------------------------------------------------------
src/toil/__init__.py                                       108     50    54%
src/toil/batchSystems/__init__.py                           36     25    31%
...
src/toil/utils/toilDestroyCluster.py                        10      5    50%
src/toil/worker.py                                         237     29    88%
----------------------------------------------------------------------------
TOTAL                                                    23674  10746    55%
```

These results might be a bit off from the actual. I am currently having some issues with CWL tests not passing on my machiene and had to ignore them to get these results.