### PR TITLE
Prevent Toil from zipping entire dirs

### DIFF
--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -287,8 +287,8 @@ class DirectoryResource(Resource):
         else:
             # This is a simple user script (with possibly a few helper files)
             rootDir = path
-        blacklistDir = ['/tmp', '/var', '/etc', '/bin', '/sbin', '/home', '/dev', '/sys', '/usr', '/run']
-        if path not in blacklistDir:
+        skipdirList = ['/tmp', '/var', '/etc', '/bin', '/sbin', '/home', '/dev', '/sys', '/usr', '/run']
+        if path not in skipdirList:
             with ZipFile(file=bytesIO, mode='w') as zipFile:
                 for dirName, _, fileList in os.walk(path):
                     for fileName in fileList:

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -296,12 +296,12 @@ class DirectoryResource(Resource):
                             fullPath = os.path.join(dirName, fileName)
                             zipFile.write(fullPath, os.path.relpath(fullPath, rootDir))
                         except IOError:
-                            log.critical('Cannot access and read the file at address: %s' % fullPath)
-                            sys.exit()
+                            log.critical('Cannot access and read the file at path: %s' % fullPath)
+                            sys.exit(1)
         else:
             log.critical("Couldn't package the directory at %s for hot deployment. Would recommend to create a \
                 subdirectory (ie %s/MYDIR_HERE/)" % (path, path))
-            sys.exit()
+            sys.exit(1)
         bytesIO.seek(0)
         return bytesIO
 


### PR DESCRIPTION
Added a check to not allow user to execute toil in a dir such as /tmp or /var. 