### PR TITLE
Add a flag for running CWL internal jobs on workers.

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -315,7 +315,8 @@ class BatchSystemLocalSupport(BatchSystemSupport):
         Returns the jobID if the jobNode has been submitted to the local queue,
         otherwise returns None
         """
-        if jobNode.jobName.startswith(CWL_INTERNAL_JOBS):
+        if (not self.config.runCwlInternalJobsOnWorkers
+                and jobNode.jobName.startswith(CWL_INTERNAL_JOBS)):
             return self.localBatch.issueBatchJob(jobNode)
         else:
             return None

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -126,6 +126,13 @@ def addOptions(addOptionFn, config):
                 help="Do not add the default arguments: 'hv=MEMORY' & 'h_vmem=MEMORY' to "
                      "the qsub call, and instead rely on TOIL_GRIDGENGINE_ARGS to supply "
                      "alternative arguments.  Requires that TOIL_GRIDGENGINE_ARGS be set.")
+    addOptionFn("--runCwlInternalJobsOnWorkers", dest="runCwlInternalJobsOnWorkers",
+                action='store_true', default=None,
+                help=("Whether to run CWL internal jobs (e.g. CWLScatter) on the worker nodes "
+                      "instead of the master. If false (default), then all such jobs are run on "
+                      "the master. Setting this to true can speed up the pipeline for very large "
+                      "workflows with many sub-workflows and/or scatters, provided that the worker "
+                      "pool is large enough."))
 
     for o in _options:
         o(addOptionFn, config)

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -129,8 +129,8 @@ def addOptions(addOptionFn, config):
     addOptionFn("--runCwlInternalJobsOnWorkers", dest="runCwlInternalJobsOnWorkers",
                 action='store_true', default=None,
                 help=("Whether to run CWL internal jobs (e.g. CWLScatter) on the worker nodes "
-                      "instead of the master. If false (default), then all such jobs are run on "
-                      "the master. Setting this to true can speed up the pipeline for very large "
+                      "instead of the primary node. If false (default), then all such jobs are run on "
+                      "the primary node. Setting this to true can speed up the pipeline for very large "
                       "workflows with many sub-workflows and/or scatters, provided that the worker "
                       "pool is large enough."))
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -127,6 +127,7 @@ class Config(object):
         self.servicePollingInterval = 60
         self.useAsync = True
         self.forceDockerAppliance = False
+        self.runCwlInternalJobsOnWorkers = False
 
         # Debug options
         self.debugWorker = False
@@ -260,13 +261,14 @@ class Config(object):
         setOption("maxJobDuration", int, iC(1))
         setOption("rescueJobsFrequency", int, iC(1))
 
-        #Misc
+        # Misc
         setOption("maxLocalJobs", int)
         setOption("disableCaching")
         setOption("disableChaining")
         setOption("maxLogFileSize", h2b, iC(1))
         setOption("writeLogs")
         setOption("writeLogsGzip")
+        setOption("runCwlInternalJobsOnWorkers")
 
         def checkSse(sseKey):
             with open(sseKey) as f:


### PR DESCRIPTION
Add an option to run CWL internal jobs on workers instead of the master. This will speed up the pipeline considerably for very large workflows that contain many scatters and/or sub-workflows (provided that there are enough workers).

Tested:
Built a docker image with these changes and tested with the flag being true and false.