### PR TITLE
Use current python executable

### DIFF
--- a/src/toil/wdl/toilwdl.py
+++ b/src/toil/wdl/toilwdl.py
@@ -18,6 +18,7 @@ from __future__ import division
 import argparse
 import os
 import logging
+import sys
 
 from toil import subprocess
 from toil.wdl.wdl_analysis import AnalyzeWDL
@@ -141,7 +142,8 @@ def main():
         sWDL.write_mappings(aWDL)
     else:
         wdllogger.debug('WDL file compiled to toil script.  Running now.')
-        cmd = ['python', sWDL.output_file]
+        exe = sys.executable if sys.executable else 'python'
+        cmd = [exe, sWDL.output_file]
         cmd.extend(wdl_run_args)
         subprocess.check_call(cmd)
         os.remove(sWDL.output_file)


### PR DESCRIPTION
I had to switch to python3 to get Toil working with `$PYTHONUSERBASE` (#2598). But I still have old python in my `$PATH`. This uses the proper python. (Some tests could be updated too, but this is the only actual bug I found.)