### PR TITLE
Terminate the leader first when destroying a cluster.

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -94,6 +94,10 @@ def awsRetry(f):
     return wrapper
 
 
+class InvalidClusterStateException(Exception):
+    pass
+
+
 class AWSProvisioner(AbstractProvisioner):
     """
     Implements an AWS provisioner using the boto libraries.
@@ -208,16 +212,36 @@ class AWSProvisioner(AbstractProvisioner):
         def expectedShutdownErrors(e):
             return e.status == 400 and 'dependent object' in e.body
 
+        def destroyInstances(instances):
+            """
+            Similar to _terminateInstances, except that it also cleans up any
+            resources associated with the instances (e.g. IAM profiles).
+            """
+            self._deleteIAMProfiles(instances)
+            self._terminateInstances(instances)
+
+        # We should terminate the leader first in case a workflow is still running in the cluster.
+        # The leader may create more instances while we're terminating the workers.
+        vpcId = None
+        try:
+            leader = self.getLeader(returnRawInstance=True)
+            vpcId = leader.vpc_id
+            logger.info('Terminating the leader first ...')
+            destroyInstances([leader])
+            logger.info('Now terminating any remaining workers ...')
+        except (NoSuchClusterException, InvalidClusterStateException):
+            # It's ok if the leader is not found. We'll terminate any remaining
+            # instances below anyway.
+            pass
+
         instances = self._getNodesInCluster(nodeType=None, both=True)
         spotIDs = self._getSpotRequestIDs()
         if spotIDs:
             self._ctx.ec2.cancel_spot_instance_requests(request_ids=spotIDs)
         instancesToTerminate = awsFilterImpairedNodes(instances, self._ctx.ec2)
-        vpcId = None
         if instancesToTerminate:
-            vpcId = instancesToTerminate[0].vpc_id
-            self._deleteIAMProfiles(instances=instancesToTerminate)
-            self._terminateInstances(instances=instancesToTerminate)
+            vpcId = vpcId or instancesToTerminate[0].vpc_id
+            destroyInstances(instancesToTerminate)
         if len(instances) == len(instancesToTerminate):
             logger.debug('Deleting security group...')
             removed = False
@@ -366,7 +390,7 @@ class AWSProvisioner(AbstractProvisioner):
             namespace = '/' + namespace + '/'
         return namespace.replace('-', '/')
 
-    def getLeader(self, wait=False):
+    def getLeader(self, wait=False, returnRawInstance=False):
         assert self._ctx
         instances = self._getNodesInCluster(nodeType=None, both=True)
         instances.sort(key=lambda x: x.launch_time)
@@ -375,7 +399,7 @@ class AWSProvisioner(AbstractProvisioner):
         except IndexError:
             raise NoSuchClusterException(self.clusterName)
         if (leader.tags.get(_TOIL_NODE_TYPE_TAG_KEY) or 'leader') != 'leader':
-            raise RuntimeError(
+            raise InvalidClusterStateException(
                 'Invalid cluster state! The first launched instance appears not to be the leader '
                 'as it is missing the "leader" tag. The safest recovery is to destroy the cluster '
                 'and restart the job. Incorrect Leader ID: %s' % leader.id
@@ -390,7 +414,7 @@ class AWSProvisioner(AbstractProvisioner):
             self._waitForIP(leader)
             leaderNode.waitForNode('toil_leader')
 
-        return leaderNode
+        return leader if returnRawInstance else leaderNode
 
     @classmethod
     @awsRetry


### PR DESCRIPTION
Related to #2671 and #2685 

This is the cleanest solution that I could come up with: to special case `vpcId` and group other termination operations (for now just IAM role deletion) into a single method.

Tested with various configurations:
* Only the leader running
* Only workers running
* Both leader and workers running
* No instances running (this is a no-op).

Resolves #2670 