### PR TITLE
Add documentation about --awsEc2ProfileArn.

### DIFF
--- a/docs/appendices/aws_min_permissions.rst
+++ b/docs/appendices/aws_min_permissions.rst
@@ -1,0 +1,27 @@
+.. _minAwsPermissions:
+
+Minimum AWS IAM permissions
+---------------------------
+
+Toil requires at least the following permissions in an IAM role to operate on a cluster.
+These are added by default when launching a cluster. However, ensure that they are present
+if creating a custom IAM role when :ref:`launching a cluster <launchAwsClusterDetails>`
+with the ``--awsEc2ProfileArn`` parameter.
+
+::
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:*",
+                    "s3:*",
+                    "sdb:*",
+                    "iam:PassRole"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ If using Toil for your research, please cite
    :maxdepth: 2
 
    appendices/architecture
+   appendices/aws_min_permissions
    appendices/deploy
    appendices/environment_vars
    appendices/staticAzure

--- a/docs/running/cloud/amazon.rst
+++ b/docs/running/cloud/amazon.rst
@@ -172,6 +172,8 @@ platforms, and you can even simulate a cluster locally (see :ref:`appliance_dev`
 
 For information on using the Toil Provisioner have a look at :ref:`Autoscaling`.
 
+.. _launchAwsClusterDetails:
+
 Details about Launching a Cluster in AWS
 ----------------------------------------
 
@@ -195,6 +197,13 @@ Alternatively, you can specify this option via the ``TOIL_AWS_ZONE`` environment
 Note: the zone is different from an EC2 region. A region corresponds to a geographical area
 like ``us-west-2 (Oregon)``, and availability zones are partitions of this area like
 ``us-west-2a``.
+
+By default, Toil creates an IAM role for each cluster with sufficient permissions
+to perform cluster operations (e.g. full S3, EC2, and SDB access). If the default permissions
+are not sufficient for your use case (e.g. if you need access to ECR), you may create a
+custom IAM role with all necessary permissions and set the ``--awsEc2ProfileArn`` parameter
+when launching the cluster. Note that your custom role must at least have
+:ref:`these permissions <minAwsPermissions>` in order for the Toil cluster to function properly.
 
 For more information on options try: ::
 


### PR DESCRIPTION
Add documentation about the new `--awsEc2ProfileArn` flag. I added an appendix section so that we can include all customized permissions when @tthyer finalizes the list in #2700.