### PR TITLE
fixes for python 3.x and slurm try 2

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -165,7 +165,7 @@ def physicalMemory():
     try:
         return os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     except ValueError:
-        return int(subprocess.check_output(['sysctl', '-n', 'hw.memsize']).strip())
+        return int(subprocess.check_output(['sysctl', '-n', 'hw.memsize']).decode('utf-8').strip())
 
 
 def physicalDisk(config, toilWorkflowDir=None):

--- a/src/toil/batchSystems/__init__.py
+++ b/src/toil/batchSystems/__init__.py
@@ -57,3 +57,6 @@ class MemoryString(object):
 
     def __cmp__(self, other):
         return cmp(self.bytes, other.bytes)
+
+    def __gt__(self, other):
+        return self.bytes > other.bytes

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -47,7 +47,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
             process = subprocess.Popen(["qstat"], stdout=subprocess.PIPE)
             stdout, stderr = process.communicate()
 
-            for currline in stdout.split('\n'):
+            for currline in stdout.decode('utf-8').split('\n'):
                 items = currline.strip().split()
                 if items:
                     if items[0] in currentjobs and items[4] == 'r':
@@ -65,7 +65,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
 
         def submitJob(self, subLine):
             process = subprocess.Popen(subLine, stdout=subprocess.PIPE)
-            result = int(process.stdout.readline().strip())
+            result = int(process.stdout.readline().decode('utf-8').strip())
             return result
 
         def getJobExitCode(self, sgeJobID):
@@ -138,7 +138,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
     def obtainSystemConstants(cls):
         def byteStrip(s):
             return s.encode('utf-8').strip()
-        lines = [_f for _f in map(byteStrip, subprocess.check_output(["qhost"]).split('\n')) if _f]
+        lines = [_f for _f in map(byteStrip, subprocess.check_output(["qhost"]).decode('utf-8').split('\n')) if _f]
         line = lines[0]
         items = line.strip().split()
         num_columns = len(items)

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -56,7 +56,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     stdout=subprocess.PIPE)
             stdout, _ = process.communicate()
 
-            for curline in stdout.split('\n'):
+            for curline in stdout.decode('utf-8').split('\n'):
                 items = curline.strip().split('|')
                 if items[0] in currentjobs and items[1] == 'RUN':
                     jobstart = parse(items[2], default=datetime.now(tzlocal()))
@@ -75,7 +75,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             combinedEnv.update(os.environ)
             process = subprocess.Popen(subLine, stdout=subprocess.PIPE,
                                        env=combinedEnv)
-            line = process.stdout.readline()
+            line = process.stdout.readline().decode('utf-8')
             logger.debug("BSUB: " + line)
             result = int(line.strip().split()[1].strip('<>'))
             logger.debug("Got the job id: {}".format(result))
@@ -191,7 +191,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
         p = subprocess.Popen(["lshosts"], stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT)
 
-        line = p.stdout.readline()
+        line = p.stdout.readline().decode('utf-8')
         items = line.strip().split()
         num_columns = len(items)
         cpu_index = None
@@ -206,7 +206,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                 RuntimeError("lshosts command does not return ncpus or maxmem "
                              "columns")
 
-        # p.stdout.readline()
+        # p.stdout.readline().decode('utf-8')
 
         maxCPU = 0
         maxMEM = MemoryString("0")

--- a/src/toil/batchSystems/lsfHelper.py
+++ b/src/toil/batchSystems/lsfHelper.py
@@ -100,7 +100,7 @@ def apply_bparams(fn):
     """
     cmd = ["bparams", "-a"]
     try:
-        output = subprocess.check_output(cmd)
+        output = subprocess.check_output(cmd).decode('utf-8')
     except:
         return None
     return fn(output.split("\n"))
@@ -111,7 +111,7 @@ def apply_lsadmin(fn):
     """
     cmd = ["lsadmin", "showconf", "lim"]
     try:
-        output = subprocess.check_output(cmd)
+        output = subprocess.check_output(cmd).decode('utf-8')
     except:
         return None
     return fn(output.split("\n"))

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -117,10 +117,10 @@ class ParasolBatchSystem(BatchSystemSupport):
                                        bufsize=-1)
             stdout, stderr = process.communicate()
             status = process.wait()
-            for line in stderr.split('\n'):
+            for line in stderr.decode('utf-8').split('\n'):
                 if line: logger.warn(line)
             if status == 0:
-                return 0, stdout.split('\n')
+                return 0, stdout.decode('utf-8').split('\n')
             message = 'Command %r failed with exit status %i' % (command, status)
             if autoRetry:
                 logger.warn(message)

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -46,7 +46,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
             # -h for no header
             # --format to get jobid i, state %t and time days-hours:minutes:seconds
 
-            lines = subprocess.check_output(['squeue', '-h', '--format', '%i %t %M']).split('\n')
+            lines = subprocess.check_output(['squeue', '-h', '--format', '%i %t %M']).decode('utf-8').split('\n')
             for line in lines:
                 values = line.split()
                 if len(values) < 3:
@@ -66,7 +66,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
         def submitJob(self, subLine):
             try:
-                output = subprocess.check_output(subLine, stderr=subprocess.STDOUT)
+                output = subprocess.check_output(subLine, stderr=subprocess.STDOUT).decode('utf-8')
                 # sbatch prints a line like 'Submitted batch job 2954103'
                 result = int(output.strip().split()[-1])
                 logger.debug("sbatch submitted job %d", result)
@@ -107,7 +107,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
                 return (None, -999)
             
             for line in process.stdout:
-                values = line.strip().split('|')
+                values = line.decode('utf-8').strip().split('|')
                 if len(values) < 2:
                     continue
                 state, exitcode = values
@@ -129,7 +129,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
     
             job = dict()
             for line in process.stdout:
-                values = line.strip().split()
+                values = line.decode('utf-8').strip().split()
     
                 # If job information is not available an error is issued:
                 # slurm_load_jobs error: Invalid job id specified
@@ -227,7 +227,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
         # --format to get memory, cpu
         max_cpu = 0
         max_mem = MemoryString('0')
-        lines = subprocess.check_output(['sinfo', '-Nhe', '--format', '%m %c']).split('\n')
+        lines = subprocess.check_output(['sinfo', '-Nhe', '--format', '%m %c']).decode('utf-8').split('\n')
         for line in lines:
             values = line.split()
             if len(values) < 2:

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -48,7 +48,7 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
             """ Determines PBS/Torque version via pbsnodes
             """
             try:
-                out = subprocess.check_output(["pbsnodes", "--version"])
+                out = subprocess.check_output(["pbsnodes", "--version"]).decode('utf-8')
 
                 if "PBSPro" in out:
                      logger.debug("PBS Pro proprietary Torque version detected")
@@ -86,7 +86,7 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
 
             # qstat supports XML output which is more comprehensive, but PBSPro does not support it 
             # so instead we stick with plain commandline qstat tabular outputs
-            for currline in stdout.split('\n'):
+            for currline in stdout.decode('utf-8').split('\n'):
                 items = currline.strip().split()
                 if items:
                     jobid = items[0].strip()

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1152,7 +1152,7 @@ class ToilMetrics:
     def _containerRunning(containerName):
         try:
             result = subprocess.check_output(["docker", "inspect", "-f",
-                                              "'{{.State.Running}}'", containerName]) == "true"
+                                              "'{{.State.Running}}'", containerName]).decode('utf-8') == "true"
         except subprocess.CalledProcessError:
             result = False
         return result
@@ -1329,8 +1329,7 @@ def getDirSizeRecursively(dirPath):
     # allocated with the environment variable: BLOCKSIZE='512' set, and we
     # multiply this by 512 to return the filesize in bytes.
     return int(subprocess.check_output(['du', '-s', dirPath],
-                                       env=dict(os.environ, BLOCKSIZE='512')).split()[0].decode(
-        'ascii')) * 512
+                                       env=dict(os.environ, BLOCKSIZE='512')).decode('utf-8').split()[0]) * 512
 
 
 def getFileSystemSize(dirPath):

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -349,7 +349,7 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
     >>> with open(path,'w') as f: 
     ...     _ = f.write('from toil.resource import ModuleDescriptor\\n'
     ...                 'print(ModuleDescriptor.forModule(__name__))')
-    >>> subprocess.check_output([ sys.executable, path ]).decode('utf-8') # doctest: +ELLIPSIS +ALLOW_BYTES
+    >>> subprocess.check_output([ sys.executable, path ]) # doctest: +ELLIPSIS +ALLOW_BYTES
     b"ModuleDescriptor(dirPath='...', name='foo', fromVirtualEnv=False)\\n"
 
     >>> from shutil import rmtree

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -349,7 +349,7 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
     >>> with open(path,'w') as f: 
     ...     _ = f.write('from toil.resource import ModuleDescriptor\\n'
     ...                 'print(ModuleDescriptor.forModule(__name__))')
-    >>> subprocess.check_output([ sys.executable, path ]) # doctest: +ELLIPSIS +ALLOW_BYTES
+    >>> subprocess.check_output([ sys.executable, path ]).decode('utf-8') # doctest: +ELLIPSIS +ALLOW_BYTES
     b"ModuleDescriptor(dirPath='...', name='foo', fromVirtualEnv=False)\\n"
 
     >>> from shutil import rmtree

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -517,7 +517,7 @@ def needs_appliance(test_item):
     if which('docker'):
         image = applianceSelf()
         try:
-            images = subprocess.check_output(['docker', 'inspect', image])
+            images = subprocess.check_output(['docker', 'inspect', image]).decode('utf-8')
         except subprocess.CalledProcessError:
             images = []
         else:

--- a/src/toil/wdl/wdl_functions.py
+++ b/src/toil/wdl/wdl_functions.py
@@ -252,8 +252,8 @@ def process_single_outfile(f, fileStore, workDir, outDir):
     elif os.path.exists(os.path.join(workDir, f)):
         output_f_path = os.path.join(workDir, f)
     else:
-        tmp = subprocess.check_output(['ls', '-lha', workDir])
-        exe = subprocess.check_output(['ls', '-lha', os.path.join(workDir, 'execution')])
+        tmp = subprocess.check_output(['ls', '-lha', workDir]).decode('utf-8')
+        exe = subprocess.check_output(['ls', '-lha', os.path.join(workDir, 'execution')]).decode('utf-8')
         raise RuntimeError('OUTPUT FILE: {} was not found!\n'
                            '{}\n\n'
                            '{}\n'.format(f, tmp, exe))

--- a/version_template.py
+++ b/version_template.py
@@ -106,7 +106,7 @@ def buildNumber():
 def currentCommit():
     from subprocess import check_output
     try:
-        output = check_output('git log --pretty=oneline -n 1 -- $(pwd)', shell=True).split()[0]
+        output = check_output('git log --pretty=oneline -n 1 -- $(pwd)', shell=True).decode('utf-8').split()[0]
     except:
         # Return this we are not in a git environment.
         return '000'


### PR DESCRIPTION
Sorry @markasbach, I screwed up your PR https://github.com/DataBiosphere/toil/pull/2492, here is a re-do

> This is a set of a few small commits to enhance python 3.x compatibility, especially when using slurm. Unfortunately, I'm not a git pro and didn't find an easy way so squash them to a single commit as requested by https://toil.readthedocs.io/en/latest/contributing/contributing.html#naming-conventions.

> Is related to #2408 but doesn't fix the issue (over 60 offline tests still fail).