### PR TITLE
Optimize filestore links

### DIFF
--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -374,7 +374,7 @@ class FileJobStore(AbstractJobStore):
         # If local file would end up on same file system as the one hosting this job store ...
         if os.stat(jobStoreFilePath).st_dev == os.stat(localDirPath).st_dev:
             # ... we can hard-link the file, ...
-            if symlink:
+            if symlink or self.linkImports:
                 try:
                     os.symlink(jobStoreFilePath, localFilePath)
                 except OSError as e:

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -387,14 +387,14 @@ class FileJobStore(AbstractJobStore):
                         raise
             else:
                 try:
-                    os.link(jobStoreFilePath, localFilePath)
+                    os.link(os.path.realpath(jobStoreFilePath), localFilePath)
                 except OSError as e:
                     if e.errno == errno.EEXIST:
                         # Overwrite existing file, emulating shutil.copyfile().
                         os.unlink(localFilePath)
                         # It would be very unlikely to fail again for same reason but possible
                         # nonetheless in which case we should just give up.
-                        os.link(jobStoreFilePath, localFilePath)
+                        os.link(os.path.realpath(jobStoreFilePath), localFilePath)
                     else:
                         logger.critical('jobStoreFilePath: ' + jobStoreFilePath + ' ' + str(os.path.exists(jobStoreFilePath)))
                         logger.critical('localFilePath: ' + localFilePath + ' ' + str(os.path.exists(localFilePath)))

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -90,6 +90,7 @@ class FileJobStore(AbstractJobStore):
         if not os.path.isdir(self.jobStoreDir):
             raise NoSuchJobStoreException(self.jobStoreDir)
         super(FileJobStore, self).resume()
+        self.linkImports = self.config.linkImports
 
     def robust_rmtree(self, path, max_retries=3):
         """Robustly tries to delete paths.


### PR DESCRIPTION
Use --linkImports also when importing files from jobStore to workDir and allow symlinks across devices (resolves #2550, resolves #2551)