### PR TITLE
Add an option to set custom AWS IAM roles (resolves #2575).

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -40,6 +40,9 @@ from toil.lib.generatedEC2Lists import E2Instances
 
 logger = logging.getLogger(__name__)
 logging.getLogger("boto").setLevel(logging.CRITICAL)
+# Pefix for EC2 instance profiles that are automatically created by Toil.
+_INSTANCE_PROFILE_ROLE_NAME = 'toil'
+
 
 def awsRetryPredicate(e):
     if not isinstance(e, BotoServerError):
@@ -120,6 +123,7 @@ class AWSProvisioner(AbstractProvisioner):
         self._keyName = list(instanceMetaData['public-keys'].keys())[0]
         self._tags = self.getLeader().tags
         self._masterPublicKey = self._setSSH()
+        self._leaderProfileArn = instanceMetaData['iam']['info']['InstanceProfileArn']
 
     def launchCluster(self, leaderNodeType, leaderStorage, owner, **kwargs):
         """
@@ -131,9 +135,9 @@ class AWSProvisioner(AbstractProvisioner):
         if 'keyName' not in kwargs:
             raise RuntimeError("A keyPairName is required for the AWS provisioner.")
         self._keyName = kwargs['keyName']
-        self._vpcSubnet = kwargs['vpcSubnet'] if 'vpcSubnet' in kwargs else None
+        self._vpcSubnet = kwargs.get('vpcSubnet')
 
-        profileARN = self._getProfileARN()
+        profileArn = kwargs.get('awsEc2ProfileArn') or self._getProfileArn()
         # the security group name is used as the cluster identifier
         sgs = self._createSecurityGroup()
         bdm = self._getBlockDeviceMapping(E2Instances[leaderNodeType], rootVolSize=leaderStorage)
@@ -143,7 +147,7 @@ class AWSProvisioner(AbstractProvisioner):
         specKwargs = {'key_name': self._keyName, 'security_group_ids': [sg.id for sg in sgs],
                   'instance_type': leaderNodeType,
                   'user_data': userData, 'block_device_map': bdm,
-                  'instance_profile_arn': profileARN,
+                  'instance_profile_arn': profileArn,
                   'placement': self._zone}
         if self._vpcSubnet:
             specKwargs["subnet_id"] = self._vpcSubnet
@@ -248,7 +252,6 @@ class AWSProvisioner(AbstractProvisioner):
                 raise RuntimeError("No spot bid given for a preemptable node request.")
         instanceType = E2Instances[nodeType]
         bdm = self._getBlockDeviceMapping(instanceType, rootVolSize=self._nodeStorage)
-        arn = self._getProfileARN()
 
         keyPath = self._sseKey if self._sseKey else None
         userData =  self._getCloudConfigUserData('worker', self._masterPublicKey, keyPath, preemptable)
@@ -258,7 +261,7 @@ class AWSProvisioner(AbstractProvisioner):
                   'instance_type': instanceType.name,
                   'user_data': userData,
                   'block_device_map': bdm,
-                  'instance_profile_arn': arn,
+                  'instance_profile_arn': self._leaderProfileArn,
                   'placement': self._zone,
                   'subnet_id': self._subnetID}
 
@@ -427,6 +430,11 @@ class AWSProvisioner(AbstractProvisioner):
             # boto won't look things up by the ARN so we have to parse it to get
             # the profile name
             profileName = profile.rsplit('/')[-1]
+
+            # Only delete profiles that were automatically created by Toil.
+            if profileName != self._ctx.to_aws_name(_INSTANCE_PROFILE_ROLE_NAME):
+                continue
+
             try:
                 profileResult = self._ctx.iam.get_instance_profile(profileName)
             except BotoServerError as e:
@@ -555,14 +563,13 @@ class AWSProvisioner(AbstractProvisioner):
         return out
 
     @awsRetry
-    def _getProfileARN(self):
+    def _getProfileArn(self):
         assert self._ctx
         def addRoleErrors(e):
             return e.status == 404
-        roleName = 'toil'
         policy = dict(iam_full=iamFullPolicy, ec2_full=ec2FullPolicy,
                       s3_full=s3FullPolicy, sbd_full=sdbFullPolicy)
-        iamRoleName = self._ctx.setup_iam_ec2_role(role_name=roleName, policies=policy)
+        iamRoleName = self._ctx.setup_iam_ec2_role(role_name=_INSTANCE_PROFILE_ROLE_NAME, policies=policy)
 
         try:
             profile = self._ctx.iam.get_instance_profile(iamRoleName)

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -40,7 +40,7 @@ from toil.lib.generatedEC2Lists import E2Instances
 
 logger = logging.getLogger(__name__)
 logging.getLogger("boto").setLevel(logging.CRITICAL)
-# Pefix for EC2 instance profiles that are automatically created by Toil.
+# Role name (used as the suffix) for EC2 instance profiles that are automatically created by Toil.
 _INSTANCE_PROFILE_ROLE_NAME = 'toil'
 
 

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -95,6 +95,10 @@ def main():
                         help="The location of the file containing the Azure storage credentials. If not specified,"
                              " the default file is used with Azure provisioning. Use 'None' to disable"
                              " the transfer of credentials.")
+    parser.add_argument('--awsEc2ProfileArn', dest='awsEc2ProfileArn', default=None, type=str,
+                        help="If provided, the specified ARN is used as the instance profile for EC2 instances."
+                             "Useful for setting custom IAM profiles. If not specified, a new IAM role is created "
+                             "by default with sufficient access to perform basic cluster operations.")
     config = parseBasicOptions(parser)
     tagsDict = None if config.tags is None else createTagsDict(config.tags)
     checkValidNodeTypes(config.provisioner, config.nodeTypes)
@@ -154,7 +158,8 @@ def main():
                           userTags=tagsDict,
                           vpcSubnet=config.vpcSubnet,
                           publicKeyFile=config.publicKeyFile,
-                          azureStorageCredentials=config.azureStorageCredentials)
+                          azureStorageCredentials=config.azureStorageCredentials,
+                          awsEc2ProfileArn=config.awsEc2ProfileArn)
 
     for nodeType, workers in zip(nodeTypes, numNodes):
         cluster.addNodes(nodeType=nodeType, numNodes=workers, preemptable=False)


### PR DESCRIPTION
Adds an option to specify EC2 IAM profile via `--awsEc2ProfileArn` flag. If not provided, it creates the profile automatically (existing behavior). This also only destroys the profile if it matches the one that was automatically created. I think this heuristic is ok for now to keep things simple (assumes custom roles won't have the same name as the one that Toil creates), but please let me know if you have better ideas!

P.S. I also renamed `ARN` to `Arn` to match the AWS field name in instanceMetadata.

Resolves #2575 