### PR TITLE
Encode logs for gzip

### DIFF
--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -489,7 +489,7 @@ class AWSJobStore(AbstractJobStore):
             keyName = url.path[1:]
             bucketName = url.netloc
             bucket = s3.get_bucket(bucketName)
-            key = bucket.get_key(bytes(keyName))
+            key = bucket.get_key(keyName.encode('utf-8'))
             if existing is True:
                 if key is None:
                     raise RuntimeError("Key '%s' does not exist in bucket '%s'." %

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -91,7 +91,7 @@ class StatsAndLogging( object ):
 
         fullName = createName(path, mainFileName, extension)
         with writeFn(fullName, 'w') as f:
-            f.writelines(l + '\n' for l in jobLogList)
+            f.writelines((l + '\n').encode('utf-8') for l in jobLogList)
         for alternateName in jobNames[1:]:
             # There are chained jobs in this output - indicate this with a symlink
             # of the job's name to this file

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -90,7 +90,7 @@ class StatsAndLogging( object ):
             return
 
         fullName = createName(path, mainFileName, extension)
-        with writeFn(fullName, 'w') as f:
+        with writeFn(fullName, 'wb') as f:
             f.writelines((l + '\n').encode('utf-8') for l in jobLogList)
         for alternateName in jobNames[1:]:
             # There are chained jobs in this output - indicate this with a symlink

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import mimetypes
 import sys
 import os
@@ -20,6 +21,8 @@ from toil import subprocess
 from toil.test import ToilTest, slow
 from toil.test.mesos import helloWorld
 
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 class RegularLogTest(ToilTest):
 
@@ -32,25 +35,24 @@ class RegularLogTest(ToilTest):
 
     def _assertFileTypeExists(self, dir, extension, encoding=None):
         # an encoding of None implies no compression
-        log.info("Checking for %s file in %s", extension, dir)
+        logger.info("Checking for %s file in %s", extension, dir)
         onlyFiles = self._getFiles(dir)
-        log.info("Found: %s", str(os.listdir(dir)))
+        logger.info("Found: %s", str(os.listdir(dir)))
         onlyLogs = [f for f in onlyFiles if f.endswith(extension)]
-        log.info("Found matching: %s", str(onlyLogs))
+        logger.info("Found matching: %s", str(onlyLogs))
         assert onlyLogs
         
         if encoding is not None:
             for log in onlyLogs:
                 with open(log, "rb") as f:
-                    log.info("Checking for encoding %s on file %s", str(onlyLogs), log)
+                    logger.info("Checking for encoding %s on file %s", str(encoding), log)
                     if encoding == "gzip":
                         # Check for gzip magic header '\x1f\x8b'
                         assert f.read().startswith(b'\x1f\x8b')
                     else:
                         mime = mimetypes.guess_type(log)
                         self.assertEqual(mime[1], encoding)
-
-
+    
     @slow
     def testLogToMaster(self):
         toilOutput = subprocess.check_output([sys.executable,

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -63,24 +63,22 @@ class RegularLogTest(ToilTest):
         assert helloWorld.childMessage in toilOutput.decode('utf-8')
 
     def testWriteLogs(self):
-        toilOutput = subprocess.check_output([sys.executable,
-                                              '-m', helloWorld.__name__,
-                                              './toilTest',
-                                              '--clean=always',
-                                              '--logLevel=debug',
-                                              '--writeLogs=%s' % self.tempDir],
-                                             stderr=subprocess.STDOUT)
+        subprocess.check_call([sys.executable,
+                               '-m', helloWorld.__name__,
+                               './toilTest',
+                               '--clean=always',
+                               '--logLevel=debug',
+                               '--writeLogs=%s' % self.tempDir])
         self._assertFileTypeExists(self.tempDir, '.log')
 
     @slow
     def testWriteGzipLogs(self):
-        toilOutput = subprocess.check_output([sys.executable,
-                                              '-m', helloWorld.__name__,
-                                              './toilTest',
-                                              '--clean=always',
-                                              '--logLevel=debug',
-                                              '--writeLogsGzip=%s' % self.tempDir],
-                                              stderr=subprocess.STDOUT)
+        subprocess.check_call([sys.executable,
+                               '-m', helloWorld.__name__,
+                               './toilTest',
+                               '--clean=always',
+                               '--logLevel=debug',
+                               '--writeLogsGzip=%s' % self.tempDir])
         self._assertFileTypeExists(self.tempDir, '.log.gz', 'gzip')
 
     @slow

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -32,18 +32,23 @@ class RegularLogTest(ToilTest):
 
     def _assertFileTypeExists(self, dir, extension, encoding=None):
         # an encoding of None implies no compression
+        log.info("Checking for %s file in %s", extension, dir)
         onlyFiles = self._getFiles(dir)
-        print(os.listdir(dir))
+        log.info("Found: %s", str(os.listdir(dir)))
         onlyLogs = [f for f in onlyFiles if f.endswith(extension)]
+        log.info("Found matching: %s", str(onlyLogs))
         assert onlyLogs
-        for log in onlyLogs:
-            with open(log, "rb") as f:
-                if encoding == "gzip":
-                    # Check for gzip magic header '\x1f\x8b'
-                    assert f.read().startswith(b'\x1f\x8b')
-                else:
-                    mime = mimetypes.guess_type(log)
-                    self.assertEqual(mime[1], encoding)
+        
+        if encoding is not None:
+            for log in onlyLogs:
+                with open(log, "rb") as f:
+                    log.info("Checking for encoding %s on file %s", str(onlyLogs), log)
+                    if encoding == "gzip":
+                        # Check for gzip magic header '\x1f\x8b'
+                        assert f.read().startswith(b'\x1f\x8b')
+                    else:
+                        mime = mimetypes.guess_type(log)
+                        self.assertEqual(mime[1], encoding)
 
 
     @slow

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -235,6 +235,7 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
     statsDict.workers.logsToMaster = []
     blockFn = lambda : True
     listOfJobs = [jobName]
+    job = None
     try:
 
         #Put a message at the top of the log, just to make sure it's working.


### PR DESCRIPTION
This should fix #2594. We weren't encoding log lines before trying to feed them into the gzip compressor, which Python 3 was upset by.

I'm not sure why we didn't see the message in the test environment that I saw running the test workflow manually:

```
python -m toil.test.mesos.helloWorld ./toilTest '--clean=always' '--logLevel=debug' '--writeLogsGzip=testlog'
...
Exception in thread Thread-642:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/public/home/anovak/build/toil/src/toil/statsAndLogging.py", line 140, in statsAndLoggingAggregator
    if jobStore.readStatsAndLogging(callback) == 0:
  File "/public/home/anovak/build/toil/src/toil/jobStores/fileJobStore.py", line 480, in readStatsAndLogging
    callback(fH)
  File "/public/home/anovak/build/toil/src/toil/statsAndLogging.py", line 133, in callback
    cls.writeLogFiles(jobNames, messages, config=config)
  File "/public/home/anovak/build/toil/src/toil/statsAndLogging.py", line 94, in writeLogFiles
    f.writelines(l + '\n' for l in jobLogList)
  File "/usr/lib64/python3.6/gzip.py", line 260, in write
    data = memoryview(data)
TypeError: memoryview: a bytes-like object is required, not 'str'
...
```

In addition to the actual fix, this PR includes some additional logging code in the function that verify the log files that come out (since I couldn't tell if they had run or not looking at the Gitlab test output), and a couple fixes to the worker script that I needed to get it to properly tell me not to run user scripts out of Python module directories (because I tried that and the error was getting swallowed).

