### PR TITLE
Add support for running custom init commands in docker.

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -83,8 +83,10 @@ print(heredoc('''
 
     ADD waitForKey.sh /usr/bin/waitForKey.sh
 
-    RUN chmod 777 /usr/bin/waitForKey.sh
+    ADD customDockerInit.sh /usr/bin/customDockerInit.sh
 
+    RUN chmod 777 /usr/bin/waitForKey.sh && chmod 777 /usr/bin/customDockerInit.sh
+    
     # The stock pip is too old and can't install from sdist with extras
     RUN pip install --upgrade pip==9.0.1
 

--- a/docker/customDockerInit.sh
+++ b/docker/customDockerInit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Runs custom initialization before running the main docker service.
+# The first argument is a single string containing the custom init command.
+# The second argument is the docker service binary (e.g. mesos-slave).
+# The rest of the arguments are passed into the service.
+# All arguments are required!
+#
+# Example usage:
+# $ customDockerInit.sh 'echo "hello world"' mesos-slave --log_dir=/var/lib/mesos ...
+
+CUSTOM_INIT_COMMAND="${1}"
+SERVICE_COMMAND="${2}"
+SERVICE_COMMAND_ARGS="${@:3}"
+
+bash -c "${CUSTOM_INIT_COMMAND}"
+eval "${SERVICE_COMMAND}" "${SERVICE_COMMAND_ARGS}"

--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -4,91 +4,99 @@ Environment Variables
 =====================
 There are several environment variables that affect the way Toil runs.
 
-+------------------------+----------------------------------------------------+
-| TOIL_WORKDIR           | An absolute path to a directory where Toil will    |
-|                        | write its temporary files. This directory must     |
-|                        | exist on each worker node and may be set to a      |
-|                        | different value on each worker. The ``--workDir``  |
-|                        | command line option overrides this. On Mesos nodes,|
-|                        | ``TOIL_WORKDIR`` generally defaults to the Mesos   |
-|                        | sandbox, except on CGCloud-provisioned nodes where |
-|                        | it defaults to ``/var/lib/mesos``. In all other    |
-|                        | cases, the system's `standard temporary directory`_|
-|                        | is used.                                           |
-+------------------------+----------------------------------------------------+
-| TOIL_APPLIANCE_SELF    | The fully qualified reference for the Toil         |
-|                        | Appliance you wish to use, in the form             |
-|                        | ``REPO/IMAGE:TAG``.                                |
-|                        | ``quay.io/ucsc_cgl/toil:3.6.0`` and                |
-|                        | ``cket/toil:3.5.0`` are both examples of valid     |
-|                        | options. Note that since Docker defaults to        |
-|                        | Dockerhub repos, only quay.io repos need to        |
-|                        | specify their registry.                            |
-+------------------------+----------------------------------------------------+
-| TOIL_DOCKER_REGISTRY   | The URL of the registry of the Toil Appliance      |
-|                        | image you wish to use. Docker will use Dockerhub   |
-|                        | by default, but the quay.io registry is also       |
-|                        | very popular and easily specifiable by settting    |
-|                        | this option to ``quay.io``.                        |
-+------------------------+----------------------------------------------------+
-| TOIL_DOCKER_NAME       | The name of the Toil Appliance image you           |
-|                        | wish to use. Generally this is simply ``toil`` but |
-|                        | this option is provided to override this,          |
-|                        | since the image can be built with arbitrary names. |
-+------------------------+----------------------------------------------------+
-| TOIL_AWS_ZONE          | The EC2 zone to provision nodes in if using        |
-|                        | Toil's provisioner.                                |
-+------------------------+----------------------------------------------------+
-| TOIL_AWS_AMI           | ID of the AMI to use in node provisioning. If in   |
-|                        | doubt, don't set this variable.                    |
-+------------------------+----------------------------------------------------+
-| TOIL_AWS_NODE_DEBUG    | Determines whether to preserve nodes that have     |
-|                        | failed health checks. If set to ``True``, nodes    |
-|                        | that fail EC2 health checks won't immediately be   |
-|                        | terminated so they can be examined and the cause   |
-|                        | of failure determined. If any EC2 nodes are left   |
-|                        | behind in this manner, the security group will     |
-|                        | also be left behind by necessity as it cannot be   |
-|                        | deleted until all associated nodes have been       |
-|                        | terminated.                                        |
-+------------------------+----------------------------------------------------+
-| TOIL_AZURE_ZONE        | A specified region for provisioning instances.     |
-+------------------------+----------------------------------------------------+
-| TOIL_SLURM_ARGS        | Arguments for sbatch for the slurm batch system.   |
-|                        | Do not pass CPU or memory specifications here.     |
-|                        | Instead, define resource requirements for the job. |
-|                        | There is no default value for this variable.       |
-+------------------------+----------------------------------------------------+
-| TOIL_GRIDENGINE_ARGS   | Arguments for qsub for the gridengine batch        |
-|                        | system. Do not pass CPU or memory specifications   |
-|                        | here. Instead, define resource requirements for    |
-|                        | the job. There is no default value for this        |
-|                        | variable.                                          |
-+------------------------+----------------------------------------------------+
-| TOIL_GRIDENGINE_PE     | Parallel environment arguments for qsub and for    |
-|                        | the gridengine batch system. There is no default   |
-|                        | value for this variable.                           |
-+------------------------+----------------------------------------------------+
-| TOIL_TORQUE_ARGS       | Arguments for qsub for the Torque batch system.    |
-|                        | Do not pass CPU or memory specifications here.     |
-|                        | Instead, define extra parameters for the job such  |
-|                        | as queue. Example: -q medium                       |
-|                        | Use TOIL_TORQUE_REQS to pass extra values for the  |
-|                        | -l resource requirements parameter.                |
-|                        | There is no default value for this variable.       |
-+------------------------+----------------------------------------------------+
-| TOIL_TORQUE_REQS       | Arguments for the resource requirements for Torque |
-|                        | batch system. Do not pass CPU or memory            |
-|                        | specifications here. Instead, define extra resource| 
-|                        | requirements as a string that goes after the -l    |
-|                        | argument to qsub. Example:                         |
-|                        | walltime=2:00:00,file=50gb                         |
-|                        | There is no default value for this variable.       |
-+------------------------+----------------------------------------------------+
-| TOIL_LSF_ARGS          | Additional arguments for the LSF's bsub command.   |
-|                        | Instead, define extra parameters for the job such  |
-|                        | as queue. Example: -q medium.                      |
-|                        | There is no default value for this variable.       |
-+------------------------+----------------------------------------------------+
++----------------------------------+----------------------------------------------------+
+| TOIL_WORKDIR                     | An absolute path to a directory where Toil will    |
+|                                  | write its temporary files. This directory must     |
+|                                  | exist on each worker node and may be set to a      |
+|                                  | different value on each worker. The ``--workDir``  |
+|                                  | command line option overrides this. On Mesos nodes,|
+|                                  | ``TOIL_WORKDIR`` generally defaults to the Mesos   |
+|                                  | sandbox, except on CGCloud-provisioned nodes where |
+|                                  | it defaults to ``/var/lib/mesos``. In all other    |
+|                                  | cases, the system's `standard temporary directory`_|
+|                                  | is used.                                           |
++----------------------------------+----------------------------------------------------+
+| TOIL_APPLIANCE_SELF              | The fully qualified reference for the Toil         |
+|                                  | Appliance you wish to use, in the form             |
+|                                  | ``REPO/IMAGE:TAG``.                                |
+|                                  | ``quay.io/ucsc_cgl/toil:3.6.0`` and                |
+|                                  | ``cket/toil:3.5.0`` are both examples of valid     |
+|                                  | options. Note that since Docker defaults to        |
+|                                  | Dockerhub repos, only quay.io repos need to        |
+|                                  | specify their registry.                            |
++----------------------------------+----------------------------------------------------+
+| TOIL_DOCKER_REGISTRY             | The URL of the registry of the Toil Appliance      |
+|                                  | image you wish to use. Docker will use Dockerhub   |
+|                                  | by default, but the quay.io registry is also       |
+|                                  | very popular and easily specifiable by settting    |
+|                                  | this option to ``quay.io``.                        |
++----------------------------------+----------------------------------------------------+
+| TOIL_DOCKER_NAME                 | The name of the Toil Appliance image you           |
+|                                  | wish to use. Generally this is simply ``toil`` but |
+|                                  | this option is provided to override this,          |
+|                                  | since the image can be built with arbitrary names. |
++----------------------------------+----------------------------------------------------+
+| TOIL_AWS_ZONE                    | The EC2 zone to provision nodes in if using        |
+|                                  | Toil's provisioner.                                |
++----------------------------------+----------------------------------------------------+
+| TOIL_AWS_AMI                     | ID of the AMI to use in node provisioning. If in   |
+|                                  | doubt, don't set this variable.                    |
++----------------------------------+----------------------------------------------------+
+| TOIL_AWS_NODE_DEBUG              | Determines whether to preserve nodes that have     |
+|                                  | failed health checks. If set to ``True``, nodes    |
+|                                  | that fail EC2 health checks won't immediately be   |
+|                                  | terminated so they can be examined and the cause   |
+|                                  | of failure determined. If any EC2 nodes are left   |
+|                                  | behind in this manner, the security group will     |
+|                                  | also be left behind by necessity as it cannot be   |
+|                                  | deleted until all associated nodes have been       |
+|                                  | terminated.                                        |
++----------------------------------+----------------------------------------------------+
+| TOIL_AZURE_ZONE                  | A specified region for provisioning instances.     |
++----------------------------------+----------------------------------------------------+
+| TOIL_SLURM_ARGS                  | Arguments for sbatch for the slurm batch system.   |
+|                                  | Do not pass CPU or memory specifications here.     |
+|                                  | Instead, define resource requirements for the job. |
+|                                  | There is no default value for this variable.       |
++----------------------------------+----------------------------------------------------+
+| TOIL_GRIDENGINE_ARGS             | Arguments for qsub for the gridengine batch        |
+|                                  | system. Do not pass CPU or memory specifications   |
+|                                  | here. Instead, define resource requirements for    |
+|                                  | the job. There is no default value for this        |
+|                                  | variable.                                          |
++----------------------------------+----------------------------------------------------+
+| TOIL_GRIDENGINE_PE               | Parallel environment arguments for qsub and for    |
+|                                  | the gridengine batch system. There is no default   |
+|                                  | value for this variable.                           |
++----------------------------------+----------------------------------------------------+
+| TOIL_TORQUE_ARGS                 | Arguments for qsub for the Torque batch system.    |
+|                                  | Do not pass CPU or memory specifications here.     |
+|                                  | Instead, define extra parameters for the job such  |
+|                                  | as queue. Example: -q medium                       |
+|                                  | Use TOIL_TORQUE_REQS to pass extra values for the  |
+|                                  | -l resource requirements parameter.                |
+|                                  | There is no default value for this variable.       |
++----------------------------------+----------------------------------------------------+
+| TOIL_TORQUE_REQS                 | Arguments for the resource requirements for Torque |
+|                                  | batch system. Do not pass CPU or memory            |
+|                                  | specifications here. Instead, define extra resource|
+|                                  | requirements as a string that goes after the -l    |
+|                                  | argument to qsub. Example:                         |
+|                                  | walltime=2:00:00,file=50gb                         |
+|                                  | There is no default value for this variable.       |
++----------------------------------+----------------------------------------------------+
+| TOIL_LSF_ARGS                    | Additional arguments for the LSF's bsub command.   |
+|                                  | Instead, define extra parameters for the job such  |
+|                                  | as queue. Example: -q medium.                      |
+|                                  | There is no default value for this variable.       |
++----------------------------------+----------------------------------------------------+
+| TOIL_CUSTOM_DOCKER_INIT_COMMAND  | Any custom bash command to run in the Toil docker  |
+|                                  | container prior to running the Toil services.      |
+|                                  | Can be used for any custom initialization in the   |
+|                                  | worker and/or primary nodes such as private docker |
+|                                  | docker authentication. Example for AWS ECR:        |
+|                                  | ``pip install awscli && eval $(aws ecr get-login   |
+|                                  | --no-include-email --region us-east-1)``.          |
++----------------------------------+----------------------------------------------------+
 
 .. _standard temporary directory: https://docs.python.org/2/library/tempfile.html#tempfile.gettempdir

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -216,6 +216,22 @@ def applianceSelf(forceDockerAppliance=False):
         return checkDockerImageExists(appliance=appliance)
 
 
+def customDockerInitCmd():
+    """
+    Returns the custom command (if any) provided through the ``TOIL_CUSTOM_DOCKER_INIT_COMMAND``
+    environment variable to run just after the docker leader/worker has been initialized.
+    This can be useful for doing any custom initialization on instances (e.g. authenticating to
+    private docker registries). An empty string is returned if the environment variable is not
+    set.
+
+    :rtype: str
+    """
+    command = lookupEnvVar(name='user-defined custom docker init command',
+                           envName='TOIL_CUSTOM_DOCKER_INIT_COMMAND',
+                           defaultValue='')
+    return command.replace("'", "'\\''")  # Ensure any single quotes are escaped.
+
+
 def lookupEnvVar(name, envName, defaultValue):
     """
     Use this for looking up environment variables that control Toil and are important enough to

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -219,7 +219,7 @@ def applianceSelf(forceDockerAppliance=False):
 def customDockerInitCmd():
     """
     Returns the custom command (if any) provided through the ``TOIL_CUSTOM_DOCKER_INIT_COMMAND``
-    environment variable to run just after the docker leader/worker has been initialized.
+    environment variable to run prior to running the workers and/or the primary node's services.
     This can be useful for doing any custom initialization on instances (e.g. authenticating to
     private docker registries). An empty string is returned if the environment variable is not
     set.

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -19,7 +19,7 @@ import logging
 import os.path
 
 from toil import subprocess
-from toil import applianceSelf
+from toil import applianceSelf, customDockerInitCmd
 from toil.lib.retry import never
 
 a_short_time = 5
@@ -402,6 +402,10 @@ coreos:
         if keyPath:
             mesosArgs = keyPath + ' ' + mesosArgs
             entryPoint = "waitForKey.sh"
+        customDockerInitCommand = customDockerInitCmd()
+        if customDockerInitCommand:
+            mesosArgs = " ".join(["'" + customDockerInitCommand + "'", entryPoint, mesosArgs])
+            entryPoint = "customDockerInit.sh"
         templateArgs = dict(role=role,
                             dockerImage=applianceSelf(),
                             entrypoint=entryPoint,


### PR DESCRIPTION
This solves the private docker authentication issue #2166 as one can add `TOIL_CUSTOM_DOCKER_INIT_COMMAND='pip install awscli && eval $(aws ecr get-login --no-include-email --region us-east-1)'` to the environment variable, which is then executed on the docker instance in all workers (note: this is easy to do manually on the master, but not possible on the workers when running a large cluster).

Notes:
* I figured to make this more generic to allow any type of custom initialization and not be AWS ECR specific. We can even consider removing `waitForKey.sh` in favor of this.
* Using an environment variable is not ideal, but passing the argument through all provisioners made it complicated.
* This does not work if the Toil image itself is hosted in a private repository, but can be addressed either via using a custom AMI or adding another similar pre-init command that is run prior to `toil-{role}.service`.