### PR TITLE
Make ServiceManager stop blocking while (most) services are established

### DIFF
--- a/src/toil/serviceManager.py
+++ b/src/toil/serviceManager.py
@@ -21,7 +21,7 @@ import time
 
 from threading import Thread, Event
 
-from bd2k.util.throttle import throttle
+from toil.lib.throttle import throttle
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue


### PR DESCRIPTION
This is an old bit I never merged upstream--probably only useful for Cactus on very large trees.

The ServiceManager thread previously launched only one "batch" of
services at a time. This caused massive bottlenecks when many services
needed to be started at once. This causes all services to be issued
simultaneously, *unless* they have a special hierarchy (i.e. parent
and child services), in which case the old behavior is kept to avoid
problems where e.g., Spark master services would crowd out Spark
worker services.