### PR TITLE
Get value of taskId in Mesos' killTask method.

### DIFF
--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -98,7 +98,7 @@ class MesosExecutor(Executor):
         Kill parent task process and all its spawned children
         """
         try:
-            pid = self.runningTasks[taskId]
+            pid = self.runningTasks[taskId.value]
             pgid = os.getpgid(pid)
         except KeyError:
             pass


### PR DESCRIPTION
This fixes the root cause in issue #2655 . I still need to add tests for it, but decided to fix the root cause in the meantime while I figure out how tests work :)

Tested to ensure tasks do indeed get killed once the timeout is reached.
