### PR TITLE
Add missing imports

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -19,10 +19,12 @@ import logging
 import os
 import sys
 import requests
+import time
 from datetime import datetime
 from pytz import timezone
 from docker.errors import ImageNotFound
 from toil.lib.memoize import memoize
+from toil.lib.misc import mkdir_p
 from toil.version import currentCommit
 
 # subprocess32 is a backport of python3's subprocess module for use on Python2,


### PR DESCRIPTION
I forgot a couple of the imports that the credential caching code uses when I moved it over.

I've now checked `src/toil/__init__.py` with `pylint`, so there shouldn't be any more missing imports in it.