### PR TITLE
Fix invalid qsub in torque.py

### DIFF
--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -183,7 +183,6 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
                 reqline.append('mem=' + memStr)
 
             if cpu is not None and math.ceil(cpu) > 1:
-                reqline.append('ncpus=' + str(int(math.ceil(cpu))))
                 reqline.append('nodes=1:ppn=' + str(int(math.ceil(cpu))))
 
             # Other resource requirements can be passed through the environment (see man qsub)


### PR DESCRIPTION
In the torque documentation, since at least version 4, it is supposed to throw an error if you use ncpus and nodes in the resource request argument (-l). http://docs.adaptivecomputing.com/torque/6-1-2/adminGuide/torque.htm#topics/torque/2-jobs/requestingRes.htm