### PR TITLE
Remove linear-time bottleneck from Mesos batch system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ install:
   - make develop extras=[aws,google] # adding extras to avoid import errors
 script:
   - TOIL_TEST_QUICK=True make test_offline
+env:
+  # Necessary to get boto to work in Travis's Ubuntu Precise
+  # environment (see #2498). Consider removing this if/when we
+  # transition to the Xenial environment.
+  - BOTO_CONFIG=/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.6"
   - "2.7"
-sudo: false
 install:
   - make prepare
   - make develop extras=[aws,google] # adding extras to avoid import errors

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -424,8 +424,7 @@ class MesosBatchSystem(BatchSystemLocalSupport,
 
         jobTypes = self.jobQueues.sortedTypes
 
-        # TODO: We may want to assert that numIssued >= numRunning
-        if not jobTypes or len(self.getIssuedBatchJobIDs()) == len(self.getRunningBatchJobIDs()):
+        if not jobTypes:
             log.debug('There are no queued tasks. Declining Mesos offers.')
             # Without jobs, we can get stuck with no jobs and no new offers until we decline it.
             self._declineAllOffers(driver, offers)


### PR DESCRIPTION
This fixes an annoying bug where Toil slows to a crawl when dealing with many jobs.

Previously the system had essentially 0 throughput when there were
more than ~100-300k queued jobs. The existing check took linear time
in the number of issued jobs, but was actually redundant for determining
the number of queued jobs, because `jobTypes` contains only queued
jobs. Checking the length of `jobTypes` is sufficient by itself to determine
whether there are jobs to issue to Mesos.