### PR TITLE
WIP: Try to fix #2488 with Google Analytics reporting from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,118 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import find_packages, setup
-import sys
+from setuptools import find_packages, setup, command
 
+try:
+    # On Python 3 urlopen is here
+    from urllib.request import urlopen
+    from urllib.error import URLError
+except ImportError:
+    # On Python 2 it is here
+    from urllib2 import urlopen, URLError
+
+import sys
+import uuid
+import inspect
+import importlib
+
+# We have an analytics system to keep track of installs. The next few functions
+# support that. TODO: We can't hook a wheel being installed, only made. See
+# <https://github.com/pypa/packaging-problems/issues/64>
+
+def phone_home(event):
+    """
+    Report setup.py activity events and Toil installation/packaging to the UCSC
+    Genomics Institute.
+    
+    Reports high bits of the IP address, Toil version, and the setuptools
+    command being used.
+    
+    Does not report any personally identifiable information. Uses a random
+    ephemeral user ID for every action, even if an install takes multiple
+    actions, or if the same machine installs multiple times.
+    """
+    
+    print("reporting {} to UCSC Genomics Institute".format(event))
+        
+    # Compose the GA report
+    report_data = '&'.join([
+        'v=1',
+        'aip=1',
+        'tid=UA-103168923-3',
+        'cid=' + str(uuid.uuid4()),
+        't=event',
+        'ec=lifecycle',
+        'ea=' + event,
+        'an=toil',
+        'av=' + version.distVersion,
+        'aid=edu.ucsc.gi.toil'
+    ]).encode('utf-8')
+    
+    # We assume that Toil version numbers don't need to be URL encoded.
+    # That means they can't contain +
+    
+    print(report_data)
+    
+    try:
+        # Send the data and open the reply with a 1 second timeout
+        handle = urlopen('https://www.google-analytics.com/collect', report_data, 1.0)
+        print("report sent")
+    except URLError:
+        print("could not report event; continuing")
+        
+def wrap_command(imported_command, command_name):
+    """
+    Wrap a single setuptools command class.
+    Uses its local scope so we can find the base class.
+    """
+    
+    class WrappedCommand(imported_command):
+        """
+        Setuptools install command wrapper that phones home.
+        """
+        
+        def run(self):
+            # First do the base work
+            # Problem: we need to get ahold of the original imported command but our enclosing scope vars may have changed.
+            imported_command.run(self)
+            
+            # Then report in
+            phone_home(command_name)
+            
+    return WrappedCommand
+    
+    
+def wrap_commands():
+    """
+    Wrap all commands from setuptools.command and make them phone home.
+    
+    Returns a dict from Setuptools command name to wrapped implementing class.
+    """
+    
+    to_return = {}
+    
+    for command_name in command.__all__:
+        # For each (basic) command defined by setuptools
+        # We expect it to be a class with the command name in a module with the command name
+        
+        # Grab it by import. These all need importing.
+        try:
+            # We expect a class named after the module in each module.
+            imported_command = importlib.import_module('setuptools.command.{}'.format(command_name)).__dict__[command_name]
+        except:
+            # If it's not there, skip this module
+            continue
+        
+        if not inspect.isclass(imported_command):
+            # This is some other child module
+            continue
+        
+        # Save the wrapping class
+        to_return[command_name] = wrap_command(imported_command, command_name)
+        
+    return to_return
+                
 def runSetup():
     """
     Calls setup(). This function exists so the setup() invocation preceded more internal
@@ -137,6 +246,7 @@ def runSetup():
           'Topic :: System :: Distributed Computing',
           'Topic :: Utilities'],
         license="Apache License v2.0",
+        cmdclass=wrap_commands(), # Report to Toil Central Command when Toil is installed
         install_requires=core_reqs,
         extras_require={
             'mesos': mesos_reqs,


### PR DESCRIPTION
This (probably; I haven't been able to check on the receiving end) sends Google Analytics events (with random, non-persistent user IDs) when Toil's setup.py does things like install Toil.

Due to https://github.com/pypa/packaging-problems/issues/64 this won't work with installs from wheels, because wheels don't have a chance to run any code on installation. If we're serious about counting all the installations we'd need to not distribute wheels. We could also just instrument the library on load instead and count usage.

Before we merge this, someone ought to check if the events are actually being received, or if some more setup on the GA side is needed, or if I'm just sending them wrong.