### PR TITLE
Fix boto3 credentials for permanent credentials.

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import errno
 import logging
 import os
 import sys
@@ -564,6 +565,7 @@ def _monkey_patch_boto():
                             self._credential_expiry_time = str_to_datetime(record[3])
                         else:
                             log.debug('%s is empty. Credentials are not temporary.', path)
+                            self._obtain_credentials_from_boto3()
                             return
                 except IOError as e:
                     if e.errno == errno.ENOENT:


### PR DESCRIPTION
An [empty credentials file is created](https://github.com/DataBiosphere/toil/blob/044970558318d28654d2f79d1c9ccf31c4dfab81/src/toil/__init__.py#L613) in case of permanent credentials. The check [here](https://github.com/DataBiosphere/toil/blob/044970558318d28654d2f79d1c9ccf31c4dfab81/src/toil/__init__.py#L565) simply returns if an empty file exists, but does not set the credentials. As a result, credentials are not found and it shows an error.

