### PR TITLE
Address python3 deprecation warnings.

### DIFF
--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -66,14 +66,14 @@ class SingleMachineBatchSystem(BatchSystemSupport):
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         if maxCores > self.numCores:
-            log.warn('Limiting maxCores to CPU count of system (%i).', self.numCores)
+            log.warning('Limiting maxCores to CPU count of system (%i).', self.numCores)
             maxCores = self.numCores
         if maxMemory > self.physicalMemory:
-            log.warn('Limiting maxMemory to physically available memory (%i).', self.physicalMemory)
+            log.warning('Limiting maxMemory to physically available memory (%i).', self.physicalMemory)
             maxMemory = self.physicalMemory
         self.physicalDisk = toil.physicalDisk(config)
         if maxDisk > self.physicalDisk:
-            log.warn('Limiting maxDisk to physically available disk (%i).', self.physicalDisk)
+            log.warning('Limiting maxDisk to physically available disk (%i).', self.physicalDisk)
             maxDisk = self.physicalDisk
         super(SingleMachineBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
         assert self.maxCores >= self.minCores

--- a/src/toil/lib/context.py
+++ b/src/toil/lib/context.py
@@ -480,7 +480,7 @@ class Context(object):
         try:
             return self.iam.get_user().user_name
         except BaseException:
-            log.warn("IAMConnection.get_user() failed.", exc_info=True)
+            log.warning("IAMConnection.get_user() failed.", exc_info=True)
             return None
 
     current_user_placeholder = '__me__'

--- a/src/toil/lib/ec2.py
+++ b/src/toil/lib/ec2.py
@@ -122,7 +122,7 @@ def wait_spot_requests_active(ec2, requests, timeout=None, tentative=False):
     open_ids = None
 
     def cancel():
-        log.warn('Cancelling remaining %i spot requests.', len(open_ids))
+        log.warning('Cancelling remaining %i spot requests.', len(open_ids))
         ec2.cancel_spot_instance_requests(list(open_ids))
 
     def spot_request_not_found(e):
@@ -161,7 +161,7 @@ def wait_spot_requests_active(ec2, requests, timeout=None, tentative=False):
                 break
             sleep_time = 2 * a_short_time
             if timeout is not None and time.time() + sleep_time >= timeout:
-                log.warn('Timed out waiting for spot requests.')
+                log.warning('Timed out waiting for spot requests.')
                 break
             log.info('Sleeping for %is', sleep_time)
             time.sleep(sleep_time)
@@ -223,11 +223,11 @@ def create_spot_instances(ec2, price, image_id, spec, num_instances=1, timeout=N
     if not num_active:
         message = 'None of the spot requests entered the active state'
         if tentative:
-            log.warn(message + '.')
+            log.warning(message + '.')
         else:
             raise RuntimeError(message)
     if num_other:
-        log.warn('%i request(s) entered a state other than active.', num_other)
+        log.warning('%i request(s) entered a state other than active.', num_other)
 
 
 def inconsistencies_detected(e):

--- a/src/toil/lib/exceptions.py
+++ b/src/toil/lib/exceptions.py
@@ -50,6 +50,6 @@ class panic( object ):
 
     def __exit__( self, *exc_info ):
         if self.log is not None and exc_info and exc_info[ 0 ]:
-            self.log.warn( "Exception during panic", exc_info=exc_info )
+            self.log.warning( "Exception during panic", exc_info=exc_info )
         exc_type, exc_value, traceback = self.exc_info
         raise_(exc_type, exc_value, traceback)

--- a/src/toil/realtimeLogger.py
+++ b/src/toil/realtimeLogger.py
@@ -156,7 +156,7 @@ class RealtimeLogger(with_metaclass(RealtimeLoggerMetaclass, object)):
                     log.debug('Real-time logging disabled')
             else:
                 if level:
-                    log.warn('Ignoring nested request to start real-time logging')
+                    log.warning('Ignoring nested request to start real-time logging')
 
     @classmethod
     def _stopLeader(cls):

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -150,7 +150,7 @@ class Resource(namedtuple('Resource', ('name', 'pathHash', 'url', 'contentHash')
             path_key = cls.resourceEnvNamePrefix + pathHash
             s = os.environ[path_key]
         except KeyError:
-            log.warn("'%s' may exist, but is not yet referenced by the worker (KeyError from os.environ[]).", str(path_key))
+            log.warning("'%s' may exist, but is not yet referenced by the worker (KeyError from os.environ[]).", str(path_key))
             return None
         else:
             self = cls.unpickle(s)
@@ -483,7 +483,7 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
         :rtype: toil.resource.Resource
         """
         if not self._runningOnWorker():
-            log.warn('The localize() method should only be invoked on a worker.')
+            log.warning('The localize() method should only be invoked on a worker.')
         resource = Resource.lookup(self._resourcePath)
         if resource is None:
             return self
@@ -530,7 +530,7 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
         except IOError as e:
             if e.errno == errno.ENOENT:
                 if self._runningOnWorker():
-                    log.warn("Can't globalize module %r.", self)
+                    log.warning("Can't globalize module %r.", self)
                 return self
             else:
                 raise

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -454,13 +454,13 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
         # This test isn't general enough to cover every possible value of minCores in
         # SingleMachineBatchSystem. Instead we hard-code a value and assert it.
         minCores = F(1, 10)
-        self.assertEquals(float(minCores), SingleMachineBatchSystem.minCores)
+        self.assertEqual(float(minCores), SingleMachineBatchSystem.minCores)
         for maxCores in {F(minCores), minCores * 10, F(1), F(numCores, 2), F(numCores)}:
             for coresPerJob in {F(minCores), F(minCores * 10), F(1), F(maxCores, 2), F(maxCores)}:
                 for load in (F(1, 10), F(1), F(10)):
                     jobs = int(maxCores / coresPerJob * load)
                     if jobs >= 1 and minCores <= coresPerJob < maxCores:
-                        self.assertEquals(maxCores, float(maxCores))
+                        self.assertEqual(maxCores, float(maxCores))
                         bs = SingleMachineBatchSystem(
                             config=hidden.AbstractBatchSystemTest.createConfig(),
                             maxCores=float(maxCores),
@@ -476,24 +476,24 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                                                                         memory=1, disk=1,
                                                                         preemptable=preemptable),
                                                                     jobName=str(i), unitName='', jobStoreID=str(i))))
-                            self.assertEquals(len(jobIds), jobs)
+                            self.assertEqual(len(jobIds), jobs)
                             while jobIds:
                                 job = bs.getUpdatedBatchJob(maxWait=10)
                                 self.assertIsNotNone(job)
                                 jobId, status, wallTime = job
-                                self.assertEquals(status, 0)
+                                self.assertEqual(status, 0)
                                 # would raise KeyError on absence
                                 jobIds.remove(jobId)
                         finally:
                             bs.shutdown()
                         concurrentTasks, maxConcurrentTasks = getCounters(self.counterPath)
-                        self.assertEquals(concurrentTasks, 0)
+                        self.assertEqual(concurrentTasks, 0)
                         log.info('maxCores: {maxCores}, '
                                  'coresPerJob: {coresPerJob}, '
                                  'load: {load}'.format(**locals()))
                         # This is the key assertion:
                         expectedMaxConcurrentTasks = min(old_div(maxCores, coresPerJob), jobs)
-                        self.assertEquals(maxConcurrentTasks, expectedMaxConcurrentTasks)
+                        self.assertEqual(maxConcurrentTasks, expectedMaxConcurrentTasks)
                         resetCounters(self.counterPath)
 
     @skipIf(SingleMachineBatchSystem.numCores < 3, 'Need at least three cores to run this test')

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -74,7 +74,7 @@ class CWLTest(ToilTest):
         out[out_name].pop("http://commonwl.org/cwltool#generation", None)
         out[out_name].pop("nameext", None)
         out[out_name].pop("nameroot", None)
-        self.assertEquals(out, expect)
+        self.assertEqual(out, expect)
 
     def _debug_worker_tester(self, cwlfile, jobfile, expect):
         from toil.cwl import cwltoil
@@ -86,7 +86,7 @@ class CWLTest(ToilTest):
         out["output"].pop("http://commonwl.org/cwltool#generation", None)
         out["output"].pop("nameext", None)
         out["output"].pop("nameroot", None)
-        self.assertEquals(out, expect)
+        self.assertEqual(out, expect)
 
     def revsort(self, cwl_filename, tester_fn):
         tester_fn('src/toil/test/cwl/' + cwl_filename,

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -163,17 +163,17 @@ class AbstractJobStoreTest(object):
             job = jobstore.create(aJobNode)
 
             self.assertTrue(jobstore.exists(job.jobStoreID))
-            self.assertEquals(job.command, 'parent1')
-            self.assertEquals(job.memory, self.parentJobReqs['memory'])
-            self.assertEquals(job.cores, self.parentJobReqs['cores'])
-            self.assertEquals(job.disk, self.parentJobReqs['disk'])
-            self.assertEquals(job.preemptable, self.parentJobReqs['preemptable'])
-            self.assertEquals(job.jobName, 'test1')
-            self.assertEquals(job.unitName, 'onParent')
-            self.assertEquals(job.stack, [])
-            self.assertEquals(job.predecessorNumber, 0)
-            self.assertEquals(job.predecessorsFinished, set())
-            self.assertEquals(job.logJobStoreFileID, None)
+            self.assertEqual(job.command, 'parent1')
+            self.assertEqual(job.memory, self.parentJobReqs['memory'])
+            self.assertEqual(job.cores, self.parentJobReqs['cores'])
+            self.assertEqual(job.disk, self.parentJobReqs['disk'])
+            self.assertEqual(job.preemptable, self.parentJobReqs['preemptable'])
+            self.assertEqual(job.jobName, 'test1')
+            self.assertEqual(job.unitName, 'onParent')
+            self.assertEqual(job.stack, [])
+            self.assertEqual(job.predecessorNumber, 0)
+            self.assertEqual(job.predecessorsFinished, set())
+            self.assertEqual(job.logJobStoreFileID, None)
 
         def testConfigEquality(self):
             """
@@ -187,7 +187,7 @@ class AbstractJobStoreTest(object):
 
             newJobStore = self._createJobStore()
             newJobStore.resume()
-            self.assertEquals(newJobStore.config, self.config)
+            self.assertEqual(newJobStore.config, self.config)
             self.assertIsNot(newJobStore.config, self.config)
 
         def testJobLoadEquality(self):
@@ -203,7 +203,7 @@ class AbstractJobStoreTest(object):
             # Load it onto the second jobstore
             job2 = self.jobstore_resumed_noconfig.load(job1.jobStoreID)
 
-            self.assertEquals(job1, job2)
+            self.assertEqual(job1, job2)
 
         def testChildLoadingEquality(self):
             """Test that loading a child job operates as expected."""
@@ -220,7 +220,7 @@ class AbstractJobStoreTest(object):
             childJob = self.jobstore_initialized.create(jobNodeOnChild)
             job.stack.append(childJob)
             self.jobstore_initialized.update(job)
-            self.assertEquals(self.jobstore_initialized.load(childJob.jobStoreID), childJob)
+            self.assertEqual(self.jobstore_initialized.load(childJob.jobStoreID), childJob)
 
         def testPersistantFilesToDelete(self):
             """
@@ -240,7 +240,7 @@ class AbstractJobStoreTest(object):
             job = self.jobstore_initialized.create(jobNode)
             job.filesToDelete = ['1', '2']
             self.jobstore_initialized.update(job)
-            self.assertEquals(self.jobstore_initialized.load(job.jobStoreID).filesToDelete, ['1', '2'])
+            self.assertEqual(self.jobstore_initialized.load(job.jobStoreID).filesToDelete, ['1', '2'])
 
         def testUpdateBehavior(self):
             """Tests the proper behavior during updating jobs."""
@@ -279,12 +279,12 @@ class AbstractJobStoreTest(object):
 
             # Reload parent job on jobstore, "refreshing" the job.
             job1 = jobstore1.load(job1.jobStoreID)
-            self.assertEquals(job2, job1)
+            self.assertEqual(job2, job1)
 
             # Load children on jobstore and check equivalence
-            self.assertEquals(jobstore1.load(childJob1.jobStoreID), childJob1)
-            self.assertEquals(jobstore1.load(childJob2.jobStoreID), childJob2)
-            self.assertEquals(job1,job2)            # The jobs should both have children now...
+            self.assertEqual(jobstore1.load(childJob1.jobStoreID), childJob1)
+            self.assertEqual(jobstore1.load(childJob2.jobStoreID), childJob2)
+            self.assertEqual(job1,job2)            # The jobs should both have children now...
             self.assertIsNot(job1,job2)             # but should not be the same.
 
         def testChangingJobStoreID(self):
@@ -321,7 +321,7 @@ class AbstractJobStoreTest(object):
 
             # Compare children before and after update.
             for childJob in parentJob2.stack:
-                self.assertEquals(childJob, jobstore1.load(childJob.jobStoreID))
+                self.assertEqual(childJob, jobstore1.load(childJob.jobStoreID))
                 childJob.logJobStoreFileID = str(uuid.uuid4())
                 childJob.remainingRetryCount = 66
                 self.assertNotEquals(childJob, jobstore1.load(childJob.jobStoreID))
@@ -332,8 +332,8 @@ class AbstractJobStoreTest(object):
 
             # Check that the jobs are equivalent after being reloaded.
             for childJob in parentJob2.stack:
-                self.assertEquals(jobstore1.load(childJob.jobStoreID), childJob)
-                self.assertEquals(jobstore2.load(childJob.jobStoreID), childJob)
+                self.assertEqual(jobstore1.load(childJob.jobStoreID), childJob)
+                self.assertEqual(jobstore2.load(childJob.jobStoreID), childJob)
 
         def testJobDeletions(self):
             """Tests the consequences of deleting jobs."""
@@ -407,10 +407,10 @@ class AbstractJobStoreTest(object):
                 f.write(bar)
             # ... read that file on worker, ...
             with jobstore2.readSharedFileStream('foo') as f:
-                self.assertEquals(bar, f.read())
+                self.assertEqual(bar, f.read())
             # ... and read it again on jobstore1.
             with jobstore1.readSharedFileStream('foo') as f:
-                self.assertEquals(bar, f.read())
+                self.assertEqual(bar, f.read())
 
             with jobstore1.writeSharedFileStream('nonEncrypted', isProtected=False) as f:
                 f.write(bar)
@@ -446,7 +446,7 @@ class AbstractJobStoreTest(object):
                 f.write(one)
             # ... read the file as a stream on the jobstore1, ....
             with jobstore1.readFileStream(fileOne) as f:
-                self.assertEquals(f.read(), one)
+                self.assertEqual(f.read(), one)
 
             # ... and copy it to a temporary physical file on the jobstore1.
             fh, path = tempfile.mkstemp()
@@ -459,7 +459,7 @@ class AbstractJobStoreTest(object):
                 finally:
                     os.unlink(tmpPath)
                 with open(path, 'rb+') as f:
-                    self.assertEquals(f.read(), one)
+                    self.assertEqual(f.read(), one)
                     # Write a different string to the local file ...
                     f.seek(0)
                     f.truncate(0)
@@ -467,18 +467,18 @@ class AbstractJobStoreTest(object):
                 # ... and create a second file from the local file.
                 fileTwo = jobstore1.writeFile(path, jobOnJobStore1.jobStoreID)
                 with jobstore2.readFileStream(fileTwo) as f:
-                    self.assertEquals(f.read(), two)
+                    self.assertEqual(f.read(), two)
                 # Now update the first file from the local file ...
                 jobstore1.updateFile(fileOne, path)
                 with jobstore2.readFileStream(fileOne) as f:
-                    self.assertEquals(f.read(), two)
+                    self.assertEqual(f.read(), two)
             finally:
                 os.unlink(path)
             # Create a third file to test the last remaining method.
             with jobstore2.writeFileStream(jobOnJobStore1.jobStoreID) as (f, fileThree):
                 f.write(three)
             with jobstore1.readFileStream(fileThree) as f:
-                self.assertEquals(f.read(), three)
+                self.assertEqual(f.read(), three)
             # Delete a file explicitly but leave files for the implicit deletion through the parent
             jobstore2.deleteFile(fileOne)
 
@@ -524,26 +524,26 @@ class AbstractJobStoreTest(object):
             stats = set()
 
             # No stats or logging added yet. Expect nothing.
-            self.assertEquals(0, jobstore1.readStatsAndLogging(callback))
-            self.assertEquals(set(), stats)
+            self.assertEqual(0, jobstore1.readStatsAndLogging(callback))
+            self.assertEqual(set(), stats)
 
             # Test writing and reading.
             jobstore2.writeStatsAndLogging(one)
-            self.assertEquals(1, jobstore1.readStatsAndLogging(callback))
-            self.assertEquals({one}, stats)
-            self.assertEquals(0, jobstore1.readStatsAndLogging(callback))   # readStatsAndLogging purges saved stats etc
+            self.assertEqual(1, jobstore1.readStatsAndLogging(callback))
+            self.assertEqual({one}, stats)
+            self.assertEqual(0, jobstore1.readStatsAndLogging(callback))   # readStatsAndLogging purges saved stats etc
 
             jobstore2.writeStatsAndLogging(one)
             jobstore2.writeStatsAndLogging(two)
             stats = set()
-            self.assertEquals(2, jobstore1.readStatsAndLogging(callback))
-            self.assertEquals({one, two}, stats)
+            self.assertEqual(2, jobstore1.readStatsAndLogging(callback))
+            self.assertEqual({one, two}, stats)
 
             largeLogEntry = os.urandom(self._largeLogEntrySize())
             stats = set()
             jobstore2.writeStatsAndLogging(largeLogEntry)
-            self.assertEquals(1, jobstore1.readStatsAndLogging(callback))
-            self.assertEquals({largeLogEntry}, stats)
+            self.assertEqual(1, jobstore1.readStatsAndLogging(callback))
+            self.assertEqual({largeLogEntry}, stats)
 
             # test the readAll parameter
             self.assertEqual(4, jobstore1.readStatsAndLogging(callback, readAll=True))
@@ -593,12 +593,12 @@ class AbstractJobStoreTest(object):
             job.foo_attribute = arbitraryLargeData
             self.jobstore_initialized.update(job)
             check_job = self.jobstore_initialized.load(job.jobStoreID)
-            self.assertEquals(check_job.foo_attribute, arbitraryLargeData)
+            self.assertEqual(check_job.foo_attribute, arbitraryLargeData)
             # Make the job shrink back close to its original size
             job.foo_attribute = None
             self.jobstore_initialized.update(job)
             check_job = self.jobstore_initialized.load(job.jobStoreID)
-            self.assertEquals(check_job.foo_attribute, None)
+            self.assertEqual(check_job.foo_attribute, None)
 
         def _prepareTestFile(self, store, size=None):
             """
@@ -796,7 +796,7 @@ class AbstractJobStoreTest(object):
             # http://unix.stackexchange.com/questions/11946/how-big-is-the-pipe-buffer
             bufSize = 65536
             partSize = self._partSize()
-            self.assertEquals(partSize % bufSize, 0)
+            self.assertEqual(partSize % bufSize, 0)
             job = self.jobstore_initialized.create(self.arbitraryJob)
 
             # Test file/stream ending on part boundary and within a part
@@ -837,7 +837,7 @@ class AbstractJobStoreTest(object):
                             break
                         checksum.update(buf)
                 after = checksum.hexdigest()
-                self.assertEquals(before, after)
+                self.assertEqual(before, after)
 
                 # Multi-part upload from file
                 checksum = hashlib.md5()
@@ -863,7 +863,7 @@ class AbstractJobStoreTest(object):
                             break
                         checksum.update(buf)
                 after = checksum.hexdigest()
-                self.assertEquals(before, after)
+                self.assertEqual(before, after)
             self.jobstore_initialized.delete(job.jobStoreID)
 
         def testZeroLengthFiles(self):
@@ -999,7 +999,7 @@ class AbstractJobStoreTest(object):
                     a = b'a'
                 f.write(a * 300000)
             with self.jobstore_initialized.readFileStream(fileID) as f:
-                self.assertEquals(f.read(1), a)
+                self.assertEqual(f.read(1), a)
             # If it times out here, there's a deadlock
 
         @abstractmethod

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -135,7 +135,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
                         # Now check the file is properly sorted..
                         with open(options.outputFile, 'r') as fileHandle:
                             l2 = fileHandle.readlines()
-                            self.assertEquals(l, l2)
+                            self.assertEqual(l, l2)
 
                 options.restart = False
 
@@ -268,7 +268,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
             sort(tempFile1)
             with open(tempFile1, 'r') as f:
                 lines2 = f.readlines()
-            self.assertEquals(lines1, lines2)
+            self.assertEqual(lines1, lines2)
 
     def testMerge(self):
         for test in range(self.testNo):
@@ -287,7 +287,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
             lines1.sort()
             with open(tempFile3, 'r') as f:
                 lines2 = f.readlines()
-            self.assertEquals(lines1, lines2)
+            self.assertEqual(lines1, lines2)
 
     def testCopySubRangeOfFile(self):
         for test in range(self.testNo):
@@ -304,7 +304,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
                 l = f.read()
             with open(tempFile, 'r') as f:
                 l2 = f.read()[fileStart:fileEnd]
-            self.assertEquals(l, l2)
+            self.assertEqual(l, l2)
 
     def testGetMidPoint(self):
         for test in range(self.testNo):

--- a/src/toil/test/src/importExportFileTest.py
+++ b/src/toil/test/src/importExportFileTest.py
@@ -91,7 +91,7 @@ class ImportExportFileTest(ToilTest):
                 f.write('some data')
             toil.importFile('file://' + srcFile, sharedFileName=sharedFileName)
             with toil._jobStore.readSharedFileStream(sharedFileName) as f:
-                self.assertEquals(f.read().decode('utf-8'), 'some data')
+                self.assertEqual(f.read().decode('utf-8'), 'some data')
 
 
 class RestartingJob(Job):

--- a/src/toil/test/src/jobEncapsulationTest.py
+++ b/src/toil/test/src/jobEncapsulationTest.py
@@ -47,7 +47,7 @@ class JobEncapsulationTest(ToilTest):
             # Run the workflow, the return value being the number of failed jobs
             T.Runner.startToil(a, options)
             # Check output
-            self.assertEquals(open(outFile, 'r').readline(), "ABCDE")
+            self.assertEqual(open(outFile, 'r').readline(), "ABCDE")
         finally:
             os.remove(outFile)
 
@@ -60,7 +60,7 @@ class JobEncapsulationTest(ToilTest):
         a = T.wrapFn(noOp)
         b = T.wrapFn(noOp)
         a.addChild(b).encapsulate()
-        self.assertEquals(len(a.getRootJobs()), 1)
+        self.assertEqual(len(a.getRootJobs()), 1)
 
 
 def noOp():

--- a/src/toil/test/src/jobGraphTest.py
+++ b/src/toil/test/src/jobGraphTest.py
@@ -29,7 +29,7 @@ class JobGraphTest(ToilTest):
         Job.Runner.addToilOptions(parser)
         options = parser.parse_args(args=[self.jobStorePath])
         self.toil = Toil(options)
-        self.assertEquals( self.toil, self.toil.__enter__() )
+        self.assertEqual( self.toil, self.toil.__enter__() )
 
     def tearDown(self):
         self.toil.__exit__(None, None, None)
@@ -57,24 +57,24 @@ class JobGraphTest(ToilTest):
         
         #Check attributes
         #
-        self.assertEquals(j.command, command)
-        self.assertEquals(j.memory, memory)
-        self.assertEquals(j.disk, disk)
-        self.assertEquals(j.cores, cores)
-        self.assertEquals(j.preemptable, preemptable)
-        self.assertEquals(j.jobStoreID, jobStoreID)
-        self.assertEquals(j.remainingRetryCount, remainingRetryCount)
-        self.assertEquals(j.predecessorNumber, predecessorNumber)
-        self.assertEquals(j.stack, [])
-        self.assertEquals(j.predecessorsFinished, set())
-        self.assertEquals(j.logJobStoreFileID, None)
+        self.assertEqual(j.command, command)
+        self.assertEqual(j.memory, memory)
+        self.assertEqual(j.disk, disk)
+        self.assertEqual(j.cores, cores)
+        self.assertEqual(j.preemptable, preemptable)
+        self.assertEqual(j.jobStoreID, jobStoreID)
+        self.assertEqual(j.remainingRetryCount, remainingRetryCount)
+        self.assertEqual(j.predecessorNumber, predecessorNumber)
+        self.assertEqual(j.stack, [])
+        self.assertEqual(j.predecessorsFinished, set())
+        self.assertEqual(j.logJobStoreFileID, None)
         
         #Check equals function
         j2 = JobGraph(command=command, memory=memory, cores=cores, disk=disk,
                       preemptable=preemptable,
                       jobStoreID=jobStoreID, remainingRetryCount=remainingRetryCount,
                       predecessorNumber=predecessorNumber, jobName='testJobGraph', unitName='noName')
-        self.assertEquals(j, j2)
+        self.assertEqual(j, j2)
         #Change an attribute and check not equal
         j.predecessorsFinished = {"1", "2"}
         self.assertNotEquals(j, j2)

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -72,7 +72,7 @@ class JobServiceTest(ToilTest):
                 self.runToil(t)
 
                 # Check output
-                self.assertEquals(int(open(outFile, 'r').readline()), messageInt)
+                self.assertEqual(int(open(outFile, 'r').readline()), messageInt)
             finally:
                 os.remove(outFile)
 
@@ -133,7 +133,7 @@ class JobServiceTest(ToilTest):
                 self.runToil(t)
 
                 # Check output
-                self.assertEquals(list(map(int, open(outFile, 'r').readlines())), messages)
+                self.assertEqual(list(map(int, open(outFile, 'r').readlines())), messages)
             finally:
                 os.remove(outFile)
 
@@ -157,7 +157,7 @@ class JobServiceTest(ToilTest):
 
                 # Check output
                 for (messages, outFile) in zip(messageBundles, outFiles):
-                    self.assertEquals(list(map(int, open(outFile, 'r').readlines())), messages)
+                    self.assertEqual(list(map(int, open(outFile, 'r').readlines())), messages)
             finally:
                 list(map(os.remove, outFiles))
 

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -85,7 +85,7 @@ class JobTest(ToilTest):
             Job.Runner.startToil(A, options)
 
             # Check output
-            self.assertEquals(open(outFile, 'r').readline(), "ABCDEFG")
+            self.assertEqual(open(outFile, 'r').readline(), "ABCDEFG")
         finally:
             os.remove(outFile)
 
@@ -125,7 +125,7 @@ class JobTest(ToilTest):
             Job.Runner.startToil(A, options)
 
             # Check output
-            self.assertEquals(open(outFile, 'r').readline(), "ABCDE")
+            self.assertEqual(open(outFile, 'r').readline(), "ABCDE")
         finally:
             os.remove(outFile)
 
@@ -200,7 +200,7 @@ class JobTest(ToilTest):
             rootJob.checkJobGraphAcylic()  # This should not throw an exception
             rootJob.checkJobGraphConnected()  # Nor this
             # Check root detection explicitly
-            self.assertEquals(rootJob.getRootJobs(), {rootJob})
+            self.assertEqual(rootJob.getRootJobs(), {rootJob})
 
             # Test making multiple roots
             childEdges2 = childEdges.copy()
@@ -437,7 +437,7 @@ class JobTest(ToilTest):
             for i in range(nodeNumber):
                 with open(os.path.join(tempDir, str(i)), 'r') as fH:
                     ordering = list(map(int, fH.readline().split()))
-                    self.assertEquals(int(ordering[-1]), i)
+                    self.assertEqual(int(ordering[-1]), i)
                     for j in ordering[:-1]:
                         adjacencyList[int(j)].add(i)
             # Check the ordering retains an acyclic graph

--- a/src/toil/test/src/miscTests.py
+++ b/src/toil/test/src/miscTests.py
@@ -43,7 +43,7 @@ class MiscTests(ToilTest):
         prevNodeID = None
         for i in range(10, 1):
             nodeID = getNodeID()
-            self.assertEquals(nodeID, prevNodeID)
+            self.assertEqual(nodeID, prevNodeID)
             prevNodeID = nodeID
 
     @slow
@@ -156,8 +156,8 @@ class TestPanic(ToilTest):
 
     def __assert_raised_exception_is_primary(self):
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        self.assertEquals(exc_type, ValueError)
-        self.assertEquals(str(exc_value), "primary")
+        self.assertEqual(exc_type, ValueError)
+        self.assertEqual(str(exc_value), "primary")
         while exc_traceback.tb_next is not None:
             exc_traceback = exc_traceback.tb_next
-        self.assertEquals(exc_traceback.tb_lineno, self.line_of_primary_exc)
+        self.assertEqual(exc_traceback.tb_lineno, self.line_of_primary_exc)

--- a/src/toil/test/src/promisesTest.py
+++ b/src/toil/test/src/promisesTest.py
@@ -50,7 +50,7 @@ class ChainedIndexedPromisesTest(ToilTest):
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.logLevel = 'INFO'
         root = Job.wrapJobFn(a)
-        self.assertEquals(Job.Runner.startToil(root, options), 42)
+        self.assertEqual(Job.Runner.startToil(root, options), 42)
 
 
 def a(job):
@@ -75,7 +75,7 @@ class PathIndexingPromiseTest(ToilTest):
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.logLevel = 'INFO'
         root = Job.wrapJobFn(d)
-        self.assertEquals(Job.Runner.startToil(root, options), ('b', 43, 3))
+        self.assertEqual(Job.Runner.startToil(root, options), ('b', 43, 3))
 
 
 def d(job):

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -108,7 +108,7 @@ class ResourceTest(ToilTest):
     def testBuiltIn(self):
         # Create a ModuleDescriptor for the module containing ModuleDescriptor, i.e. toil.resource
         module_name = ModuleDescriptor.__module__
-        self.assertEquals(module_name, 'toil.resource')
+        self.assertEqual(module_name, 'toil.resource')
         self._test(module_name, shouldBelongToToil=True)
 
     def _test(self, module_name,
@@ -116,12 +116,12 @@ class ResourceTest(ToilTest):
         module = ModuleDescriptor.forModule(module_name)
         # Assert basic attributes and properties
         self.assertEqual(module.belongsToToil, shouldBelongToToil)
-        self.assertEquals(module.name, module_name)
+        self.assertEqual(module.name, module_name)
         if shouldBelongToToil:
             self.assertTrue(module.dirPath.endswith('/src'))
 
         # Before the module is saved as a resource, localize() and globalize() are identity
-        # methods. This should log warnings.
+        # methods. This should log.warnings.
         self.assertIs(module.localize(), module)
         self.assertIs(module.globalize(), module)
         # Create a mock job store ...
@@ -158,7 +158,7 @@ class ResourceTest(ToilTest):
                 else:
                     self.assertEqual(actualContents, expectedContents)
 
-        self.assertEquals(resource.url, url)
+        self.assertEqual(resource.url, url)
         # Now we're on the worker. Prepare the storage for localized resources
         Resource.prepareSystem()
         try:
@@ -168,7 +168,7 @@ class ResourceTest(ToilTest):
             # original resource. Lookup will also be used when we localize the module that was
             # originally used to create the resource.
             localResource = Resource.lookup(module._resourcePath)
-            self.assertEquals(resource, localResource)
+            self.assertEqual(resource, localResource)
             self.assertIsNot(resource, localResource)
             # Now show that we can localize the module using the registered resource. Set up a mock
             # urlopen() that yields the zipped tree ...
@@ -178,12 +178,12 @@ class ResourceTest(ToilTest):
                 # ... and use it to download and unpack the resource
                 localModule = module.localize()
             # The name should be equal between original and localized resource ...
-            self.assertEquals(module.name, localModule.name)
+            self.assertEqual(module.name, localModule.name)
             # ... but the directory should be different.
             self.assertNotEquals(module.dirPath, localModule.dirPath)
             # Show that we can 'undo' localization. This is necessary when the user script's jobs
             #  are invoked on the worker where they generate more child jobs.
-            self.assertEquals(localModule.globalize(), module)
+            self.assertEqual(localModule.globalize(), module)
         finally:
             Resource.cleanSystem()
 

--- a/src/toil/test/src/systemTest.py
+++ b/src/toil/test/src/systemTest.py
@@ -27,15 +27,15 @@ class SystemTest(ToilTest):
             finally:
                 pool.close()
                 pool.join()
-            self.assertEquals(len(grandChildIds), numTasks)
+            self.assertEqual(len(grandChildIds), numTasks)
             # Assert that we only had one winner
             grandChildIds = [n for n in grandChildIds if n is not None]
-            self.assertEquals(len(grandChildIds), 1)
+            self.assertEqual(len(grandChildIds), 1)
             # Assert that the winner's grandChild wasn't silently overwritten by a looser
             expectedGrandChildId = grandChildIds[0]
             actualGrandChild = os.path.join(child, 'grandChild')
             actualGrandChildId = os.stat(actualGrandChild).st_ino
-            self.assertEquals(actualGrandChildId, expectedGrandChildId)
+            self.assertEqual(actualGrandChildId, expectedGrandChildId)
 
 
 def _testAtomicityOfNonEmptyDirectoryRenamesTask(parent, child, _):

--- a/src/toil/test/src/toilContextManagerTest.py
+++ b/src/toil/test/src/toilContextManagerTest.py
@@ -58,7 +58,7 @@ class ToilContextManagerTest(ToilTest):
             toil.exportFile(fileID, 'file://' + self.exportPath)
         with open(self.exportPath) as f:
             # The file should have all our content
-            self.assertEquals(f.read(), "Hello, World!")
+            self.assertEqual(f.read(), "Hello, World!")
 
 class HelloWorld(Job):
     def __init__(self):

--- a/src/toil/test/src/workerTest.py
+++ b/src/toil/test/src/workerTest.py
@@ -55,25 +55,25 @@ class WorkerTests(ToilTest):
         jobGraph1 = createJobGraph(1, 2, 3, True, False)
         jobGraph2 = createJobGraph(1, 2, 3, True, False)
         jobGraph1.stack = [[jobGraph2]]
-        self.assertEquals(jobGraph2, nextChainableJobGraph(jobGraph1, self.jobStore))
+        self.assertEqual(jobGraph2, nextChainableJobGraph(jobGraph1, self.jobStore))
 
         # Identical checkpoint jobs should not be chainable.
         jobGraph1 = createJobGraph(1, 2, 3, True, False)
         jobGraph2 = createJobGraph(1, 2, 3, True, True)
         jobGraph1.stack = [[jobGraph2]]
-        self.assertEquals(None, nextChainableJobGraph(jobGraph1, self.jobStore))
+        self.assertEqual(None, nextChainableJobGraph(jobGraph1, self.jobStore))
 
         # If there is no child we should get nothing to chain.
         jobGraph1 = createJobGraph(1, 2, 3, True, False)
         jobGraph1.stack = []
-        self.assertEquals(None, nextChainableJobGraph(jobGraph1, self.jobStore))
+        self.assertEqual(None, nextChainableJobGraph(jobGraph1, self.jobStore))
 
         # If there are 2 or more children we should get nothing to chain.
         jobGraph1 = createJobGraph(1, 2, 3, True, False)
         jobGraph2 = createJobGraph(1, 2, 3, True, False)
         jobGraph3 = createJobGraph(1, 2, 3, True, False)
         jobGraph1.stack = [[jobGraph2, jobGraph3]]
-        self.assertEquals(None, nextChainableJobGraph(jobGraph1, self.jobStore))
+        self.assertEqual(None, nextChainableJobGraph(jobGraph1, self.jobStore))
 
         # If there is an increase in resource requirements we should get nothing to chain.
         reqs = {'memory': 1, 'cores': 2, 'disk': 3, 'preemptable': True, 'checkpoint': False}
@@ -82,10 +82,10 @@ class WorkerTests(ToilTest):
             reqs[increased_attribute] += 1
             jobGraph2 = createJobGraph(**reqs)
             jobGraph1.stack = [[jobGraph2]]
-            self.assertEquals(None, nextChainableJobGraph(jobGraph1, self.jobStore))
+            self.assertEqual(None, nextChainableJobGraph(jobGraph1, self.jobStore))
 
         # A change in preemptability from True to False should be disallowed.
         jobGraph1 = createJobGraph(1, 2, 3, True, False)
         jobGraph2 = createJobGraph(1, 2, 3, False, True)
         jobGraph1.stack = [[jobGraph2]]
-        self.assertEquals(None, nextChainableJobGraph(jobGraph1, self.jobStore))
+        self.assertEqual(None, nextChainableJobGraph(jobGraph1, self.jobStore))

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -263,7 +263,7 @@ class UtilsTest(ToilTest):
         # Check the file is properly sorted
         with open(self.outputFile, 'r') as fileHandle:
             l2 = fileHandle.readlines()
-            self.assertEquals(self.correctSort, l2)
+            self.assertEqual(self.correctSort, l2)
 
         # Delete output file before next step
         os.remove(self.outputFile)
@@ -299,7 +299,7 @@ class UtilsTest(ToilTest):
         # Check the file is properly sorted
         with open(self.outputFile, 'r') as fileHandle:
             l2 = fileHandle.readlines()
-            self.assertEquals(self.correctSort, l2)
+            self.assertEqual(self.correctSort, l2)
 
         # Delete output file
         os.remove(self.outputFile)


### PR DESCRIPTION
There are pages and pages of warnings when run in python3.

Changes the two main offenders:
`log.warn` -> `log.warning`
`assertEquals` -> `assertEqual`