### PR TITLE
Simplify log creation in leader.

### DIFF
--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -230,10 +230,17 @@ class Leader(object):
 
         logName = 'failed.log' if self.toilState.totalFailedJobs else 'succeeded.log'
         localLog = os.path.join(os.getcwd(), logName)
+        logger.critical('localLog: {}\n'.format(localLog))
         with open(localLog, 'w') as f:
             f.write('')
 
-        self.jobStore.importFile('file://' + localLog, logName, hardlink=True)
+        logger.critical('localLog: {}\n'.format(localLog))
+        try:
+            self.jobStore.importFile('file://' + localLog, logName, hardlink=True)
+        except IOError as e:
+            logger.critical('Error from importFile with hardlink=True: {}'.format(e))
+            self.jobStore.importFile('file://' + localLog, logName, hardlink=False)
+
         if os.path.exists(localLog):  # Bandaid for Jenkins tests failing stochastically and unexplainably.
             os.remove(localLog)
 

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -228,23 +228,12 @@ class Leader(object):
         # Filter the failed jobs
         self.toilState.totalFailedJobs = [j for j in self.toilState.totalFailedJobs if self.jobStore.exists(j.jobStoreID)]
 
-        if self.toilState.totalFailedJobs:
-            # Log the failed jobs.
-            localLog = os.path.join(os.getcwd(), 'failed.log')
-            with open(localLog, 'w') as failLog:
-                failLog.write('Failed Jobs for workflow ')
-                for job in self.toilState.totalFailedJobs:
-                    failLog.write(job.jobStoreID)
-            self.jobStore.importFile('file://' + localLog, 'failed.log', hardlink=True)
-            if os.path.exists(localLog):  # Bandaid for Jenkins tests failing stochastically and unexplainably.
-                os.remove(localLog)
-        else:
-            localLog = os.path.join(os.getcwd(), 'succeeded.log')
-            with open(localLog, 'w') as succeedLog:
-                succeedLog.write('This workflow completed successfully.')
-            self.jobStore.importFile('file://' + localLog, 'succeeded.log', hardlink=True)
-            if os.path.exists(localLog):  # Bandaid for Jenkins tests failing stochastically and unexplainably.
-                os.remove(localLog)
+        localLog = 'failed.log' if self.toilState.totalFailedJobs else 'succeeded.log'
+        with open(localLog, 'w') as f:
+            f.write()
+        self.jobStore.importFile('file://' + localLog, 'failed.log', hardlink=True)
+        if os.path.exists(localLog):  # Bandaid for Jenkins tests failing stochastically and unexplainably.
+            os.remove(localLog)
 
         logger.info("Finished toil run %s" %
                      ("successfully." if not self.toilState.totalFailedJobs \

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -230,7 +230,7 @@ class Leader(object):
 
         localLog = 'failed.log' if self.toilState.totalFailedJobs else 'succeeded.log'
         with open(localLog, 'w') as f:
-            f.write()
+            f.write('')
         self.jobStore.importFile('file://' + localLog, 'failed.log', hardlink=True)
         if os.path.exists(localLog):  # Bandaid for Jenkins tests failing stochastically and unexplainably.
             os.remove(localLog)

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -228,10 +228,12 @@ class Leader(object):
         # Filter the failed jobs
         self.toilState.totalFailedJobs = [j for j in self.toilState.totalFailedJobs if self.jobStore.exists(j.jobStoreID)]
 
-        localLog = 'failed.log' if self.toilState.totalFailedJobs else 'succeeded.log'
+        logName = 'failed.log' if self.toilState.totalFailedJobs else 'succeeded.log'
+        localLog = os.path.join(os.getcwd(), logName)
         with open(localLog, 'w') as f:
             f.write('')
-        self.jobStore.importFile('file://' + localLog, 'failed.log', hardlink=True)
+
+        self.jobStore.importFile('file://' + localLog, logName, hardlink=True)
         if os.path.exists(localLog):  # Bandaid for Jenkins tests failing stochastically and unexplainably.
             os.remove(localLog)
 


### PR DESCRIPTION
By no longer logging the failed jobs, the code for creating logs can be simplified. This PR would do that.