### PR TITLE
workDir defaults to tmpdir_prefix now if not set by the user.  Resolves #2354.

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -1073,6 +1073,10 @@ def main(args=None, stdout=sys.stdout):
     # we use workdir as jobStore:
     options = parser.parse_args([workdir] + args)
 
+    # if tmpdir_prefix is not the default value, set workDir too
+    if options.tmpdir_prefix != 'tmp':
+        options.workDir = options.tmpdir_prefix
+
     if options.provisioner and not options.jobStore:
         raise NoSuchJobStoreException(
             'Please specify a jobstore with the --jobStore option when specifying a provisioner.')

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -15,22 +15,23 @@ from __future__ import absolute_import
 from __future__ import print_function
 import json
 import os
-from toil import subprocess
+import sys
 import unittest
 import re
 import shutil
+import zipfile
 import pytest
 from future.moves.urllib.request import urlretrieve
-import zipfile
-
-# Python 3 compatibility imports
 from six.moves import StringIO
 from six import u as str
 
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from toil import subprocess
 from toil.test import (ToilTest, needs_cwl, slow, needs_docker, needs_lsf,
                        needs_mesos, needs_parasol, needs_gridengine, needs_slurm,
                        needs_torque)
-
 
 
 @needs_cwl


### PR DESCRIPTION
Addresses #2354.

Also changed the test file so that it will run from any directory, not just when cwd == its directory.