### PR TITLE
Stop logging every message twice in certain cases

### DIFF
--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -23,7 +23,6 @@ from builtins import object
 import json
 import logging
 import os
-import sys
 import time
 from collections import defaultdict
 
@@ -38,13 +37,6 @@ from toil.job import ServiceJobNode
 from toil.common import defaultTargetTime
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-ch = logging.StreamHandler(sys.stdout)
-ch.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-ch.setFormatter(formatter)
-logging.getLogger().addHandler(ch)
-
 
 class BinPackedFit(object):
     """


### PR DESCRIPTION
Occassionally toil will get in a state where every message is logged
twice. The root cause of these extra messages was a stray logging
handler set up in clusterScaler.py.