### PR TITLE
docs/running/hpcEnvironments.rst: mention support for HTCondor

### DIFF
--- a/docs/running/hpcEnvironments.rst
+++ b/docs/running/hpcEnvironments.rst
@@ -4,7 +4,9 @@ HPC Environments
 ================
 
 Toil is a flexible framework that can be leveraged in a variety of environments, including high-performance computing (HPC) environments.
-Toil provides support for a number of batch systems, including `Grid Engine`_, `Slurm`_, `Torque`_ and `LSF`_, which are popular schedulers used in these environments. To use one of these batch systems specify the "-\\-batchSystem" argument to the toil script.
+Toil provides support for a number of batch systems, including `Grid Engine`_, `Slurm`_, `Torque`_ and `LSF`_, which are popular schedulers used in these environments.
+Toil also supports `HTCondor`_, which is a popular scheduler for high-throughput computing (HTC).
+To use one of these batch systems specify the "-\\-batchSystem" argument to the toil script.
 
 Due to the cost and complexity of maintaining support for these schedulers we currently consider them to be "community supported", that is the core development team does not regularly test or develop support for these systems. However, there are members of the Toil community currently deploying Toil in HPC environments and we welcome external contributions.
 
@@ -17,3 +19,5 @@ Developing the support of a new or existing batch system involves extending the 
 .. _Torque: http://www.adaptivecomputing.com/products/open-source/torque/
 
 .. _LSF: https://en.wikipedia.org/wiki/Platform_LSF
+
+.. _HTCondor: https://research.cs.wisc.edu/htcondor/


### PR DESCRIPTION
It would be good to mention HTCondor explicitly in `docs/running/hpcEnvironments.rst`: it's a reasonably popular scheduler for high-throughput computing (HTC), and is used e.g. by the [Open Science Grid](https://opensciencegrid.org/).