### PR TITLE
Fix python3.7 break on __new__ static method.

### DIFF
--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -1337,7 +1337,7 @@ def _exportStaticMethodAsGlobalFunctions(cls):
     the convention that the first argument of a job function is named 'job'.
     """
     for name, kind, clazz, value in inspect.classify_class_attrs(cls):
-        if kind == 'static method':
+        if kind == 'static method' and name != '__new__':  # __new__ became static in 3.7
             method = value.__func__
             args = inspect.getargspec(method).args
             if args and args[0] == 'job':


### PR DESCRIPTION
Addresses the bug in #2645.  I'll fix the warnings in a separate PR.