### PR TITLE
StatsAndLogging(): ensure json.load() receives only string input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.5"
   - "3.6"
   - "2.7"
 install:

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -368,10 +368,10 @@ Pull Requests
   
   .. code-block:: bash
   
-      USER="jqrandom"
+      CONTRIBUTOR="jqrandom"
       SOURCE_BRANCH="fix-thingy"
       DESTINATION_BRANCH="issues/1234-fix-thingy"
-      git fetch git@github.com:${USER}/toil.git ${SOURCE_BRANCH}
+      git fetch git@github.com:${CONTRIBUTOR}/toil.git ${SOURCE_BRANCH}
       git push git@github.com:DataBiosphere/toil.git FETCH_HEAD:refs/heads/${DESTINATION_BRANCH}
      
   These steps must be repeated every time the PR submitter updates their PR,

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -109,7 +109,10 @@ class StatsAndLogging( object ):
         startClock = getTotalCpuTime()
 
         def callback(fileHandle):
-            stats = json.load(fileHandle, object_hook=Expando)
+            statsStr = fileHandle.read()
+            if not isinstance(statsStr, str):
+                statsStr = statsStr.decode()
+            stats = json.loads(statsStr, object_hook=Expando)
             try:
                 logs = stats.workers.logsToMaster
             except AttributeError:

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -91,7 +91,12 @@ class StatsAndLogging( object ):
 
         fullName = createName(path, mainFileName, extension)
         with writeFn(fullName, 'wb') as f:
-            f.writelines((l + '\n').encode('utf-8') for l in jobLogList)
+            for l in jobLogList:
+                try:
+                    l = l.decode('utf-8')
+                except AttributeError:
+                    pass
+                f.write((l + '\n').encode('utf-8'))
         for alternateName in jobNames[1:]:
             # There are chained jobs in this output - indicate this with a symlink
             # of the job's name to this file

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -96,7 +96,9 @@ class StatsAndLogging( object ):
                     l = l.decode('utf-8')
                 except AttributeError:
                     pass
-                f.write((l + '\n').encode('utf-8'))
+                if not l.endswith('\n'):
+                    l += '\n'
+                f.write(l.encode('utf-8'))
         for alternateName in jobNames[1:]:
             # There are chained jobs in this output - indicate this with a symlink
             # of the job's name to this file

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -56,6 +56,7 @@ from toil.jobStores.abstractJobStore import (NoSuchJobException,
                                              NoSuchFileException)
 from toil.jobStores.googleJobStore import googleRetry
 from toil.jobStores.fileJobStore import FileJobStore
+from toil.statsAndLogging import StatsAndLogging
 from toil.test import (ToilTest,
                        needs_aws,
                        needs_azure,
@@ -551,6 +552,20 @@ class AbstractJobStoreTest(object):
             jobstore1.delete(jobOnJobStore1.jobStoreID)
             self.assertFalse(jobstore1.exists(jobOnJobStore1.jobStoreID))
             # TODO: Who deletes the shared files?
+
+        def testWriteLogFiles(self):
+            """Test writing log files."""
+            jobNames = ['testStatsAndLogging_writeLogFiles']
+            jobLogList = ['string', b'bytes', '', b'newline\n']
+            config = self._createConfig()
+            setattr(config, 'writeLogs', '.')
+            setattr(config, 'writeLogsGzip', None)
+            StatsAndLogging.writeLogFiles(jobNames, jobLogList, config)
+            jobLogFile = os.path.join(config.writeLogs, jobNames[0] + '000.log')
+            self.assertTrue(os.path.isfile(jobLogFile))
+            with open(jobLogFile, 'r') as f:
+                self.assertEqual(f.read(), 'string\nbytes\n\nnewline\n')
+            os.remove(jobLogFile)
 
         def testBatchCreate(self):
             """Test creation of many jobs."""


### PR DESCRIPTION
I've been trying out Toil on a cluster with Python 3.4. It looks like the stats and logging files are being written in binary mode (`wb`) but `json.load()` doesn't handle binary files [until Python 3.6](https://docs.python.org/3.6/library/json.html#json.load). I therefore get errors like this:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.4/threading.py", line 911, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.4/threading.py", line 859, in run
    self._target(*self._args, **self._kwargs)
  File ".../toil/src/toil/statsAndLogging.py", line 142, in statsAndLoggingAggregator
    if jobStore.readStatsAndLogging(callback) == 0:
  File ".../toil/src/toil/jobStores/fileJobStore.py", line 480, in readStatsAndLogging
    callback(fH)
  File ".../toil/src/toil/statsAndLogging.py", line 114, in callback
    stats = json.loads(statsStr, object_hook=Expando)
  File "/usr/lib64/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```
This small patch first reads the file into a variable `statsStr`, then calls `.decode()` if it is not a `str`. `json.loads()` is then called with guaranteed string input.

Fixes https://github.com/DataBiosphere/toil/issues/2643