### PR TITLE
 HTCondorBatchSystem(): fixes and features

### DIFF
--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -90,6 +90,16 @@ There are several environment variables that affect the way Toil runs.
 |                                  | as queue. Example: -q medium.                      |
 |                                  | There is no default value for this variable.       |
 +----------------------------------+----------------------------------------------------+
+| TOIL_HTCONDOR_PARAMS             | Additional parameters to include in the HTCondor   |
+|                                  | submit file passed to condor_submit. Do not pass   |
+|                                  | CPU or memory specifications here. Instead define  |
+|                                  | extra parameters which may be required by HTCondor.|
+|                                  | This variable is parsed as a semicolon-separated   |
+|                                  | string of ``parameter = value`` pairs. Example:    |
+|                                  | ``requirements = TARGET.has_sse4_2 == true;        |
+|                                  | accounting_group = test``.                         |
+|                                  | There is no default value for this variable.       |
++----------------------------------+----------------------------------------------------+
 | TOIL_CUSTOM_DOCKER_INIT_COMMAND  | Any custom bash command to run in the Toil docker  |
 |                                  | container prior to running the Toil services.      |
 |                                  | Can be used for any custom initialization in the   |

--- a/docs/developingWorkflows/toilAPIBatchsystem.rst
+++ b/docs/developingWorkflows/toilAPIBatchsystem.rst
@@ -32,6 +32,12 @@ for running multicore jobs::
     export TOIL_GRIDENGINE_PE='smp'
     export TOIL_GRIDENGINE_ARGS='-q batch.q'
 
+For HTCondor, additional parameters can be included in the submit file passed to condor_submit::
+
+    export TOIL_HTCONDOR_PARAMS='requirements = TARGET.has_sse4_2 == true; accounting_group = test'
+
+The environment variable is parsed as a semicolon-separated string of ``parameter = value`` pairs.
+
 Batch System API
 ----------------
 

--- a/src/toil/batchSystems/htcondor.py
+++ b/src/toil/batchSystems/htcondor.py
@@ -161,7 +161,10 @@ class HTCondorBatchSystem(AbstractGridEngineBatchSystem):
 
             # Make sure a ClassAd was returned
             try:
-                ad = ads.next()
+                try:
+                    ad = next(ads)
+                except TypeError:
+                    ad = ads.next()
             except StopIteration:
                 logger.error(
                     "No HTCondor ads returned using constraint: {0}".format(requirements))
@@ -169,7 +172,10 @@ class HTCondorBatchSystem(AbstractGridEngineBatchSystem):
 
             # Make sure only one ClassAd was returned
             try:
-                ads.next()
+                try:
+                    next(ads)
+                except TypeError:
+                    ads.next()
             except StopIteration:
                 pass
             else:

--- a/src/toil/batchSystems/htcondor.py
+++ b/src/toil/batchSystems/htcondor.py
@@ -73,15 +73,12 @@ class HTCondorBatchSystem(AbstractGridEngineBatchSystem):
             memory = float(memory)/1024 # memory in KB
             disk = float(disk)/1024 # disk in KB
 
-            # Workaround for HTCondor Python bindings Unicode conversion bug
-            command = command.encode('utf-8')
-
             # Execute the entire command as /bin/sh -c "command"
             # TODO: Transfer the jobStore directory if using a local file store with a relative path.
             submit_parameters = {
                 'executable': '/bin/sh',
                 'transfer_executable': 'False',
-                'arguments': '''"-c '{0}'"'''.format(command),
+                'arguments': '''"-c '{0}'"'''.format(command).encode('utf-8'),    # Workaround for HTCondor Python bindings Unicode conversion bug
                 'environment': self.getEnvString(),
                 'request_cpus': '{0}'.format(cpu),
                 'request_memory': '{0:.3f}KB'.format(memory),

--- a/src/toil/batchSystems/htcondor.py
+++ b/src/toil/batchSystems/htcondor.py
@@ -91,6 +91,18 @@ class HTCondorBatchSystem(AbstractGridEngineBatchSystem):
                 '+ToilJobKilled': 'False',
             }
 
+            # Extra parameters for HTCondor
+            extra_parameters = os.getenv('TOIL_HTCONDOR_PARAMS')
+            if extra_parameters is not None:
+                logger.debug("Extra HTCondor parameters added to submit file from TOIL_HTCONDOR_PARAMS env. variable: {}".format(extra_parameters))
+                for parameter, value in [parameter_value.split('=', 1) for parameter_value in extra_parameters.split(';')]:
+                    parameter = parameter.strip()
+                    value = value.strip()
+                    if parameter in submit_parameters:
+                        raise ValueError("Some extra parameters are incompatible: {}".format(extra_parameters))
+
+                    submit_parameters[parameter] = value
+
             # Return the Submit object
             return htcondor.Submit(submit_parameters)
 

--- a/src/toil/batchSystems/htcondor.py
+++ b/src/toil/batchSystems/htcondor.py
@@ -80,6 +80,7 @@ class HTCondorBatchSystem(AbstractGridEngineBatchSystem):
                 'transfer_executable': 'False',
                 'arguments': '''"-c '{0}'"'''.format(command).encode('utf-8'),    # Workaround for HTCondor Python bindings Unicode conversion bug
                 'environment': self.getEnvString(),
+                'getenv': 'True',
                 'request_cpus': '{0}'.format(cpu),
                 'request_memory': '{0:.3f}KB'.format(memory),
                 'request_disk': '{0:.3f}KB'.format(disk),


### PR DESCRIPTION
This MR is a series of bug fixes and new features for HTCondor support in Toil. The cluster I'm using has HTCondor 8.8.2, and I'm using Python 3.6.

`HTCondorBatchSystem(): try iterating ClassAds with next(ads) before ads.next()`: It looks like iteration of ClassAds requires `next(ads)` instead of `ads.next()`. I'm not sure whether this was an interface change in the Python bindings to HTCondor, or a Python 2-vs-3 issue, or something else. A `try ... catch` is used to fall back to `ads.next()` if required.

`HTCondorBatchSystem(): encode 'command' to 'utf-8' after formatting`: This may be another Python 3 issue. Python >= (at least) 3.4 will format a byte string quoted with `b` prefix:
```
>>> "{0}".format('string'.encode('utf-8'))
"b'string'"
```
The `b` prefix is then included in the formatted command to condor (`'arguments': '''"-c '{0}'"'''.format(command)`) so jobs will fail with `b_toil_worker: command not found`. I'm not sure if the `.encode()` is still necessary (a comment refers to a bug in the HTCondor Python wrapper), but in any case the simple fix is to `.encode()` after `.format()`.

`HTCondorBatchSystem(): add getenv=True to default HTCondor parameters`: This simply tells HTCondor to pick up the user's environment when submitting jobs. This is required if e.g. `_toil_worker` or other required binaries are in non-system paths, e.g. a local virtual environment or pip install - as well as any other circumstance where jobs need to know the calling environment. I think this is a common enough situation that `getenv=True` should be part of the default configuration.

`HTCondorBatchSystem(): add TOIL_HTCONDOR_PARAMS environment variable for extra parameters`: In common with Slurm and other batch systems, this adds an environment variable for specifying extra parameters to HTCondor jobs. These might be ClassAd parameters for matching particularly kinds of compute nodes (e.g. requiring CPUs with a particular SSE variant) or, on the HTCondor cluster I use, an accountancy tag used for tracking cluster usage. To allow multiple parameters to be specified, the format of `TOIL_HTCONDOR_PARAMS` is a semicolon-separated string of `parameter = value` pairs. I'm pretty sure semicolons are not used anywhere in HTCondor parameters or ClassAd expressions so this should be a safe delimiter choice. The `parameter = value` pair is split only on the first `=`, so `value` may contain `=`s to allow ClassAd expressions. I've briefly documented `TOIL_HTCONDOR_PARAMS` in the appropriate locations in the documentation.