### PR TITLE
Add private IP support to node operations.

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -401,7 +401,7 @@ class AWSProvisioner(AbstractProvisioner):
         while True:
             time.sleep(a_short_time)
             instance.update()
-            if instance.ip_address or instance.public_dns_name:
+            if instance.ip_address or instance.public_dns_name or instance.private_ip_address:
                 logger.debug('...got ip')
                 break
 


### PR DESCRIPTION
With this change, Toil can now launch clusters in environments that just have private IPs (tested on AWS only). Other SSH settings (e.g. ProxyCommand) are assumed to be provided through SSH config.

Fixes #2568 
