### PR TITLE
Fix CWL tmpdir to be unique per job.

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -542,8 +542,7 @@ class CWLJob(Job):
                 cwljob.pop(inp_id)
 
         # Exports temporary directory for batch systems that reset TMPDIR
-        os.environ["TMPDIR"] = os.path.realpath(
-            self.runtime_context.tmpdir or file_store.getLocalTempDir())
+        os.environ["TMPDIR"] = os.path.realpath(file_store.getLocalTempDir())
         outdir = os.path.join(file_store.getLocalTempDir(), "out")
         os.mkdir(outdir)
         # Just keep the temporary output prefix under the job's local temp dir,
@@ -1128,7 +1127,6 @@ def main(args=None, stdout=sys.stdout):
 
     outdir = os.path.abspath(options.outdir)
     tmp_outdir_prefix = os.path.abspath(options.tmp_outdir_prefix)
-    tmpdir_prefix = os.path.abspath(options.tmpdir_prefix)
 
     fileindex = {}
     existing = {}
@@ -1228,7 +1226,6 @@ def main(args=None, stdout=sys.stdout):
 
             try:
                 runtime_context.use_container = use_container
-                runtime_context.tmpdir = os.path.realpath(tmpdir_prefix)
                 runtime_context.tmp_outdir_prefix = os.path.realpath(
                     tmp_outdir_prefix)
                 runtime_context.job_script_provider = job_script_provider


### PR DESCRIPTION
Setting `tmpdir` actually [overrides tmpdir_prefix](https://github.com/common-workflow-language/cwltool/blob/master/cwltool/command_line_tool.py#L542) and is not needed (results in a bug where files get corrupted if multiple jobs are running in the same worker and dont create unique tmp files in the `/tmp` folder).

Just setting `tmpdir_prefix` is enough for cwltool to create a unique tmpdir in the specified directory.

Tested with both `--tmpdir-prefix` and without.

Fixes #2744 