### PR TITLE
Subprocess dockercall bytestring compatibility for py2/3.

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -25,6 +25,7 @@ import collections
 import importlib
 import inspect
 import logging
+import sys
 import os
 import time
 import dill
@@ -1419,7 +1420,11 @@ class FunctionWrappingJob(Job):
         """
         # Use the user-specified requirements, if specified, else grab the default argument
         # from the function, if specified, else default to None
-        argSpec = inspect.getargspec(userFunction)
+        if sys.version_info >= (3, 0):
+            argSpec = inspect.getfullargspec(userFunction)
+        else:
+            argSpec = inspect.getargspec(userFunction)
+
         if argSpec.defaults is None:
             argDict = {}
         else:

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -12,6 +12,7 @@ import base64
 import requests
 import logging
 import os
+import sys
 from docker.errors import create_api_error_from_http_exception
 from docker.errors import ContainerError
 from docker.errors import ImageNotFound
@@ -229,7 +230,8 @@ def apiDockerCall(job,
                                         user=user,
                                         environment=environment,
                                         **kwargs)
-
+            if sys.version_info >= (3, 0):
+                out = out.decode('utf-8')
             return out
         else:
             if (stdout or stderr) and log_config is None:

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -230,8 +230,6 @@ def apiDockerCall(job,
                                         user=user,
                                         environment=environment,
                                         **kwargs)
-            if sys.version_info >= (3, 0):
-                out = out.decode('utf-8')
             return out
         else:
             if (stdout or stderr) and log_config is None:

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -283,6 +283,7 @@ class DockerTest(ToilTest):
     def testNonCachingDockerChainErrorDetection(self):
         self.testDockerPipeChainErrorDetection(disableCaching=False)
 
+
 def _testDockerCleanFn(job,
                        working_dir,
                        detached=None,
@@ -322,13 +323,15 @@ def _testDockerCleanFn(job,
                   remove=rm,
                   privileged=True)
 
+
 def _testDockerPipeChainFn(job):
     """Return the result of a simple pipe chain.  Should be 2."""
-    parameters = [ ['printf', 'x\n y\n'], ['wc', '-l'] ]
+    parameters = [['printf', 'x\n y\n'], ['wc', '-l']]
     return apiDockerCall(job,
-                         image='quay.io/ucsc_cgl/spooky_test',
+                         image='ubuntu:latest',
                          parameters=parameters,
                          privileged=True)
+
 
 def _testDockerPipeChainErrorFn(job):
     """Return True if the command exit 1 | wc -l raises a ContainerError."""

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -32,7 +32,7 @@ from toil.lib.docker import FORGO, STOP, RM
 logger = logging.getLogger(__name__)
 
 
-# @needs_appliance
+@needs_appliance
 class DockerTest(ToilTest):
     """
     Tests dockerCall and ensures no containers are left around.

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -16,6 +16,7 @@ import logging
 import signal
 import time
 import os
+import sys
 import uuid
 import docker
 from threading import Thread
@@ -258,6 +259,8 @@ class DockerTest(ToilTest):
         options.caching = disableCaching
         A = Job.wrapJobFn(_testDockerPipeChainFn)
         rv = Job.Runner.startToil(A, options)
+        if sys.version_info >= (3, 0):
+            rv = rv.decode('utf-8')
         assert rv.strip() == '2'
 
     def testDockerPipeChainErrorDetection(self, disableCaching=True):


### PR DESCRIPTION
Ugh, only tested in py2 so missed this.