### PR TITLE
Clean up temporary directories cwltoil uses to hold output streams

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -593,7 +593,11 @@ class CWLJob(Job):
         tmp_outdir_prefix = os.path.join(
             _makeNestedTempDir(top=top_tmp_outdir, seed=outdir, levels=2),
             "out_tmpdir")
+        os.mkdir(tmp_outdir_prefix)
         self.openTempDirs.append(tmp_outdir_prefix)
+        # cwltool doesn't necessarily put a / in when it makes filenames with tmp_outdir_prefix.
+        # So make sure it actually ends up in a real directory with the name we made.
+        tmp_outdir_prefix = os.path.join(tmp_outdir_prefix, "tmp")
 
         index = {}
         existing = {}


### PR DESCRIPTION
This should fix #2601 

cwltoil has a whole system for creating job-specific temporary directories
under its work directory. It should instead probably be using Toil's built-in
concept of a work directory, and not maintaining its own. After #2587 merges I
think they will always be under the same path, so then we can rip out the
second system and see if anything breaks.