### PR TITLE
resource.getrusage returns KB already, so dividing by 1024 yields MB

### DIFF
--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -304,7 +304,7 @@ def sprintTag(key, tag, options, columnWidths=None):
             (tag.max_memory, columnWidths.getWidth("memory", "max")),
             (tag.total_memory, columnWidths.getWidth("memory", "total")),
             ]:
-            tag_str += reportMemory(t, options, field=width, isBytes=True)
+            tag_str += reportMemory(t, options, field=width)
     out_str += header + "\n"
     out_str += sub_header + "\n"
     out_str += tag_str + "\n"


### PR DESCRIPTION
not KB

Still would like confirmation that this memory for the report does indeed come from `resource.getrusage()` (I see that being used in the `worker` script, but can't exactly tie it to the reference used in `toilStats` 