### PR TITLE
Adjust test encoding to fix #2652

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,18 +11,17 @@ after_script:
 
 
 stages:
-  - py2
-  - py3
+  - test
 
 
 py2-job:
-  stage: py2
+  stage: test
   script:
     - pwd
-    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor && make test
+    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor && PYTHONIOENCODING=utf-8 make test
 
 py3-job:
-  stage: py3
+  stage: test
   script:
     - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor && make test
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor && PYTHONIOENCODING=utf-8 make test


### PR DESCRIPTION
The Gitlab runner did not like our Python 3 tests, because its locale is set such that Python doesn't want to print anything but ASCII to the console.

This tells Python to treat its standard IO streams as UTF-8, whatever the locale says.

I'm also setting the Python 2 and 3 tests to run in parallel so we aren't tempted to rely on just one of them.