### PR TITLE
WIP Translate cloud-config to ignition.

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 import os
-import textwrap
+from toil.lib.misc import heredoc
 
 applianceSelf = os.environ['TOIL_APPLIANCE_SELF']
 sdistName = os.environ['_TOIL_SDIST_NAME']
@@ -34,12 +34,12 @@ dependencies = ' '.join(['libffi-dev',  # For client side encryption for 'azure'
                          'screen'])
 
 
-def heredoc(s):
-    s = textwrap.dedent(s).format(**globals())
+def docker_heredoc(s):
+    s = heredoc(s, dictionary=globals())
     return s[1:] if s.startswith('\n') else s
 
 
-motd = heredoc('''
+motd = docker_heredoc('''
 
     This is the Toil appliance. You can run your Toil script directly on the appliance. 
     Run toil <workflow>.py --help to see all options for running your workflow.
@@ -54,7 +54,7 @@ motd = heredoc('''
 # Prepare motd to be echoed in the Dockerfile using a RUN statement that uses bash's print
 motd = ''.join(l + '\\n\\\n' for l in motd.splitlines())
 
-print(heredoc('''
+print(docker_heredoc('''
     FROM ubuntu:14.04
 
     RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" \

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ def runSetup():
                                # Note that we intentionally include the top-level `test` package for
                                # functionality like the @experimental and @integrative decoratorss:
                                exclude=['*.test.*']),
-        package_data = {
+        package_data={
             '': ['*.yml', 'contrib/azure_rm.py', 'cloud-config'],
         },
         # Unfortunately, the names of the entry points are hard-coded elsewhere in the code base so
@@ -176,7 +176,7 @@ def importVersion():
                 raise
 
         if old != new:
-            with NamedTemporaryFile(mode='w',dir='src/toil', prefix='version.py.', delete=False) as f:
+            with NamedTemporaryFile(mode='w', dir='src/toil', prefix='version.py.', delete=False) as f:
                 f.write(new)
             os.rename(f.name, 'src/toil/version.py')
     # Unfortunately, we can't use a straight import here because that would also load the stuff

--- a/src/toil/lib/context.py
+++ b/src/toil/lib/context.py
@@ -403,26 +403,6 @@ class Context(object):
             name = name[len(self.namespace):]
         return name
 
-    def base_name(self, name):
-        """
-        Return the last component of a name, absolute or relative.
-
-        >>> ctx = Context( 'us-west-1b', namespace='/foo/bar/')
-        >>> ctx.base_name('')
-        ''
-        >>> ctx.base_name('/')
-        ''
-        >>> ctx.base_name('/a')
-        'a'
-        >>> ctx.base_name('/a/')
-        ''
-        >>> ctx.base_name('/a/b')
-        'b'
-        >>> ctx.base_name('/a/b/')
-        ''
-        """
-        return name.split('/')[-1]
-
     def contains_name(self, name):
         return not self.is_absolute_name(name) or name.startswith(self.namespace)
 
@@ -446,11 +426,8 @@ class Context(object):
         >>> c('/' ).contains_aws_name('bar_foo_x')
         True
         """
-        return self.contains_name(self.from_aws_name(aws_name))
-
-    def try_contains_aws_name(self, aws_name):
         try:
-            return self.contains_aws_name(aws_name)
+            return self.contains_name(self.from_aws_name(aws_name))
         except self.InvalidPathError:
             return False
 
@@ -576,7 +553,7 @@ class Context(object):
                 break
 
     def local_roles(self):
-        return [r for r in self._get_all_roles() if self.try_contains_aws_name(r.role_name)]
+        return [r for r in self._get_all_roles() if self.contains_aws_name(r.role_name)]
 
     def _get_all_roles(self):
         return self._pager(self.iam.list_roles, 'roles')

--- a/src/toil/lib/misc.py
+++ b/src/toil/lib/misc.py
@@ -2,7 +2,13 @@ import random
 from six.moves import xrange
 from math import sqrt
 import errno
+import textwrap
 import os
+
+
+def heredoc(template, dictionary={}, indent=''):
+    template = textwrap.dedent(template).format(**dictionary)
+    return template.replace('\n', '\n' + indent) + '\n'
 
 
 def mkdir_p(path):

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -138,7 +138,7 @@ class AWSProvisioner(AbstractProvisioner):
         bdm = self._getBlockDeviceMapping(E2Instances[leaderNodeType], rootVolSize=leaderStorage)
 
         self._masterPublicKey = 'AAAAB3NzaC1yc2Enoauthorizedkeyneeded' # dummy key
-        userData =  self._getCloudConfigUserData('leader', self._masterPublicKey)
+        userData =  self.getCloudConfigUserData('leader', self._masterPublicKey)
         specKwargs = {'key_name': self._keyName, 'security_group_ids': [sg.id for sg in sgs],
                   'instance_type': leaderNodeType,
                   'user_data': userData, 'block_device_map': bdm,
@@ -250,7 +250,7 @@ class AWSProvisioner(AbstractProvisioner):
         arn = self._getProfileARN()
 
         keyPath = self._sseKey if self._sseKey else None
-        userData =  self._getCloudConfigUserData('worker', self._masterPublicKey, keyPath, preemptable)
+        userData =  self.getCloudConfigUserData('worker', self._masterPublicKey, keyPath, preemptable)
         sgs = [sg for sg in self._ctx.ec2.get_all_security_groups() if sg.name == self.clusterName]
         kwargs = {'key_name': self._keyName,
                   'security_group_ids': [sg.id for sg in sgs],

--- a/src/toil/provisioners/azure/azureProvisioner.py
+++ b/src/toil/provisioners/azure/azureProvisioner.py
@@ -153,7 +153,7 @@ class AzureProvisioner(AnsibleDriver):
         }
         # Ansible reads the cloud-config script from a file.
         with tempfile.NamedTemporaryFile(delete=False) as t:
-            userData =  self._getCloudConfigUserData('leader')
+            userData =  self.getCloudConfigUserData('leader')
             t.write(userData)
             ansibleArgs['cloudconfig'] = t.name
 
@@ -225,7 +225,7 @@ class AzureProvisioner(AnsibleDriver):
         self.callPlaybook(self.playbook['destroy'], ansibleArgs, wait=True)
 
     def addNodes(self, nodeType, numNodes, preemptable=False, spotBid=None):
-        assert self._leaderPrivateIP # for getCloudConfigUserData
+        assert self._leaderPrivateIP  # for getCloudConfigUserData
 
         ansibleArgs = dict(vmsize=nodeType,
                            resgrp=self.clusterName,
@@ -235,7 +235,7 @@ class AzureProvisioner(AnsibleDriver):
                            role="worker",
                            publickeyfile=self._masterPublicKeyFile)
         with tempfile.NamedTemporaryFile(delete=False) as t:
-            userData =  self._getCloudConfigUserData('worker')
+            userData = self.getCloudConfigUserData('worker')
             t.write(userData)
             ansibleArgs['cloudconfig'] = t.name
 

--- a/src/toil/provisioners/container_linux_config.yaml
+++ b/src/toil/provisioners/container_linux_config.yaml
@@ -1,0 +1,115 @@
+# This config is meant to be consumed by the config transpiler, which will
+# generate the corresponding Ignition config. Do not pass this config directly
+# to instances of Container Linux.
+
+storage:
+  files:
+    - filesystem: "root"
+      path: "/home/core/volumes.sh"
+      mode: 0777
+      contents:
+        inline: |
+          #!/bin/bash
+          set -x
+          ephemeral_count=0
+          drives=""
+          directories="toil mesos docker cwl"
+          for drive in /dev/xvd{{a..z}} /dev/nvme{{0..26}}n1; do
+              echo checking for $drive
+              if [ -b $drive ]; then
+                  echo found it
+                  if mount | grep $drive; then
+                      echo "already mounted, likely a root device"
+                  else
+                      ephemeral_count=$((ephemeral_count + 1 ))
+                      drives="$drives $drive"
+                      echo increased ephemeral count by one
+                  fi
+              fi
+          done
+          if (("$ephemeral_count" == "0" )); then
+              echo no ephemeral drive
+              for directory in $directories; do
+                  sudo mkdir -p /var/lib/$directory
+              done
+              exit 0
+          fi
+          sudo mkdir /mnt/ephemeral
+          if (("$ephemeral_count" == "1" )); then
+              echo one ephemeral drive to mount
+              sudo mkfs.ext4 -F $drives
+              sudo mount $drives /mnt/ephemeral
+          fi
+          if (("$ephemeral_count" > "1" )); then
+              echo multiple drives
+              for drive in $drives; do
+                  dd if=/dev/zero of=$drive bs=4096 count=1024
+              done
+              sudo mdadm --create -f --verbose /dev/md0 --level=0 --raid-devices=$ephemeral_count $drives # determine force flag
+              sudo mkfs.ext4 -F /dev/md0
+              sudo mount /dev/md0 /mnt/ephemeral
+          fi
+          for directory in $directories; do
+              sudo mkdir -p /mnt/ephemeral/var/lib/$directory
+              sudo mkdir -p /var/lib/$directory
+              sudo mount --bind /mnt/ephemeral/var/lib/$directory /var/lib/$directory
+          done
+
+systemd:
+  units:
+    - name: "volume-mounting.service"
+      enable: true
+      contents: |
+        [Unit]
+        Description=mounts ephemeral volumes & bind mounts toil directories
+        Before=docker.service
+
+        [Service]
+        Type=oneshot
+        Restart=no
+        ExecStart=/usr/bin/bash /home/core/volumes.sh
+    - name: "toil-{role}.service"
+        enable: true
+        contents: |
+          [Unit]
+          Description=toil-{role} container
+          After=docker.service
+
+          [Service]
+          Restart=on-failure
+          RestartSec=2
+          ExecStartPre=-/usr/bin/docker rm toil_{role}
+          ExecStart=/usr/bin/docker run \
+             --entrypoint={entrypoint} \
+             --net=host \
+             -v /var/run/docker.sock:/var/run/docker.sock \
+             -v /var/lib/mesos:/var/lib/mesos \
+             -v /var/lib/docker:/var/lib/docker \
+             -v /var/lib/toil:/var/lib/toil \
+             -v /var/lib/cwl:/var/lib/cwl \
+             -v /tmp:/tmp \
+             --name=toil_{role} \
+             {dockerImage} \
+             {mesosArgs}
+    - name: "node-exporter.service"
+        enable: true
+        contents: |
+          [Unit]
+          Description=node-exporter container
+          After=docker.service
+
+          [Service]
+          Restart=on-failure
+          RestartSec=2
+          ExecStartPre=-/usr/bin/docker rm node_exporter
+          ExecStart=/usr/bin/docker run \
+              -p 9100:9100 \
+              -v /proc:/host/proc \
+              -v /sys:/host/sys \
+              -v /:/rootfs \
+              --name node-exporter \
+              --restart always \
+              prom/node-exporter:v0.15.2 \
+              --path.procfs /host/proc \
+              --path.sysfs /host/sys \
+              --collector.filesystem.ignored-mount-points ^/(sys|proc|dev|host|etc)($|/)

--- a/src/toil/provisioners/gceProvisioner.py
+++ b/src/toil/provisioners/gceProvisioner.py
@@ -135,16 +135,15 @@ class GCEProvisioner(AbstractProvisioner):
             tags.update(kwargs['userTags'])
         self._tags = json.dumps(tags)
 
-        userData =  self._getCloudConfigUserData('leader')
+        userData = self.getCloudConfigUserData('leader')
         metadata = {'items': [{'key': 'user-data', 'value': userData}]}
         imageType = 'coreos-stable'
         sa_scopes = [{'scopes': ['compute', 'storage-full']}]
         disk = {}
-        disk['initializeParams'] = {
-            'sourceImage': self.SOURCE_IMAGE,
-            'diskSizeGb' : leaderStorage }
+        disk['initializeParams'] = {'sourceImage': self.SOURCE_IMAGE,
+                                    'diskSizeGb': leaderStorage}
         disk.update({'boot': True,
-             'autoDelete': True })
+                     'autoDelete': True})
         name= 'l' + str(uuid.uuid4())
         leader = self._gceDriver.create_node(name, leaderNodeType, imageType,
                                             location=self._zone,
@@ -241,7 +240,7 @@ class GCEProvisioner(AbstractProvisioner):
             logger.debug('Launching %s preemptable nodes', numNodes)
 
         #kwargs["subnet_id"] = self.subnetID if self.subnetID else self._getClusterInstance(self.instanceMetaData).subnet_id
-        userData =  self._getCloudConfigUserData('worker', self._masterPublicKey, keyPath, preemptable)
+        userData =  self.getCloudConfigUserData('worker', self._masterPublicKey, keyPath, preemptable)
         metadata = {'items': [{'key': 'user-data', 'value': userData}]}
         imageType = 'coreos-stable'
         sa_scopes = [{'scopes': ['compute', 'storage-full']}]
@@ -411,10 +410,7 @@ class GCEProvisioner(AbstractProvisioner):
         if not hasattr(ex_network, 'name'):
             ex_network = driver.ex_get_network(ex_network)
         if ex_subnetwork and not hasattr(ex_subnetwork, 'name'):
-            ex_subnetwork = \
-                driver.ex_get_subnetwork(ex_subnetwork,
-                                       region=driver._get_region_from_zone(
-                                           location))
+            ex_subnetwork = driver.ex_get_subnetwork(ex_subnetwork, region=driver._get_region_from_zone(location))
         if ex_image_family:
             image = driver.ex_get_image_from_family(ex_image_family)
         if image and not hasattr(image, 'name'):
@@ -447,14 +443,14 @@ class GCEProvisioner(AbstractProvisioner):
 
         for i in range(number):
             name = 'wp' if ex_preemptible else 'wn'
-            name += str(uuid.uuid4()) #'%s-%03d' % (base_name, i)
+            name += str(uuid.uuid4())  # '%s-%03d' % (base_name, i)
             status = {'name': name, 'node_response': None, 'node': None}
             status_list.append(status)
 
         start_time = time.time()
         complete = False
         while not complete:
-            if (time.time() - start_time >= timeout):
+            if time.time() - start_time >= timeout:
                 raise Exception("Timeout (%s sec) while waiting for multiple "
                                 "instances")
             complete = True

--- a/src/toil/wdl/wdl_functions.py
+++ b/src/toil/wdl/wdl_functions.py
@@ -19,13 +19,12 @@ from past.builtins import basestring
 import fnmatch
 import os
 import logging
-import textwrap
 import csv
 
 from toil import subprocess
+from toil.lib.misc import heredoc
 
 wdllogger = logging.getLogger(__name__)
-
 
 
 def glob(glob_pattern, directoryname):
@@ -73,7 +72,7 @@ def generate_docker_bashscript_file(temp_dir, docker_dir, globs, cmd, job_name):
     :return: Nothing, but it writes and deposits a bash script in temp_dir
              intended to be run inside of a docker container for this job.
     '''
-    wdl_copyright = heredoc_wdl('''        \n
+    wdl_copyright = heredoc('''        \n
         # Borrowed/rewritten from the Broad's Cromwell implementation.  As 
         # that is under a BSD-ish license, I include here the license off 
         # of their GitHub repo.  Thank you Broadies!
@@ -110,7 +109,7 @@ def generate_docker_bashscript_file(temp_dir, docker_dir, globs, cmd, job_name):
         ''')
     prefix_dict = {"docker_dir": docker_dir,
                    "cmd": cmd}
-    bashfile_prefix = heredoc_wdl('''
+    bashfile_prefix = heredoc('''
         tmpDir=$(mktemp -d /{docker_dir}/execution/tmp.XXXXXX)
         chmod 777 $tmpDir
         # set destination for java to deposit all of its files
@@ -129,7 +128,7 @@ def generate_docker_bashscript_file(temp_dir, docker_dir, globs, cmd, job_name):
 
     bashfile_string = '#!/bin/bash' + wdl_copyright + bashfile_prefix
 
-    begin_globbing_string = heredoc_wdl('''
+    begin_globbing_string = heredoc('''
         (
         mkdir "$tmpDir/globs"
         ''')
@@ -143,7 +142,7 @@ def generate_docker_bashscript_file(temp_dir, docker_dir, globs, cmd, job_name):
             ' "$tmpDir/globs" )\n'
         bashfile_string = bashfile_string + add_this_glob
 
-    bashfile_suffix = heredoc_wdl('''
+    bashfile_suffix = heredoc('''
         )
 
         # flush RAM to disk
@@ -507,10 +506,6 @@ def combine_dicts(dict1, dict2):
     return combineddict
 
 
-def heredoc_wdl(template, dictionary={}, indent=''):
-    template = textwrap.dedent(template).format(**dictionary)
-    return template.replace('\n', '\n' + indent) + '\n'
-
 def read_tsv(f, delimiter="\t"):
     '''
     Take a tsv filepath and return an array; e.g. [[],[],[]].
@@ -531,7 +526,8 @@ def read_tsv(f, delimiter="\t"):
         data_file = csv.reader(f, delimiter=delimiter)
         for line in data_file:
             tsv_array.append(line)
-    return (tsv_array)
+    return tsv_array
+
 
 def read_csv(f):
     '''

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -20,7 +20,7 @@ import os
 import logging
 
 import toil.wdl.wdl_parser as wdl_parser
-from toil.wdl.wdl_functions import heredoc_wdl
+from toil.lib.misc import heredoc
 
 wdllogger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ class SynthesizeWDL:
 
     def write_modules(self):
         # string used to write imports to the file
-        module_string = heredoc_wdl('''
+        module_string = heredoc('''
                     from toil.job import Job
                     from toil.common import Toil
                     from toil.lib.docker import apiDockerCall
@@ -164,7 +164,7 @@ class SynthesizeWDL:
         return main_section
 
     def write_main_header(self):
-        main_header = heredoc_wdl('''
+        main_header = heredoc('''
             if __name__=="__main__":
                 options = Job.Runner.getDefaultOptions("{jobstore}")
                 options.clean = 'always'
@@ -234,7 +234,7 @@ class SynthesizeWDL:
 
         :return: A string representing this.
         '''
-        main_section = heredoc_wdl('''
+        main_section = heredoc('''
             outdir = '{outdir}'
             onlyfiles = [os.path.join(outdir, f) for f in os.listdir(outdir) if os.path.isfile(os.path.join(outdir, f))]
             for output_f_path in onlyfiles:
@@ -460,7 +460,7 @@ class SynthesizeWDL:
         for input in scatter_inputs:
             fn_section += '        self.id_{input} = {input}\n'.format(input=input)
 
-        fn_section += heredoc_wdl('''
+        fn_section += heredoc('''
                                  super({jobname}Cls, self).__init__(*args, **kwargs)
 
                              def run(self, fileStore):
@@ -657,7 +657,7 @@ class SynthesizeWDL:
 
                 fn_section += '        self.id_{} = {}\n'.format(var, var_expressn)
 
-        fn_section += heredoc_wdl('''
+        fn_section += heredoc('''
                                  super({jobname}Cls, self).__init__(*args, **kwargs)
 
                              def run(self, fileStore):
@@ -739,7 +739,7 @@ class SynthesizeWDL:
         docker_dict = {"docker_image": self.tasks_dictionary[job]['runtime']['docker'],
                        "job_task_reference": job,
                        "docker_user": str(self.docker_user)}
-        docker_template = heredoc_wdl('''
+        docker_template = heredoc('''
         stdout = apiDockerCall(self, 
                                image={docker_image}, 
                                working_dir=tempDir, 
@@ -772,7 +772,7 @@ class SynthesizeWDL:
             for cmd in self.tasks_dictionary[job]['raw_commandline']:
                 if not cmd.startswith("r'''"):
                     cmd = 'str({i} if not isinstance({i}, tuple) else process_and_read_file({i}, tempDir, fileStore)).strip("{nl}")'.format(i=cmd, nl=r"\n")
-                fn_section = fn_section + heredoc_wdl('''
+                fn_section = fn_section + heredoc('''
                         try:
                             # Intended to deal with "optional" inputs that may not exist
                             # TODO: handle this better
@@ -801,7 +801,7 @@ class SynthesizeWDL:
                         (job priority #, job ID #, Job Skeleton Name, Job Alias)
         :return: A string representing this.
         '''
-        fn_section = heredoc_wdl('''
+        fn_section = heredoc('''
                 this_process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 stdout, stderr = this_process.communicate()\n''', indent='        ')
 
@@ -833,7 +833,7 @@ class SynthesizeWDL:
                         "out_dir": self.output_directory,
                         "output_type": output_type}
 
-                    nonglob_template = heredoc_wdl('''
+                    nonglob_template = heredoc('''
                         # output-type: {output_type}
                         output_filename = {expression}
                         {output_name} = process_outfile(output_filename, fileStore, tempDir, '{out_dir}')


### PR DESCRIPTION
The `cloud-config` format should be accurately translated over into `Container Linux Config` format as per documentation here: https://coreos.com/os/docs/latest/migrating-to-clcs.html

This requires a `ct` dependency to be set up as the new format using ignition is now a two-step process: https://coreos.com/os/docs/latest/overview-of-ct.html

This basically means converting the yaml format `Container Linux Config` into an ignition json using `ct` as needed.  This is kind of silly in my mind, and I want to discuss just using the json directly and cutting out the `ct` requirement, though this sacrifices some readibility.