### PR TITLE
Add an option to set disableCaching to false.

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -117,7 +117,7 @@ class Config(object):
         self.rescueJobsFrequency = 3600
 
         # Misc
-        self.disableCaching = False
+        self.disableCaching = True
         self.disableChaining = False
         self.maxLogFileSize = 64000
         self.writeLogs = None
@@ -519,7 +519,8 @@ def _addOptions(addGroupFn, config):
     # Misc options
     #
     addOptionFn = addGroupFn("Toil Miscellaneous Options", "Miscellaneous Options")
-    addOptionFn('--disableCaching', dest='disableCaching', action='store_true', default=False,
+    addOptionFn('--disableCaching', dest='disableCaching',
+                type='bool', nargs='?', const=True, default=True,
                 help='Disables caching in the file store. This flag must be set to use '
                      'a batch system that does not support caching such as Grid Engine, Parasol, '
                      'LSF, or Slurm')
@@ -593,6 +594,7 @@ def addOptions(parser, config=Config()):
         def addGroup(headingString, bodyString):
             return parser.add_argument_group(headingString, bodyString).add_argument
 
+        parser.register("type", "bool", lambda v: v.lower() == "true")  # Custom type for arg=True/False.
         _addOptions(addGroup, config)
     else:
         raise RuntimeError("Unanticipated class passed to addOptions(), %s. Expecting "

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -117,7 +117,7 @@ class Config(object):
         self.rescueJobsFrequency = 3600
 
         # Misc
-        self.disableCaching = True
+        self.disableCaching = False
         self.disableChaining = False
         self.maxLogFileSize = 64000
         self.writeLogs = None
@@ -519,7 +519,7 @@ def _addOptions(addGroupFn, config):
     # Misc options
     #
     addOptionFn = addGroupFn("Toil Miscellaneous Options", "Miscellaneous Options")
-    addOptionFn('--disableCaching', dest='disableCaching', action='store_true', default=True,
+    addOptionFn('--disableCaching', dest='disableCaching', action='store_true', default=False,
                 help='Disables caching in the file store. This flag must be set to use '
                      'a batch system that does not support caching such as Grid Engine, Parasol, '
                      'LSF, or Slurm')


### PR DESCRIPTION
Fixes #2586

This was changed in https://github.com/DataBiosphere/toil/commit/2e54371ea316fe2803ce53d1477a51fadcfb5d2e , which effectively disables caching altogether (there is no way to turn caching on). Was that the intention?

This PR changes the existing default behavior though. I can add an `enableCaching` option if we want to keep the existing default behavior. Please let me know!
