### PR TITLE
Fix python3-dev conflict.

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -23,7 +23,6 @@ sdistName = os.environ['_TOIL_SDIST_NAME']
 dependencies = ' '.join(['libffi-dev',  # For client side encryption for 'azure' extra with PyNACL
                          'python3.6',
                          'python3.6-dev',
-                         'python-dev',  # For installing Python packages with native code
                          'python-pip',  # Bootstrap pip, but needs upgrading, see below
                          'python3-pip',
                          'libcurl4-openssl-dev',

--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -23,6 +23,7 @@ sdistName = os.environ['_TOIL_SDIST_NAME']
 dependencies = ' '.join(['libffi-dev',  # For client side encryption for 'azure' extra with PyNACL
                          'python3.6',
                          'python3.6-dev',
+                         'python-dev',  # For installing Python packages with native code
                          'python-pip',  # Bootstrap pip, but needs upgrading, see below
                          'python3-pip',
                          'libcurl4-openssl-dev',

--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -24,7 +24,6 @@ dependencies = ' '.join(['libffi-dev',  # For client side encryption for 'azure'
                          'python3.6',
                          'python3.6-dev',
                          'python-dev',  # For installing Python packages with native code
-                         'python3-dev',
                          'python-pip',  # Bootstrap pip, but needs upgrading, see below
                          'python3-pip',
                          'libcurl4-openssl-dev',


### PR DESCRIPTION
Error looks like this:
```
(venv) quokka@qcore:~/git/toil$ make test tests=/home/quokka/git/toil/src/toil/test/jobStores/jobStoreTest.py::AWSJobStoreTest::testDestructionOfCorruptedJobStore
python setup.py sdist
running sdist
running egg_info
writing requirements to src/toil.egg-info/requires.txt
writing src/toil.egg-info/PKG-INFO

...
...
...

Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 python3.6 : Breaks: python3-dev (< 3.6.5~rc1-1) but 3.5.1-3 is to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt-get -y update --fix-missing && apt-get -y upgrade && apt-get -y install libffi-dev python3.6 python3.6-dev python-dev python3-dev python-pip python3-pip libcurl4-openssl-dev libssl-dev wget curl openssh-server mesos=1.0.1-2.0.94.ubuntu1604 nodejs rsync screen && apt-get clean && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
Makefile:184: recipe for target 'docker' failed
make: *** [docker] Error 100
```