### PR TITLE
Return stream FileID to fix #1020

### DIFF
--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -180,6 +180,7 @@ class FileStore(with_metaclass(ABCMeta, object)):
         """
         raise NotImplementedError()
 
+    @contextmanager
     def writeGlobalFileStream(self, cleanup=False):
         """
         Similar to writeGlobalFile, but allows the writing of a stream to the job store.
@@ -190,8 +191,9 @@ class FileStore(with_metaclass(ABCMeta, object)):
                   1) a file handle which can be written to and
                   2) the toil.fileStore.FileID of the resulting file in the job store.
         """
+        
         # TODO: Make this work with FileID
-        with self.jobStore.writeFileStream(None if not cleanup else self.jobGraph.jobStoreID) as backingStream, fileStoreID:
+        with self.jobStore.writeFileStream(None if not cleanup else self.jobGraph.jobStoreID) as (backingStream, fileStoreID):
             # We have a string version of the file ID, and the backing stream.
             # We need to yield a stream the caller can write to, and a FileID
             # that accurately reflects the size of the data written to the

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -188,10 +188,27 @@ class FileStore(with_metaclass(ABCMeta, object)):
         :param bool cleanup: is as in :func:`toil.fileStore.FileStore.writeGlobalFile`.
         :return: A context manager yielding a tuple of
                   1) a file handle which can be written to and
-                  2) the ID of the resulting file in the job store.
+                  2) the toil.fileStore.FileID of the resulting file in the job store.
         """
         # TODO: Make this work with FileID
-        return self.jobStore.writeFileStream(None if not cleanup else self.jobGraph.jobStoreID)
+        with self.jobStore.writeFileStream(None if not cleanup else self.jobGraph.jobStoreID) as backingStream, fileStoreID:
+            # We have a string version of the file ID, and the backing stream.
+            # We need to yield a stream the caller can write to, and a FileID
+            # that accurately reflects the size of the data written to the
+            # stream. We assume the stream is not seekable.
+            
+            # Make and keep a reference to the file ID, which is currently empty
+            fileID = FileID(fileStoreID, 0)
+            
+            # Wrap the stream to increment the file ID's size for each byte written
+            wrappedStream = WriteWatchingStream(backingStream)
+            
+            # When the stream is written to, count the bytes
+            def handle(numBytes):
+                fileID.size += numBytes 
+            wrappedStream.onWrite(handle)
+            
+            yield wrappedStream, fileID
 
     @abstractmethod
     def readGlobalFile(self, fileStoreID, userPath=None, cache=True, mutable=False, symlink=False):
@@ -1847,6 +1864,65 @@ class FileID(str):
     @classmethod
     def forPath(cls, fileStoreID, filePath):
         return cls(fileStoreID, os.stat(filePath).st_size)
+        
+class WriteWatchingStream(object):
+    """
+    A stream wrapping class that calls any functions passed to onWrite() with the number of bytes written for every write.
+    
+    Not seekable.
+    """
+    
+    def __init__(self, backingStream):
+        """
+        Wrap the given backing stream.
+        """
+        
+        self.backingStream = backingStream
+        # We have no write listeners yet
+        self.writeListeners = []
+        
+    def onWrite(self, listener):
+        """
+        Call the given listener with the number of bytes written on every write.
+        """
+        
+        self.writeListeners.append(listener)
+        
+    # Implement the file API from https://docs.python.org/2.4/lib/bltin-file-objects.html
+        
+    def write(self, data):
+        """
+        Write the given data to the file.
+        """
+        
+        # Do the write
+        self.backingStream.write(data)
+        
+        for listener in self.writeListeners:
+            # Send out notifications
+            listener(len(data))
+            
+    def writelines(self, datas):
+        """
+        Write each string from the given iterable, without newlines.
+        """
+        
+        for data in datas:
+            self.write(data)
+            
+    def flush(self):
+        """
+        Flush the backing stream.
+        """
+        
+        self.backingStream.flush()
+        
+    def close(self):
+        """
+        Close the backing stream.
+        """
+        
+        self.backingStream.close()
 
 
 def shutdownFileStore(workflowDir, workflowID):


### PR DESCRIPTION
This should solve #1020 by making `writeGlobalFileStream` yield a stream that, when written to, updates the size of a real genuine FileID.

This should solve the issue where `str`s were masquerading as FileIDs after being introduced to workflows by `writeGlobalFileStream`.