### PR TITLE
Remove X86_64 type requirement from lsf support

### DIFF
--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -167,7 +167,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     mem = old_div(float(mem), 1024**3)
                     mem_resource = parse_memory_resource(mem)
                     mem_limit = parse_memory_limit(mem)
-                bsubMem = ['-R', 'select[type==X86_64 && mem > {m}] '
+                bsubMem = ['-R', 'select[mem > {m}] '
                            'rusage[mem={m}]'.format(m=mem_resource),
                            '-M', str(mem_limit)]
             else:


### PR DESCRIPTION
Hi Toil team,

Our cluster doesn't have any nodes with this `type`, and thus this hard-coded param is preventing bsub submissions for lsf.

We currently have successfully made this change in my fork of Toil, but were hoping to get it merged into DataBioSphere so we can get back to the main fork, if there are no other users that this could cause an issue for.

I've ran the test suite locally with `make test`, and received two errors related to HTCondor support, which may be due to incompatibilities of the HTCondor pypi package installing on my mac. Any advice would be appreciated.

```
Successfully tagged quay.io/ucsc_cgl/toil-mtail:3.21.0a1-81315b28d46177db81a233c92fef76ce0d17e830
TOIL_APPLIANCE_SELF=/:3.21.0a1-81315b28d46177db81a233c92fef76ce0d17e830 \
	    python -m pytest --cov=toil -vv --timeout=530 src
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 2.7.14, pytest-3.6.2, py-1.7.0, pluggy-0.6.0 -- /Users/johnsoni/.virtualenvs/toil/bin/python
cachedir: .pytest_cache
rootdir: /Users/johnsoni/Desktop/Code/toil, inifile: setup.cfg
plugins: timeout-1.2.0, cov-2.6.1
timeout: 530.0s method: signal
collected 658 items / 2 errors


==================================================================================================================================== ERRORS ====================================================================================================================================
______________________________________________________________________________________________________________ ERROR collecting src/toil/batchSystems/htcondor.py ______________________________________________________________________________________________________________
src/toil/batchSystems/htcondor.py:27: in <module>
    import htcondor
E   ImportError: No module named htcondor
______________________________________________________________________________________________________________ ERROR collecting src/toil/batchSystems/htcondor.py ______________________________________________________________________________________________________________
ImportError while importing test module '/Users/johnsoni/Desktop/Code/toil/src/toil/batchSystems/htcondor.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.virtualenvs/toil/lib/python2.7/site-packages/_pytest/python.py:468: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
../../../.virtualenvs/toil/lib/python2.7/site-packages/py/_path/local.py:668: in pyimport
    __import__(modname)
src/toil/batchSystems/htcondor.py:27: in <module>
    import htcondor
E   ImportError: No module named htcondor
```

Thank you kindly