### PR TITLE
Small typo fix: Replace 'insure' with 'ensure'.

### DIFF
--- a/docs/running/cloud/clusterUtils.rst
+++ b/docs/running/cloud/clusterUtils.rst
@@ -267,7 +267,7 @@ Finally, you can execute remote commands with the following syntax::
     $ toil ssh-cluster CLUSTER-NAME-HERE remoteCommand
 
 It is not advised that you run your Toil workflow using remote execution like this
-unless a tool like `nohup <https://linux.die.net/man/1/nohup>`_ is used to insure the
+unless a tool like `nohup <https://linux.die.net/man/1/nohup>`_ is used to ensure the
 process does not die if the SSH connection is interrupted.
 
 For an example usage, see :ref:`Autoscaling`.

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -392,7 +392,7 @@ class MesosBatchSystem(BatchSystemLocalSupport,
         return cores, memory, disk, preemptable
 
     def _prepareToRun(self, jobType, offer):
-        # Get the first element to insure FIFO
+        # Get the first element to ensure FIFO
         job = self.jobQueues.nextJobOfType(jobType)
         task = self._newMesosTask(job, offer)
         return task

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -266,7 +266,7 @@ class AWSProvisioner(AbstractProvisioner):
 
         for attempt in retry(predicate=awsRetryPredicate):
             with attempt:
-                # after we start launching instances we want to insure the full setup is done
+                # after we start launching instances we want to ensure the full setup is done
                 # the biggest obstacle is AWS request throttling, so we retry on these errors at
                 # every request in this method
                 if not preemptable:
@@ -323,7 +323,7 @@ class AWSProvisioner(AbstractProvisioner):
             self._zone = getCurrentAWSZone()
             if self._zone is None:
                 raise RuntimeError(
-                    'Could not determine availability zone. Insure that one of the following '
+                    'Could not determine availability zone. Ensure that one of the following '
                     'is true: the --zone flag is set, the TOIL_AWS_ZONE environment variable '
                     'is set, ec2_region_name is set in the .boto file, or that '
                     'you are running on EC2.')

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -313,7 +313,7 @@ class UtilsTest(ToilTest):
     @slow
     def testMultipleJobsPerWorkerStats(self):
         """
-        Tests case where multiple jobs are run on 1 worker to insure that all jobs report back their data
+        Tests case where multiple jobs are run on 1 worker to ensure that all jobs report back their data
         """
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.clean = 'never'


### PR DESCRIPTION
While trying out Toil, I got the RuntimeError in awsProvisioner.py, and figured to send a small fix to change the rest of the code as well :) 