### PR TITLE
Add recognition of conda virtual envs, resolves #2421

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -48,7 +48,10 @@ def toilPackageDirPath():
 
 
 def inVirtualEnv():
-    return hasattr(sys, 'real_prefix')
+    """
+    Returns whether we are inside a virtualenv or Conda virtual environment.
+    """
+    return hasattr(sys, 'real_prefix') or 'CONDA_DEFAULT_ENV' in os.environ
 
 
 def resolveEntryPoint(entryPoint):


### PR DESCRIPTION
When running toil in a Conda virtual environment instead of virtualenv,
_toil_worker could not be found without explicitely setting the PATH
environment variable. This commit adds recognition of Conda virtual
environments and fixes this issue.