### PR TITLE
Revert "Update fileJobStore to resolve symlinks (resolves #2553)"

### DIFF
--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -387,14 +387,14 @@ class FileJobStore(AbstractJobStore):
                         raise
             else:
                 try:
-                    os.link(os.path.realpath(jobStoreFilePath), localFilePath)
+                    os.link(jobStoreFilePath, localFilePath)
                 except OSError as e:
                     if e.errno == errno.EEXIST:
                         # Overwrite existing file, emulating shutil.copyfile().
                         os.unlink(localFilePath)
                         # It would be very unlikely to fail again for same reason but possible
                         # nonetheless in which case we should just give up.
-                        os.link(os.path.realpath(jobStoreFilePath), localFilePath)
+                        os.link(jobStoreFilePath, localFilePath)
                     else:
                         logger.critical('jobStoreFilePath: ' + jobStoreFilePath + ' ' + str(os.path.exists(jobStoreFilePath)))
                         logger.critical('localFilePath: ' + localFilePath + ' ' + str(os.path.exists(localFilePath)))


### PR DESCRIPTION
Reverts DataBiosphere/toil#2556.  I believe I may have been overzealous in merging this as it seems to be causing jobs to fail.

Will test this more after reversion.