### PR TITLE
Increase hardcoded encapsulate follow-on resources

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1571,7 +1571,8 @@ class EncapsulatedJob(Job):
         self.encapsulatedJob = job
         Job.addChild(self, job)
         # Use small resource requirements for dummy Job instance.
-        self.encapsulatedFollowOn = Job(disk='1M', memory='32M', cores=0.1)
+        # But not too small, or the job won't have enough resources to safely start up Toil.
+        self.encapsulatedFollowOn = Job(disk='100M', memory='512M', cores=0.1)
         Job.addFollowOn(self, self.encapsulatedFollowOn)
 
     def addChild(self, childJob):


### PR DESCRIPTION
This should fix https://github.com/ComparativeGenomicsToolkit/cactus/issues/72 and fix #2590

We still will want to enforce a lower bound on job resource requirements when scheduling that is sufficient to run Toil itself.

We also will want to treat lost jobs (that finished according to the scheduler but never reported to us) as failures.