### PR TITLE
Make sure we always have current package lists (fixes #2674)

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -60,9 +60,7 @@ motd = ''.join(l + '\\n\\\n' for l in motd.splitlines())
 print(heredoc('''
     FROM ubuntu:16.04
     
-    RUN apt-get -y update && apt-get -y upgrade
-
-    RUN apt-get -y update --fix-missing && apt-get -y install apt-transport-https ca-certificates software-properties-common
+    RUN apt-get -y update --fix-missing && apt-get -y upgrade && apt-get -y install apt-transport-https ca-certificates software-properties-common && apt-get clean && rm -rf /var/lib/apt/lists/*
 
     RUN echo "deb http://repos.mesosphere.io/ubuntu/ xenial main" \
         > /etc/apt/sources.list.d/mesosphere.list \
@@ -73,9 +71,7 @@ print(heredoc('''
 
     RUN add-apt-repository -y ppa:jonathonf/python-3.6
     
-    RUN apt-get -y update
-
-    RUN apt-get -y install {dependencies} && apt-get clean && rm -rf /var/lib/apt/lists/*
+    RUN apt-get -y update --fix-missing && apt-get -y upgrade && apt-get -y install {dependencies} && apt-get clean && rm -rf /var/lib/apt/lists/*
 
     RUN mkdir /root/.ssh && \
         chmod 700 /root/.ssh


### PR DESCRIPTION
This makes sure apt package lists can't get cached in the docker cache separately from the command to install packages using them. It also makes sure that they don't go into the stack of layers used to build the final image.