### PR TITLE
Don't force all users to install pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ check_build_reqs:
 
 
 prepare: check_venv
-	$(pip) install mock==1.0.1 pytest==3.6.2 stubserver==1.0.1 pytest-timeout==1.2.0 cwltest
+	$(pip) install mock==1.0.1 pytest==3.7.4 pytest-cov==2.5.1 stubserver==1.0.1 pytest-timeout==1.2.0 cwltest
 
 
 check_venv:

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,6 @@ def runSetup():
     docker = 'docker==2.5.1'
     subprocess32 = 'subprocess32<=3.5.2'
     dateutil = 'python-dateutil'
-    pytest = 'pytest==3.7.4'
-    pytest_cov = 'pytest-cov==2.5.1'
     addict = 'addict<=2.2.0'
     sphinx = 'sphinx==1.7.5'
     pathlib2 = 'pathlib2==2.3.2'
@@ -60,8 +58,6 @@ def runSetup():
         dateutil,
         psutil,
         subprocess32,
-        pytest,
-        pytest_cov,
         addict,
         sphinx,
         pathlib2]


### PR DESCRIPTION
Move the pytest-cov install to `make prepare` to join the existing
pytest installation command there.

This is a partial revert of beeb56c8b3c16e814e392987a327e904076a4cce