### PR TITLE
Bump minimum version of galaxy-lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def runSetup():
     apacheLibcloud = 'apache-libcloud==2.2.1'
     cwltool = 'cwltool==1.0.20180820141117'
     schemaSalad = 'schema-salad>=2.6, <3'
-    galaxyLib = 'galaxy-lib==17.9.3'
+    galaxyLib = 'galaxy-lib==17.9.9'
     htcondor = 'htcondor>=8.6.0'
     dill = 'dill==0.2.7.1'
     six = 'six>=1.10.0'


### PR DESCRIPTION
Follow PR common-workflow-language/cwltool#982, which was [merged upstream](https://github.com/common-workflow-language/cwltool/commit/b82ce7ae901a54c7a062fd5eefd8d5ceb5a4d684).

Resolving software requirements using [Environment Modules](http://modules.sourceforge.net/) is a basic service of galaxy-lib, but only works since galaxyproject/galaxy@69a8700, available in 17.09.9 dated 2017-09-21. The test added upstream to cwltool demonstrated that version 17.09.3 of galaxy-lib is inadequate.

This PR bumps the minimum version of galaxy-lib to 17.09.9 for Toil as well.