### PR TITLE
Retry getting credentials from Boto3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ help:
 SHELL=bash
 python=python
 pip=pip
-tests=src
+tests=src/toil/test/cwl/cwlTest.py::CWLTest::test_run_s3
 tests_local=src/toil/test
 # do slightly less than travis timeout of 10 min.
 pytest_args_local=-vv --timeout=530

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ help:
 SHELL=bash
 python=python
 pip=pip
-tests=src/toil/test/cwl/cwlTest.py::CWLTest::test_run_s3
+tests=src
 tests_local=src/toil/test
 # do slightly less than travis timeout of 10 min.
 pytest_args_local=-vv --timeout=530

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -25,6 +25,7 @@ from pytz import timezone
 from docker.errors import ImageNotFound
 from toil.lib.memoize import memoize
 from toil.lib.misc import mkdir_p
+from toil.lib.retry import retry
 from toil.version import currentCommit
 
 # subprocess32 is a backport of python3's subprocess module for use on Python2,

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -538,8 +538,18 @@ def _monkey_patch_boto():
             
             # We get a Credentials object
             # <https://github.com/boto/botocore/blob/8d3ea0e61473fba43774eb3c74e1b22995ee7370/botocore/credentials.py#L227>
-            # or a RefreshableCredentials
-            creds = self._boto3_resolver.load_credentials()
+            # or a RefreshableCredentials, or None on failure.
+            creds = None
+            for attempt in retry(timeout=10, predicate=true):
+                with attempt:
+                    creds = self._boto3_resolver.load_credentials()
+                    
+                    if creds is None:
+                        try:
+                            resolvers = str(self._boto3_resolver.providers)
+                        except:
+                            resolvers = "(Resolvers unavailable)"
+                        raise RuntimeError("Could not obtain AWS credentials from Boto3. Resolvers tried: " + resolvers)
             
             # Make sure the credentials actually has some credentials if it is lazy
             creds.get_frozen_credentials()

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -541,7 +541,7 @@ def _monkey_patch_boto():
             # <https://github.com/boto/botocore/blob/8d3ea0e61473fba43774eb3c74e1b22995ee7370/botocore/credentials.py#L227>
             # or a RefreshableCredentials, or None on failure.
             creds = None
-            for attempt in retry(timeout=10, predicate=true):
+            for attempt in retry(timeout=10, predicate=True):
                 with attempt:
                     creds = self._boto3_resolver.load_credentials()
                     

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -541,7 +541,7 @@ def _monkey_patch_boto():
             # <https://github.com/boto/botocore/blob/8d3ea0e61473fba43774eb3c74e1b22995ee7370/botocore/credentials.py#L227>
             # or a RefreshableCredentials, or None on failure.
             creds = None
-            for attempt in retry(timeout=10, predicate=True):
+            for attempt in retry(timeout=10, predicate=lambda _: True):
                 with attempt:
                     creds = self._boto3_resolver.load_credentials()
                     

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -489,7 +489,7 @@ class AWSJobStore(AbstractJobStore):
             keyName = url.path[1:]
             bucketName = url.netloc
             bucket = s3.get_bucket(bucketName)
-            key = bucket.get_key(bytes(keyName))
+            key = bucket.get_key(keyName.encode('utf-8'))
             if existing is True:
                 if key is None:
                     raise RuntimeError("Key '%s' does not exist in bucket '%s'." %


### PR DESCRIPTION
It may make network requests that can fail.

Also, we want a good error message if it fails, and not a complaint about operating on None.

Fixes #2581 hopefully