### PR TITLE
WIP Run aws jobstore tests redux.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,16 +117,16 @@ py3_main:
     - python -m pytest src/toil/test/src
     - python -m pytest src/toil/test/utils
 
-#py3_integration:
-#  stage: integration
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y awscli jq
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli
-#    - export TOIL_TEST_INTEGRATIVE=True
-#    - export TOIL_AWS_KEYNAME=id_rsa
-#    - export TOIL_AWS_ZONE=us-west-2a
-#    - python setup_gitlab_ssh.py
-#    - mkdir ~/.aws
-#    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
-#    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
+py3_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y awscli jq
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli
+    - export TOIL_TEST_INTEGRATIVE=True
+    - export TOIL_AWS_KEYNAME=id_rsa
+    - export TOIL_AWS_ZONE=us-west-2a
+    - python setup_gitlab_ssh.py
+    - mkdir ~/.aws
+    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+    - python -m pytest src/toil/test/jobStores/jobStoreTest.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,8 +12,8 @@ after_script:
 
 
 stages:
-#  - main_tests
-#  - test
+  - main_tests
+  - test
   - integration
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,10 @@ after_script:
 stages:
   - main_tests
   - test
+  - integration
 
-#
+
 # Python2.7
-#
 py2_batch_systems:
   stage: test
   script:
@@ -45,7 +45,6 @@ py2_jobstore_and_provisioning:
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
     - python -m pytest src/toil/test/sort/sortTest.py
     - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
     # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
@@ -60,9 +59,22 @@ py2_main:
     - python -m pytest src/toil/test/src
     - python -m pytest src/toil/test/utils
 
-#
+py2_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y awscli jq
+    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli
+    - export TOIL_TEST_INTEGRATIVE=True
+    - export TOIL_AWS_KEYNAME=id_rsa
+    - export TOIL_AWS_ZONE=us-west-2a
+    - python setup_gitlab_ssh.py
+    - mkdir ~/.aws
+    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
+
+
 # Python3.6
-#
 py3_batch_systems:
   stage: test
   script:
@@ -104,3 +116,17 @@ py3_main:
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
     - python -m pytest src/toil/test/src
     - python -m pytest src/toil/test/utils
+
+#py3_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y awscli jq
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli
+#    - export TOIL_TEST_INTEGRATIVE=True
+#    - export TOIL_AWS_KEYNAME=id_rsa
+#    - export TOIL_AWS_ZONE=us-west-2a
+#    - python setup_gitlab_ssh.py
+#    - mkdir ~/.aws
+#    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+#    - python -m pytest src/toil/test/jobStores/jobStoreTest.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,47 +17,47 @@ stages:
   - integration
 
 
-## Python2.7
-#py2_batch_systems:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
-#    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
-#
-#py2_cwl:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/cwl/cwlTest.py
-#
-#py2_wdl:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/wdl/toilwdlTest.py
-#
-#py2_jobstore_and_provisioning:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/sort/sortTest.py
-#    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
-#    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
-#
-#py2_main:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/src
-#    - python -m pytest src/toil/test/utils
+# Python2.7
+py2_batch_systems:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
+
+py2_cwl:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/cwl/cwlTest.py
+
+py2_wdl:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/wdl/toilwdlTest.py
+
+py2_jobstore_and_provisioning:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/sort/sortTest.py
+    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
+    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
+    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
+
+py2_main:
+  stage: main_tests
+  script:
+    - pwd
+    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/src
+    - python -m pytest src/toil/test/utils
 
 py2_integration:
   stage: integration
@@ -74,59 +74,59 @@ py2_integration:
     - python -m pytest src/toil/test/jobStores/jobStoreTest.py
 
 
-## Python3.6
-#py3_batch_systems:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
-#    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
-#
-#py3_cwl:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/cwl/cwlTest.py
-#
-#py3_wdl:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/wdl/toilwdlTest.py
-#
-#py3_jobstore_and_provisioning:
-#  stage: test
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
-#    - python -m pytest src/toil/test/sort/sortTest.py
-#    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
-#    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
-#
-#py3_main:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest src/toil/test/src
-#    - python -m pytest src/toil/test/utils
-
-py3_integration:
-  stage: integration
+# Python3.6
+py3_batch_systems:
+  stage: test
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y awscli jq
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli
-    - export TOIL_TEST_INTEGRATIVE=True
-    - export TOIL_AWS_KEYNAME=id_rsa
-    - export TOIL_AWS_ZONE=us-west-2a
-    - python setup_gitlab_ssh.py
-    - mkdir ~/.aws
-    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
+
+py3_cwl:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/cwl/cwlTest.py
+
+py3_wdl:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/wdl/toilwdlTest.py
+
+py3_jobstore_and_provisioning:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
     - python -m pytest src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest src/toil/test/sort/sortTest.py
+    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
+    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
+    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
+
+py3_main:
+  stage: main_tests
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest src/toil/test/src
+    - python -m pytest src/toil/test/utils
+
+#py3_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y awscli jq
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli
+#    - export TOIL_TEST_INTEGRATIVE=True
+#    - export TOIL_AWS_KEYNAME=id_rsa
+#    - export TOIL_AWS_ZONE=us-west-2a
+#    - python setup_gitlab_ssh.py
+#    - mkdir ~/.aws
+#    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+#    - python -m pytest src/toil/test/jobStores/jobStoreTest.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,52 +12,52 @@ after_script:
 
 
 stages:
-  - main_tests
-  - test
+#  - main_tests
+#  - test
   - integration
 
 
-# Python2.7
-py2_batch_systems:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
-
-py2_cwl:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/cwl/cwlTest.py
-
-py2_wdl:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/wdl/toilwdlTest.py
-
-py2_jobstore_and_provisioning:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/sort/sortTest.py
-    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
-    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
-    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
-    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
-
-py2_main:
-  stage: main_tests
-  script:
-    - pwd
-    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/src
-    - python -m pytest src/toil/test/utils
+## Python2.7
+#py2_batch_systems:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
+#    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
+#
+#py2_cwl:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/cwl/cwlTest.py
+#
+#py2_wdl:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/wdl/toilwdlTest.py
+#
+#py2_jobstore_and_provisioning:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/sort/sortTest.py
+#    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
+#    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
+#    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
+#
+#py2_main:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/src
+#    - python -m pytest src/toil/test/utils
 
 py2_integration:
   stage: integration
@@ -74,48 +74,48 @@ py2_integration:
     - python -m pytest src/toil/test/jobStores/jobStoreTest.py
 
 
-# Python3.6
-py3_batch_systems:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
-
-py3_cwl:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/cwl/cwlTest.py
-
-py3_wdl:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/wdl/toilwdlTest.py
-
-py3_jobstore_and_provisioning:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
-    - python -m pytest src/toil/test/sort/sortTest.py
-    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
-    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
-    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
-    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
-
-py3_main:
-  stage: main_tests
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/src
-    - python -m pytest src/toil/test/utils
+## Python3.6
+#py3_batch_systems:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/batchSystems/batchSystemTest.py
+#    - python -m pytest src/toil/test/mesos/MesosDataStructuresTest.py
+#
+#py3_cwl:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/cwl/cwlTest.py
+#
+#py3_wdl:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/wdl/toilwdlTest.py
+#
+#py3_jobstore_and_provisioning:
+#  stage: test
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
+#    - python -m pytest src/toil/test/sort/sortTest.py
+#    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    # - python -m pytest src/toil/test/provisioners/azureProvisionerTest.py  # disabled and no longer maintained
+#    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
+#    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
+#
+#py3_main:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest src/toil/test/src
+#    - python -m pytest src/toil/test/utils
 
 py3_integration:
   stage: integration

--- a/setup_gitlab_ssh.py
+++ b/setup_gitlab_ssh.py
@@ -1,0 +1,19 @@
+import subprocess
+import json
+import os
+
+p = subprocess.Popen('aws secretsmanager --region us-west-2 get-secret-value --secret-id /toil/gitlab/ssh_key',
+                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+stdout, stderr = p.communicate()
+
+good_spot = os.path.expanduser('~/.ssh')
+os.mkdir(good_spot)
+
+try:
+    keys = json.loads(json.loads(stdout)['SecretString'])
+    with open(os.path.join(good_spot, 'id_rsa.pub'), 'w') as f:
+        f.write(keys['public'])
+    with open(os.path.join(good_spot, 'id_rsa'), 'w') as f:
+        f.write(keys['private'])
+except:
+    print('While attempting to set up the ssh key:\n' + str(stderr))

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -40,6 +40,7 @@ from six.moves.queue import Empty, Queue
 from six import iteritems, itervalues
 
 from pymesos import MesosSchedulerDriver, Scheduler, encode_data, decode_data
+from toil.lib.compatibility import USING_PYTHON2
 from toil import pickle
 from toil.lib.memoize import strict_bool
 from toil import resolveEntryPoint
@@ -660,7 +661,10 @@ class MesosBatchSystem(BatchSystemLocalSupport,
         """
         
         # Take it out of base 64 encoding from Protobuf
-        message = decode_data(message)
+        if USING_PYTHON2:
+            message = decode_data(message)
+        else:
+            message = decode_data(message).decode()
         
         log.debug('Got framework message from executor %s running on agent %s: %s',
                   executorId.value, agentId.value, message)

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -505,7 +505,7 @@ class MesosBatchSystem(BatchSystemLocalSupport,
     def _trackOfferedNodes(self, offers):
         for offer in offers:
             # All AgentID messages are required to have a value according to the Mesos Protobuf file.
-            assert(offer.agent_id.has_key('value'))
+            assert 'value' in offer.agent_id
             try:
                 nodeAddress = socket.gethostbyname(offer.hostname)
             except:
@@ -651,7 +651,7 @@ class MesosBatchSystem(BatchSystemLocalSupport,
                         jobID, update.state, update.message, update.reason)
             jobEnded(255)
             
-        if update.has_key('limitation'):
+        if 'limitation' in update:
             log.warning("Job limit info: %s" % update.limitation)
             
     def frameworkMessage(self, driver, executorId, agentId, message):

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -242,7 +242,7 @@ def main():
     logging.basicConfig(level=logging.DEBUG)
     log.debug("Starting executor")
 
-    if not os.environ.has_key("MESOS_AGENT_ENDPOINT"):
+    if not os.environ.get("MESOS_AGENT_ENDPOINT"):
         # Some Mesos setups in our tests somehow lack this variable. Provide a
         # fake one to maybe convince the executor driver to work.
         os.environ["MESOS_AGENT_ENDPOINT"] = os.environ.get("MESOS_SLAVE_ENDPOINT", "127.0.0.1:5051")
@@ -259,7 +259,7 @@ def main():
         
     # Parse the agent state
     agent_state = json.loads(urlopen("http://%s/state" % os.environ["MESOS_AGENT_ENDPOINT"]).read())
-    if agent_state.has_key('completed_frameworks'):
+    if 'completed_frameworks' in agent_state:
         # Drop the completed frameworks which grow over time
         del agent_state['completed_frameworks']
     log.debug("Agent state: %s", str(agent_state))

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -48,6 +48,7 @@ import boto.sdb
 from boto.exception import S3CreateError
 from boto.exception import SDBResponseError, S3ResponseError
 
+from toil.lib.compatibility import compat_bytes
 from toil.fileStores import FileID
 from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              NoSuchJobException,
@@ -305,7 +306,7 @@ class AWSJobStore(AbstractJobStore):
         for attempt in retry_sdb():
             with attempt:
                 return bool(self.jobsDomain.get_attributes(
-                    item_name=bytes(jobStoreID),
+                    item_name=compat_bytes(jobStoreID),
                     attribute_name=[SDBHelper.presenceIndicator()],
                     consistent_read=True))
 
@@ -324,7 +325,7 @@ class AWSJobStore(AbstractJobStore):
         item = None
         for attempt in retry_sdb():
             with attempt:
-                item = self.jobsDomain.get_attributes(bytes(jobStoreID), consistent_read=True)
+                item = self.jobsDomain.get_attributes(compat_bytes(jobStoreID), consistent_read=True)
         if not item:
             raise NoSuchJobException(jobStoreID)
         job = self._awsJobFromItem(item)
@@ -338,7 +339,7 @@ class AWSJobStore(AbstractJobStore):
         item = self._awsJobToItem(job)
         for attempt in retry_sdb():
             with attempt:
-                assert self.jobsDomain.put_attributes(bytes(job.jobStoreID), item)
+                assert self.jobsDomain.put_attributes(compat_bytes(job.jobStoreID), item)
 
     itemsPerBatchDelete = 25
 
@@ -350,14 +351,14 @@ class AWSJobStore(AbstractJobStore):
         item = None
         for attempt in retry_sdb():
             with attempt:
-                item = self.jobsDomain.get_attributes(bytes(jobStoreID), consistent_read=True)
+                item = self.jobsDomain.get_attributes(compat_bytes(jobStoreID), consistent_read=True)
         self._checkItem(item)
         if item["overlargeID"]:
             log.debug("Deleting job from filestore")
             self.deleteFile(item["overlargeID"])
         for attempt in retry_sdb():
             with attempt:
-                self.jobsDomain.delete_attributes(item_name=bytes(jobStoreID))
+                self.jobsDomain.delete_attributes(item_name=compat_bytes(jobStoreID))
         items = None
         for attempt in retry_sdb():
             with attempt:
@@ -380,9 +381,9 @@ class AWSJobStore(AbstractJobStore):
                 for attempt in retry_s3():
                     with attempt:
                         if version:
-                            self.filesBucket.delete_key(key_name=bytes(item.name), version_id=version)
+                            self.filesBucket.delete_key(key_name=compat_bytes(item.name), version_id=version)
                         else:
-                            self.filesBucket.delete_key(key_name=bytes(item.name))
+                            self.filesBucket.delete_key(key_name=compat_bytes(item.name))
 
     def getEmptyFileStoreID(self, jobStoreID=None, cleanup=False):
         info = self.FileInfo.create(jobStoreID if cleanup else None)
@@ -631,7 +632,7 @@ class AWSJobStore(AbstractJobStore):
                 f.write(info.content)
         for attempt in retry_s3():
             with attempt:
-                key = self.filesBucket.get_key(key_name=bytes(jobStoreFileID), version_id=info.version)
+                key = self.filesBucket.get_key(key_name=compat_bytes(jobStoreFileID), version_id=info.version)
                 key.set_canned_acl('public-read')
                 url = key.generate_url(query_auth=False,
                                        expires_in=self.publicUrlExpiration.total_seconds())
@@ -887,7 +888,7 @@ class AWSJobStore(AbstractJobStore):
             for attempt in retry_sdb():
                 with attempt:
                     return bool(cls.outer.filesDomain.get_attributes(
-                        item_name=bytes(jobStoreFileID),
+                        item_name=compat_bytes(jobStoreFileID),
                         attribute_name=[cls.presenceIndicator()],
                         consistent_read=True))
 
@@ -896,7 +897,7 @@ class AWSJobStore(AbstractJobStore):
             for attempt in retry_sdb():
                 with attempt:
                     self = cls.fromItem(
-                        cls.outer.filesDomain.get_attributes(item_name=bytes(jobStoreFileID),
+                        cls.outer.filesDomain.get_attributes(item_name=compat_bytes(jobStoreFileID),
                                                              consistent_read=True))
                     return self
 
@@ -996,14 +997,14 @@ class AWSJobStore(AbstractJobStore):
             try:
                 for attempt in retry_sdb():
                     with attempt:
-                        assert self.outer.filesDomain.put_attributes(item_name=bytes(self.fileID),
+                        assert self.outer.filesDomain.put_attributes(item_name=compat_bytes(self.fileID),
                                                                      attributes=attributes,
                                                                      expected_value=expected)
                 # clean up the old version of the file if necessary and safe
                 if self.previousVersion and (self.previousVersion != self.version):
                     for attempt in retry_s3():
                         with attempt:
-                            self.outer.filesBucket.delete_key(bytes(self.fileID),
+                            self.outer.filesBucket.delete_key(compat_bytes(self.fileID),
                                                               version_id=self.previousVersion)
                 self._previousVersion = self._version
                 if numNewContentChunks < self._numContentChunks:
@@ -1011,7 +1012,7 @@ class AWSJobStore(AbstractJobStore):
                     attributes = [self._chunkName(i) for i in residualChunks]
                     for attempt in retry_sdb():
                         with attempt:
-                            self.outer.filesDomain.delete_attributes(bytes(self.fileID),
+                            self.outer.filesDomain.delete_attributes(compat_bytes(self.fileID),
                                                                      attributes=attributes)
                 self._numContentChunks = numNewContentChunks
             except SDBResponseError as e:
@@ -1028,7 +1029,7 @@ class AWSJobStore(AbstractJobStore):
             else:
                 headers = self._s3EncryptionHeaders()
                 self.version = uploadFromPath(localFilePath, partSize=self.outer.partSize,
-                                              bucket=self.outer.filesBucket, fileID=bytes(self.fileID),
+                                              bucket=self.outer.filesBucket, fileID=compat_bytes(self.fileID),
                                               headers=headers)
 
         @contextmanager
@@ -1046,7 +1047,7 @@ class AWSJobStore(AbstractJobStore):
                         for attempt in retry_s3():
                             with attempt:
                                 upload = store.filesBucket.initiate_multipart_upload(
-                                    key_name=bytes(info.fileID),
+                                    key_name=compat_bytes(info.fileID),
                                     headers=headers)
                         try:
                             for part_num in itertools.count():
@@ -1078,7 +1079,7 @@ class AWSJobStore(AbstractJobStore):
                     if allowInlining and len(buf) <= info.maxInlinedSize():
                         info.content = buf
                     else:
-                        key = store.filesBucket.new_key(key_name=bytes(info.fileID))
+                        key = store.filesBucket.new_key(key_name=compat_bytes(info.fileID))
                         buf = StringIO(buf)
                         headers = info._s3EncryptionHeaders()
                         for attempt in retry_s3():
@@ -1124,9 +1125,9 @@ class AWSJobStore(AbstractJobStore):
                 for attempt in retry_s3():
                     encrypted = True if self.outer.sseKeyPath else False
                     if encrypted:
-                        srcKey = self.outer.filesBucket.get_key(bytes(self.fileID), headers=self._s3EncryptionHeaders())
+                        srcKey = self.outer.filesBucket.get_key(compat_bytes(self.fileID), headers=self._s3EncryptionHeaders())
                     else:
-                        srcKey = self.outer.filesBucket.get_key(bytes(self.fileID))
+                        srcKey = self.outer.filesBucket.get_key(compat_bytes(self.fileID))
                     srcKey.version_id = self.version
                     with attempt:
                         copyKeyMultipart(srcBucketName=srcKey.bucket.name,
@@ -1145,7 +1146,7 @@ class AWSJobStore(AbstractJobStore):
                     f.write(self.content)
             elif self.version:
                 headers = self._s3EncryptionHeaders()
-                key = self.outer.filesBucket.get_key(bytes(self.fileID), validate=False)
+                key = self.outer.filesBucket.get_key(compat_bytes(self.fileID), validate=False)
                 for attempt in retry_s3():
                     with attempt:
                         key.get_contents_to_filename(localFilePath,
@@ -1164,7 +1165,7 @@ class AWSJobStore(AbstractJobStore):
                         writable.write(info.content)
                     elif info.version:
                         headers = info._s3EncryptionHeaders()
-                        key = info.outer.filesBucket.get_key(bytes(info.fileID), validate=False)
+                        key = info.outer.filesBucket.get_key(compat_bytes(info.fileID), validate=False)
                         for attempt in retry_s3():
                             with attempt:
                                 key.get_contents_to_file(writable,
@@ -1182,12 +1183,12 @@ class AWSJobStore(AbstractJobStore):
                 for attempt in retry_sdb():
                     with attempt:
                         store.filesDomain.delete_attributes(
-                            bytes(self.fileID),
+                            compat_bytes(self.fileID),
                             expected_values=['version', self.previousVersion])
                 if self.previousVersion:
                     for attempt in retry_s3():
                         with attempt:
-                            store.filesBucket.delete_key(key_name=bytes(self.fileID),
+                            store.filesBucket.delete_key(key_name=compat_bytes(self.fileID),
                                                          version_id=self.previousVersion)
 
         def _getSSEKey(self):
@@ -1287,7 +1288,7 @@ class AWSJobStore(AbstractJobStore):
                 try:
                     for upload in b.list_multipart_uploads():
                         upload.cancel_upload()  # TODO: upgrade this portion to boto3
-                    bucket = s3_boto3_resource.Bucket(bytes(b.name))
+                    bucket = s3_boto3_resource.Bucket(compat_bytes(b.name))
                     bucket.objects.all().delete()
                     bucket.object_versions.delete()
                     bucket.delete()

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -47,7 +47,7 @@ import boto.sdb
 from boto.exception import S3CreateError
 from boto.exception import SDBResponseError, S3ResponseError
 
-from toil.lib.compatibility import compat_bytes, USING_PYTHON2
+from toil.lib.compatibility import compat_bytes, compat_plain, USING_PYTHON2
 from toil.fileStores import FileID
 from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              NoSuchJobException,
@@ -874,7 +874,7 @@ class AWSJobStore(AbstractJobStore):
 
         @classmethod
         def create(cls, ownerID):
-            return cls(compat_bytes(uuid.uuid4()), ownerID, encrypted=cls.outer.sseKeyPath is not None)
+            return cls(str(uuid.uuid4()), ownerID, encrypted=cls.outer.sseKeyPath is not None)
 
         @classmethod
         def presenceIndicator(cls):
@@ -1107,13 +1107,13 @@ class AWSJobStore(AbstractJobStore):
             if srcKey.size <= self.maxInlinedSize():
                 self.content = srcKey.get_contents_as_string()
             else:
-                self.version = copyKeyMultipart(srcBucketName=compat_bytes(srcKey.bucket.name),
-                                                srcKeyName=compat_bytes(srcKey.name),
-                                                srcKeyVersion=compat_bytes(srcKey.version_id),
-                                                dstBucketName=compat_bytes(self.outer.filesBucket.name),
-                                                dstKeyName=compat_bytes(self._fileID),
+                self.version = copyKeyMultipart(srcBucketName=compat_plain(srcKey.bucket.name),
+                                                srcKeyName=compat_plain(srcKey.name),
+                                                srcKeyVersion=compat_plain(srcKey.version_id),
+                                                dstBucketName=compat_plain(self.outer.filesBucket.name),
+                                                dstKeyName=compat_plain(self._fileID),
                                                 sseAlgorithm='AES256',
-                                                sseKey=compat_bytes(self._getSSEKey()))
+                                                sseKey=self._getSSEKey())
 
         def copyTo(self, dstKey):
             """
@@ -1134,13 +1134,13 @@ class AWSJobStore(AbstractJobStore):
                         srcKey = self.outer.filesBucket.get_key(compat_bytes(self.fileID))
                     srcKey.version_id = self.version
                     with attempt:
-                        copyKeyMultipart(srcBucketName=compat_bytes(srcKey.bucket.name),
-                                         srcKeyName=compat_bytes(srcKey.name),
-                                         srcKeyVersion=compat_bytes(srcKey.version_id),
-                                         dstBucketName=compat_bytes(dstKey.bucket.name),
-                                         dstKeyName=compat_bytes(dstKey.name),
+                        copyKeyMultipart(srcBucketName=compat_plain(srcKey.bucket.name),
+                                         srcKeyName=compat_plain(srcKey.name),
+                                         srcKeyVersion=compat_plain(srcKey.version_id),
+                                         dstBucketName=compat_plain(dstKey.bucket.name),
+                                         dstKeyName=compat_plain(dstKey.name),
                                          copySourceSseAlgorithm='AES256',
-                                         copySourceSseKey=compat_bytes(self._getSSEKey()))
+                                         copySourceSseKey=self._getSSEKey())
             else:
                 assert False
 

--- a/src/toil/lib/compatibility.py
+++ b/src/toil/lib/compatibility.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from past.builtins import str as oldstr
+
+import sys
+
+USING_PYTHON2 = True if sys.version_info < (3, 0) else False
+
+
+def compat_oldstr(s):
+    if USING_PYTHON2:
+        return oldstr(s)
+    else:
+        return s.decode('utf-8') if isinstance(s, bytes) else s
+
+
+def compat_bytes(s):
+    if USING_PYTHON2:
+        return bytes(s)
+    else:
+        return s.decode('utf-8') if isinstance(s, bytes) else s

--- a/src/toil/lib/compatibility.py
+++ b/src/toil/lib/compatibility.py
@@ -18,3 +18,10 @@ def compat_bytes(s):
         return bytes(s)
     else:
         return s.decode('utf-8') if isinstance(s, bytes) else s
+
+
+def compat_plain(s):
+    if USING_PYTHON2:
+        return s
+    else:
+        return s.decode('utf-8') if isinstance(s, bytes) else s

--- a/src/toil/lib/encryption/_nacl.py
+++ b/src/toil/lib/encryption/_nacl.py
@@ -15,9 +15,11 @@
 from builtins import str
 import nacl
 from nacl.secret import SecretBox
+from toil.lib.compatibility import USING_PYTHON2
 
 # 16-byte MAC plus a nonce is added to every message.
 overhead = 16 + SecretBox.NONCE_SIZE
+
 
 def encrypt(message, keyPath):
     """
@@ -54,7 +56,11 @@ def encrypt(message, keyPath):
     # recommended in the libsodium documentation.)
     nonce = nacl.utils.random(SecretBox.NONCE_SIZE)
     assert len(nonce) == SecretBox.NONCE_SIZE
-    return str(sb.encrypt(message, nonce))
+    if USING_PYTHON2:
+        return bytes(sb.encrypt(message, nonce))
+    else:
+        return str(sb.encrypt(message, nonce))
+
 
 def decrypt(ciphertext, keyPath):
     """

--- a/src/toil/lib/encryption/_nacl.py
+++ b/src/toil/lib/encryption/_nacl.py
@@ -16,6 +16,7 @@ from builtins import str
 import nacl
 from nacl.secret import SecretBox
 
+from toil.lib.compatibility import compat_bytes
 
 # 16-byte MAC plus a nonce is added to every message.
 overhead = 16 + SecretBox.NONCE_SIZE
@@ -55,7 +56,7 @@ def encrypt(message, keyPath):
     # recommended in the libsodium documentation.)
     nonce = nacl.utils.random(SecretBox.NONCE_SIZE)
     assert len(nonce) == SecretBox.NONCE_SIZE
-    return bytes(sb.encrypt(message, nonce))
+    return compat_bytes(sb.encrypt(message, nonce))
 
 def decrypt(ciphertext, keyPath):
     """

--- a/src/toil/lib/encryption/_nacl.py
+++ b/src/toil/lib/encryption/_nacl.py
@@ -16,8 +16,6 @@ from builtins import str
 import nacl
 from nacl.secret import SecretBox
 
-from toil.lib.compatibility import compat_bytes
-
 # 16-byte MAC plus a nonce is added to every message.
 overhead = 16 + SecretBox.NONCE_SIZE
 
@@ -56,7 +54,7 @@ def encrypt(message, keyPath):
     # recommended in the libsodium documentation.)
     nonce = nacl.utils.random(SecretBox.NONCE_SIZE)
     assert len(nonce) == SecretBox.NONCE_SIZE
-    return compat_bytes(sb.encrypt(message, nonce))
+    return str(sb.encrypt(message, nonce))
 
 def decrypt(ciphertext, keyPath):
     """

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -960,5 +960,3 @@ class ClusterStats(object):
                 threadName = 'Preemptable' if preemptable else 'Non-preemptable'
                 logger.debug('%s provisioner stats thread shut down successfully.', threadName)
                 self.stats[threadName] = stats
-        else:
-            pass

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -34,7 +34,7 @@ from unittest.util import strclass
 from six import iteritems, itervalues
 from six.moves.urllib.request import urlopen
 
-from toil.lib.memoize import less_strict_bool, memoize
+from toil.lib.memoize import memoize
 from toil.lib.iterables import concat
 from toil.lib.threading import ExceptionalThread
 from toil.lib.misc import mkdir_p
@@ -99,18 +99,16 @@ class ToilTest(unittest.TestCase):
         Use us-west-2 unless running on EC2, in which case use the region in which
         the instance is located
         """
-        if runningOnEC2():
-            return cls._region()
-        else:
-            return 'us-west-2'
+        return cls._region() if runningOnEC2() else 'us-west-2'
 
     @classmethod
     def _availabilityZone(cls):
         """
         Used only when running on EC2. Query this instance's metadata to determine
-        in which availability zone it is running
+        in which availability zone it is running.
         """
-        return urlopen('http://169.254.169.254/latest/meta-data/placement/availability-zone').read()
+        zone = urlopen('http://169.254.169.254/latest/meta-data/placement/availability-zone').read()
+        return zone if not isinstance(zone, bytes) else zone.decode('utf-8')
 
     @classmethod
     @memoize
@@ -120,10 +118,9 @@ class ToilTest(unittest.TestCase):
         The region will not change over the life of the instance so the result
         is memoized to avoid unnecessary work.
         """
-        m = re.match(r'^([a-z]{2}-[a-z]+-[1-9][0-9]*)([a-z])$', cls._availabilityZone())
-        assert m
-        region = m.group(1)
-        return region
+        region = re.match(r'^([a-z]{2}-[a-z]+-[1-9][0-9]*)([a-z])$', cls._availabilityZone())
+        assert region
+        return region.group(1)
 
     @classmethod
     def _getUtilScriptPath(cls, script_name):
@@ -175,8 +172,7 @@ class ToilTest(unittest.TestCase):
         :rtype: str
         """
         sdistPath = os.path.join(cls._projectRootPath(), 'dist', 'toil-%s.tar.gz' % distVersion)
-        assert os.path.isfile(
-            sdistPath), "Can't find Toil source distribution at %s. Run 'make sdist'." % sdistPath
+        assert os.path.isfile(sdistPath), "Can't find Toil source distribution at %s. Run 'make sdist'." % sdistPath
         excluded = set(cls._run('git', 'ls-files', '--others', '-i', '--exclude-standard',
                                 capture=True,
                                 cwd=cls._projectRootPath()).splitlines())
@@ -186,8 +182,7 @@ class ToilTest(unittest.TestCase):
         assert all(path.startswith('src') for path in dirty)
         dirty = set(dirty)
         dirty.difference_update(excluded)
-        assert not dirty, \
-            "Run 'make clean_sdist sdist'. Files newer than %s: %r" % (sdistPath, list(dirty))
+        assert not dirty, "Run 'make clean_sdist sdist'. Files newer than %s: %r" % (sdistPath, list(dirty))
         return sdistPath
 
     @classmethod
@@ -255,84 +250,56 @@ def needs_rsync3(test_item):
     test_item = _mark_test('rsync', test_item)
     try:
         versionInfo = subprocess.check_output(['rsync', '--version']).decode('utf-8')
+        if int(versionInfo.split()[2].split('.')[0]) < 3:  # output looks like: 'rsync  version 2.6.9 ...'
+            return unittest.skip('This test depends on rsync version 3.0.0+.')(test_item)
     except subprocess.CalledProcessError:
         return unittest.skip('rsync needs to be installed to run this test.')(test_item)
-    else:
-        # version output looks like: 'rsync  version 2.6.9 ...'
-        versionNum = int(versionInfo.split()[2].split('.')[0])
-        if versionNum < 3:
-            return unittest.skip('This test depends on rsync version 3.0.0+.')(test_item)
-
     return test_item
 
 
 def needs_aws(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if AWS usable.
-    """
+    """Use as a decorator before test classes or methods to run only if AWS is usable."""
     test_item = _mark_test('aws', test_item)
-    keyName = os.getenv('TOIL_AWS_KEYNAME')
-    if not keyName or keyName is None:
-        return unittest.skip("Set TOIL_AWS_KEYNAME to include this test.")(test_item)
-
     try:
-        # noinspection PyUnresolvedReferences
         from boto import config
+        boto_credentials = config.get('Credentials', 'aws_access_key_id')
     except ImportError:
         return unittest.skip("Install Toil with the 'aws' extra to include this test.")(test_item)
-    except:
-        raise
-    else:
-        dot_aws_credentials_path = os.path.expanduser('~/.aws/credentials')
-        boto_credentials = config.get('Credentials', 'aws_access_key_id')
-        if boto_credentials:
-            return test_item
-        if os.path.exists(dot_aws_credentials_path) or runningOnEC2():
-            # Assume that EC2 machines like the Jenkins slave that we run CI on will have IAM roles
-            return test_item
-        else:
-            return unittest.skip("Configure ~/.aws/credentials with AWS credentials to include "
-                                 "this test.")(test_item)
+
+    if not (boto_credentials or os.path.exists(os.path.expanduser('~/.aws/credentials')) or runningOnEC2()):
+        return unittest.skip("Configure AWS credentials to include this test.")(test_item)
+    elif not os.getenv('TOIL_AWS_KEYNAME'):
+        return unittest.skip("Set TOIL_AWS_KEYNAME to include this test.")(test_item)
+    return test_item
 
 
 def travis_test(test_item):
     test_item = _mark_test('travis', test_item)
     if os.environ.get('TRAVIS') != 'true':
         return unittest.skip("Set TRAVIS='true' to include this test.")(test_item)
-    else:
-        return test_item
+    return test_item
 
 
 def needs_google(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if Google Storage usable.
-    """
+    """Use as a decorator before test classes or methods to run only if Google is usable."""
     test_item = _mark_test('google', test_item)
-    projectID = os.getenv('TOIL_GOOGLE_PROJECTID')
-    if not projectID or projectID is None:
-        return unittest.skip("Set TOIL_GOOGLE_PROJECTID to include this test.")(test_item)
     try:
-        # noinspection PyUnresolvedReferences
         from boto import config
     except ImportError:
-        return unittest.skip(
-            "Install Toil with the 'google' extra to include this test.")(test_item)
-    else:
-        boto_credentials = config.get('Credentials', 'gs_access_key_id')
-        if boto_credentials:
-            return test_item
-        else:
-            return unittest.skip(
-                "Configure ~/.boto with Google Cloud credentials to include this test.")(test_item)
+        return unittest.skip("Install Toil with the 'google' extra to include this test.")(test_item)
+
+    if not os.getenv('TOIL_GOOGLE_PROJECTID'):
+        return unittest.skip("Set TOIL_GOOGLE_PROJECTID to include this test.")(test_item)
+    elif not config.get('Credentials'):  # TODO: Deprecate this check?  Needed by only by the ancients.
+        return unittest.skip("Configure ~/.boto with Google Cloud credentials to include this test.")(test_item)
+    return test_item
 
 
 def needs_azure(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if Azure is usable.
-    """
+    """Use as a decorator before test classes or methods to run only if Azure is usable."""
     test_item = _mark_test('azure', test_item)
     keyName = os.getenv('TOIL_AZURE_KEYNAME')
-    if not keyName or keyName is None:
+    if not keyName:
         return unittest.skip("Set TOIL_AZURE_KEYNAME to include this test.")(test_item)
 
     try:
@@ -340,91 +307,67 @@ def needs_azure(test_item):
         import azure.storage
     except ImportError:
         return unittest.skip("Install Toil with the 'azure' extra to include this test.")(test_item)
-    except:
-        raise
     else:
         # check for the credentials file
         from toil.jobStores.azureJobStore import credential_file_path
-        full_credential_file_path = os.path.expanduser(credential_file_path)
-        if not os.path.exists(full_credential_file_path):
+        if not os.path.exists(os.path.expanduser(credential_file_path)):
             # no file, check for environment variables
             try:
                 from toil.jobStores.azureJobStore import _fetchAzureAccountKey
                 _fetchAzureAccountKey(keyName)
             except:
-                 return unittest.skip("Configure %s with the access key for the '%s' storage "
-                                     "account." % (credential_file_path, keyName))(test_item)
+                 return unittest.skip("Configure %s with the access key for the '%s' storage account." %
+                                      (credential_file_path, keyName))(test_item)
         return test_item
 
 
 def needs_gridengine(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if GridEngine is installed.
-    """
+    """Use as a decorator before test classes or methods to run only if GridEngine is installed."""
     test_item = _mark_test('gridengine', test_item)
     if which('qhost'):
         return test_item
-    else:
-        return unittest.skip("Install GridEngine to include this test.")(test_item)
+    return unittest.skip("Install GridEngine to include this test.")(test_item)
+
 
 def needs_torque(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if PBS/Torque is installed.
-    """
+    """Use as a decorator before test classes or methods to run only ifPBS/Torque is installed."""
     test_item = _mark_test('torque', test_item)
     if which('pbsnodes'):
         return test_item
-    else:
-        return unittest.skip("Install PBS/Torque to include this test.")(test_item)
+    return unittest.skip("Install PBS/Torque to include this test.")(test_item)
 
 
 def needs_mesos(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if the Mesos is installed
-    and configured.
-    """
+    """Use as a decorator before test classes or methods to run only if Mesos is installed."""
     test_item = _mark_test('mesos', test_item)
     if not (which('mesos-master') or which('mesos-slave')):
-        return unittest.skip(
-            "Install Mesos (and Toil with the 'mesos' extra) to include this test.")(test_item)
+        return unittest.skip("Install Mesos (and Toil with the 'mesos' extra) to include this test.")(test_item)
     try:
-        # noinspection PyUnresolvedReferences
         import pymesos
         import psutil
     except ImportError:
-        return unittest.skip(
-            "Install Mesos (and Toil with the 'mesos' extra) to include this test.")(test_item)
-    except:
-        raise
-    else:
-        return test_item
+        return unittest.skip("Install Mesos (and Toil with the 'mesos' extra) to include this test.")(test_item)
+    return test_item
 
 
 def needs_parasol(test_item):
-    """
-    Use as decorator so tests are only run if Parasol is installed.
-    """
+    """Use as decorator so tests are only run if Parasol is installed."""
     test_item = _mark_test('parasol', test_item)
     if which('parasol'):
         return test_item
-    else:
-        return unittest.skip("Install Parasol to include this test.")(test_item)
+    return unittest.skip("Install Parasol to include this test.")(test_item)
 
 
 def needs_slurm(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if Slurm is installed.
-    """
+    """Use as a decorator before test classes or methods to run only if Slurm is installed."""
     test_item = _mark_test('slurm', test_item)
     if which('squeue'):
         return test_item
-    else:
-        return unittest.skip("Install Slurm to include this test.")(test_item)
+    return unittest.skip("Install Slurm to include this test.")(test_item)
+
 
 def needs_htcondor(test_item):
-    """
-    Use a decorator before test classes or methods to only run them if the HTCondor Python bindings are installed.
-    """
+    """Use a decorator before test classes or methods to run only if the HTCondor is installed."""
     test_item = _mark_test('htcondor', test_item)
     try:
         import htcondor
@@ -457,7 +400,7 @@ def needs_docker(test_item):
     docker is installed and docker-based tests are enabled.
     """
     test_item = _mark_test('docker', test_item)
-    if less_strict_bool(os.getenv('TOIL_SKIP_DOCKER')):
+    if os.getenv('TOIL_SKIP_DOCKER', '').lower() == 'true':
         return unittest.skip('Skipping docker test.')(test_item)
     if which('docker'):
         return test_item
@@ -477,8 +420,6 @@ def needs_encryption(test_item):
     except ImportError:
         return unittest.skip(
             "Install Toil with the 'encryption' extra to include this test.")(test_item)
-    except:
-        raise
     else:
         return test_item
 
@@ -494,8 +435,6 @@ def needs_cwl(test_item):
         import cwltool
     except ImportError:
         return unittest.skip("Install Toil with the 'cwl' extra to include this test.")(test_item)
-    except:
-        raise
     else:
         return test_item
 
@@ -503,7 +442,7 @@ def needs_cwl(test_item):
 def needs_appliance(test_item):
     import json
     test_item = _mark_test('appliance', test_item)
-    if less_strict_bool(os.getenv('TOIL_SKIP_DOCKER')):
+    if os.getenv('TOIL_SKIP_DOCKER', '').lower() == 'true':
         return unittest.skip('Skipping docker test.')(test_item)
     if which('docker'):
         image = applianceSelf()
@@ -525,20 +464,6 @@ def needs_appliance(test_item):
         return unittest.skip('Install Docker to include this test.')(test_item)
 
 
-def experimental(test_item):
-    """
-    Use this to decorate experimental or brittle tests in order to skip them during regular builds.
-    """
-    # We'll pytest.mark_test the test as experimental but we'll also unittest.skip it via an
-    # environment variable.
-    test_item = _mark_test('experimental', test_item)
-    if less_strict_bool(os.getenv('TOIL_TEST_EXPERIMENTAL')):
-        return test_item
-    else:
-        return unittest.skip(
-            'Set TOIL_TEST_EXPERIMENTAL="True" to include this experimental test.')(test_item)
-
-
 def integrative(test_item):
     """
     Use this to decorate integration tests so as to skip them during regular builds. We define
@@ -547,27 +472,25 @@ def integrative(test_item):
     being integrative. Neither does involvement of external services such as AWS, since that
     would cover most of Toil's test.
     """
-    # We'll pytest.mark_test the test as integrative but we'll also unittest.skip it via an
-    # environment variable.
     test_item = _mark_test('integrative', test_item)
-    if less_strict_bool(os.getenv('TOIL_TEST_INTEGRATIVE')):
+    if os.getenv('TOIL_TEST_INTEGRATIVE', '').lower() == 'true':
         return test_item
     else:
-        return unittest.skip(
-            'Set TOIL_TEST_INTEGRATIVE="True" to include this integration test, '
-            'or run `make integration_test_local` to run all integration tests.')(test_item)
+        return unittest.skip('Set TOIL_TEST_INTEGRATIVE="True" to include this integration test, '
+                             'or run `make integration_test_local` to run all integration tests.')(test_item)
+
 
 def slow(test_item):
     """
     Use this decorator to identify tests that are slow and not critical.
-    Skip them if TOIL_TEST_QUICK is true.
+    Skip if TOIL_TEST_QUICK is true.
     """
     test_item = _mark_test('slow', test_item)
-    if not less_strict_bool(os.getenv('TOIL_TEST_QUICK')):
+    if os.environ.get('TOIL_TEST_QUICK', '').lower() != 'true':
         return test_item
     else:
-        return unittest.skip(
-            'Skipped because TOIL_TEST_QUICK is "True"')(test_item)
+        return unittest.skip('Skipped because TOIL_TEST_QUICK is "True"')(test_item)
+
 
 methodNamePartRegex = re.compile('^[a-zA-Z_0-9]+$')
 
@@ -928,11 +851,11 @@ class ApplianceTestSupport(ToilTest):
             self.writeToAppliance(path + '/' + module + '.py', script)
 
     class LeaderThread(Appliance):
-        def _getRole(self):
-            return 'leader'
-
         def _entryPoint(self):
             return 'mesos-master'
+
+        def _getRole(self):
+            return 'leader'
 
         def _containerCommand(self):
             return ['--registry=in_memory',

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -140,13 +140,13 @@ class AbstractJobStoreTest(object):
             self.jobstore_initialized.destroy()
             self.jobstore_resumed_noconfig.destroy()
             super(AbstractJobStoreTest.Test, self).tearDown()
-        
+
         @travis_test
         def testInitialState(self):
             """Ensure proper handling of nonexistant files."""
             self.assertFalse(self.jobstore_initialized.exists('nonexistantFile'))
             self.assertRaises(NoSuchJobException, self.jobstore_initialized.load, 'nonexistantFile')
-        
+
         @travis_test
         def testJobCreation(self):
             """
@@ -177,7 +177,7 @@ class AbstractJobStoreTest(object):
             self.assertEqual(job.predecessorNumber, 0)
             self.assertEqual(job.predecessorsFinished, set())
             self.assertEqual(job.logJobStoreFileID, None)
-        
+
         @travis_test
         def testConfigEquality(self):
             """
@@ -191,7 +191,7 @@ class AbstractJobStoreTest(object):
             newJobStore.resume()
             self.assertEqual(newJobStore.config, self.config)
             self.assertIsNot(newJobStore.config, self.config)
-        
+
         @travis_test
         def testJobLoadEquality(self):
             """Tests that a job loaded into one jobstore from another can be used equivalently by another."""
@@ -207,7 +207,7 @@ class AbstractJobStoreTest(object):
             job2 = self.jobstore_resumed_noconfig.load(job1.jobStoreID)
 
             self.assertEqual(job1, job2)
-        
+
         @travis_test
         def testChildLoadingEquality(self):
             """Test that loading a child job operates as expected."""
@@ -225,7 +225,7 @@ class AbstractJobStoreTest(object):
             job.stack.append(childJob)
             self.jobstore_initialized.update(job)
             self.assertEqual(self.jobstore_initialized.load(childJob.jobStoreID), childJob)
-        
+
         @travis_test
         def testPersistantFilesToDelete(self):
             """
@@ -238,15 +238,15 @@ class AbstractJobStoreTest(object):
 
             # Create a job.
             jobNode = JobNode(command='job1',
-                               requirements=self.parentJobReqs,
-                               jobName='test1', unitName='onJS1',
-                               jobStoreID=None, predecessorNumber=0)
+                              requirements=self.parentJobReqs,
+                              jobName='test1', unitName='onJS1',
+                              jobStoreID=None, predecessorNumber=0)
 
             job = self.jobstore_initialized.create(jobNode)
             job.filesToDelete = ['1', '2']
             self.jobstore_initialized.update(job)
             self.assertEqual(self.jobstore_initialized.load(job.jobStoreID).filesToDelete, ['1', '2'])
-        
+
         @travis_test
         def testUpdateBehavior(self):
             """Tests the proper behavior during updating jobs."""
@@ -290,9 +290,9 @@ class AbstractJobStoreTest(object):
             # Load children on jobstore and check equivalence
             self.assertEqual(jobstore1.load(childJob1.jobStoreID), childJob1)
             self.assertEqual(jobstore1.load(childJob2.jobStoreID), childJob2)
-            self.assertEqual(job1,job2)            # The jobs should both have children now...
-            self.assertIsNot(job1,job2)             # but should not be the same.
-        
+            self.assertEqual(job1, job2)  # The jobs should both have children now...
+            self.assertIsNot(job1, job2)  # but should not be the same.
+
         @travis_test
         def testChangingJobStoreID(self):
             """
@@ -317,7 +317,7 @@ class AbstractJobStoreTest(object):
             parentJob2 = jobstore2.load(parentJob1.jobStoreID)
 
             # Create an array of child jobs for each jobstore.
-            for i in range(0,5):
+            for i in range(0, 5):
                 jobNodeOnChild1 = JobNode(command='child' + str(i),
                                           requirements=self.childJobReqs1,
                                           jobName='test' + str(i), unitName='onChild1',
@@ -341,7 +341,7 @@ class AbstractJobStoreTest(object):
             for childJob in parentJob2.stack:
                 self.assertEqual(jobstore1.load(childJob.jobStoreID), childJob)
                 self.assertEqual(jobstore2.load(childJob.jobStoreID), childJob)
-        
+
         @travis_test
         def testJobDeletions(self):
             """Tests the consequences of deleting jobs."""
@@ -401,7 +401,7 @@ class AbstractJobStoreTest(object):
                 self.fail('Expecting NoSuchFileException')
             except NoSuchFileException:
                 pass
-       
+
         @travis_test
         def testSharedFiles(self):
             """Tests the sharing of files."""
@@ -425,7 +425,7 @@ class AbstractJobStoreTest(object):
                 f.write(bar)
             self.assertUrl(jobstore1.getSharedPublicUrl('nonEncrypted'))
             self.assertRaises(NoSuchFileException, jobstore1.getSharedPublicUrl, 'missing')
-       
+
         @travis_test
         def testPerJobFiles(self):
             """Tests the behavior of files on jobs."""
@@ -503,7 +503,7 @@ class AbstractJobStoreTest(object):
                     self.fail('Expecting NoSuchFileException')
                 except NoSuchFileException:
                     pass
-        
+
         @travis_test
         def testStatsAndLogging(self):
             """Tests behavior of reading and writting stats and logging."""
@@ -542,7 +542,7 @@ class AbstractJobStoreTest(object):
             jobstore2.writeStatsAndLogging(one)
             self.assertEqual(1, jobstore1.readStatsAndLogging(callback))
             self.assertEqual({one}, stats)
-            self.assertEqual(0, jobstore1.readStatsAndLogging(callback))   # readStatsAndLogging purges saved stats etc
+            self.assertEqual(0, jobstore1.readStatsAndLogging(callback))  # readStatsAndLogging purges saved stats etc
 
             jobstore2.writeStatsAndLogging(one)
             jobstore2.writeStatsAndLogging(two)
@@ -563,7 +563,7 @@ class AbstractJobStoreTest(object):
             jobstore1.delete(jobOnJobStore1.jobStoreID)
             self.assertFalse(jobstore1.exists(jobOnJobStore1.jobStoreID))
             # TODO: Who deletes the shared files?
-       
+
         @travis_test
         def testWriteLogFiles(self):
             """Test writing log files."""
@@ -578,7 +578,7 @@ class AbstractJobStoreTest(object):
             with open(jobLogFile, 'r') as f:
                 self.assertEqual(f.read(), 'string\nbytes\n\nnewline\n')
             os.remove(jobLogFile)
-       
+
         @travis_test
         def testBatchCreate(self):
             """Test creation of many jobs."""
@@ -594,7 +594,7 @@ class AbstractJobStoreTest(object):
                     jobGraphs.append(jobstore.create(overlargeJobNode))
             for jobGraph in jobGraphs:
                 self.assertTrue(jobstore.exists(jobGraph.jobStoreID))
-       
+
         @travis_test
         def testGrowingAndShrinkingJob(self):
             """Make sure jobs update correctly if they grow/shrink."""
@@ -672,7 +672,7 @@ class AbstractJobStoreTest(object):
         @classmethod
         def makeImportExportTests(cls):
 
-            testClasses = [FileJobStoreTest, AWSJobStoreTest, AzureJobStoreTest, GoogleJobStoreTest]
+            testClasses = [FileJobStoreTest, AWSJobStoreTest, GoogleJobStoreTest]
 
             activeTestClassesByName = {testCls.__name__: testCls
                                        for testCls in testClasses
@@ -741,7 +741,7 @@ class AbstractJobStoreTest(object):
             make_tests(testImportSharedFile,
                        cls,
                        otherCls=activeTestClassesByName)
-       
+
         @travis_test
         def testImportHttpFile(self):
             '''Test importing a file over HTTP.'''
@@ -752,7 +752,8 @@ class AbstractJobStoreTest(object):
                 try:
                     assignedPort = http.server_address[1]
                     url = 'http://localhost:%d' % assignedPort
-                    with self.jobstore_initialized.readFileStream(self.jobstore_initialized.importFile(url)) as readable:
+                    with self.jobstore_initialized.readFileStream(
+                            self.jobstore_initialized.importFile(url)) as readable:
                         f1 = readable.read()
                         f2 = StubHttpRequestHandler.fileContents
                         if isinstance(f1, bytes) and not isinstance(f2, bytes):
@@ -765,7 +766,7 @@ class AbstractJobStoreTest(object):
                     httpThread.join()
             finally:
                 http.server_close()
-       
+
         @travis_test
         def testImportFtpFile(self):
             '''Test importing a file over FTP'''
@@ -795,7 +796,8 @@ class AbstractJobStoreTest(object):
             n = self._batchDeletionSize()
             for numFiles in (1, n - 1, n, n + 1, 2 * n):
                 job = self.jobstore_initialized.create(self.arbitraryJob)
-                fileIDs = [self.jobstore_initialized.getEmptyFileStoreID(job.jobStoreID, cleanup=True) for _ in range(0, numFiles)]
+                fileIDs = [self.jobstore_initialized.getEmptyFileStoreID(job.jobStoreID, cleanup=True) for _ in
+                           range(0, numFiles)]
                 self.jobstore_initialized.delete(job.jobStoreID)
                 for fileID in fileIDs:
                     # NB: the fooStream() methods return context managers
@@ -834,7 +836,8 @@ class AbstractJobStoreTest(object):
                 checksumThread.start()
                 try:
                     with open(random_device, 'rb') as readable:
-                        with self.jobstore_initialized.writeFileStream(job.jobStoreID, cleanup=True) as (writable, fileId):
+                        with self.jobstore_initialized.writeFileStream(job.jobStoreID, cleanup=True) as (
+                        writable, fileId):
                             for i in range(int(partSize * partsPerFile / bufSize)):
                                 buf = readable.read(bufSize)
                                 checksumQueue.put(buf)
@@ -881,7 +884,7 @@ class AbstractJobStoreTest(object):
                 after = checksum.hexdigest()
                 self.assertEqual(before, after)
             self.jobstore_initialized.delete(job.jobStoreID)
-        
+
         @travis_test
         def testZeroLengthFiles(self):
             '''Test reading and writing of empty files.'''
@@ -976,7 +979,6 @@ class AbstractJobStoreTest(object):
             # Running with the cache should be faster.
             self.assertTrue(cacheTime <= noCacheTime)
 
-       
         # NB: the 'thread' method seems to be needed here to actually
         # ensure the timeout is raised, probably because the only
         # "live" thread doesn't hold the GIL.
@@ -1014,7 +1016,7 @@ class AbstractJobStoreTest(object):
             jobstore = self._createJobStore()
             jobstore.destroy()
             # Note that self.jobstore_initialized.destroy() is done as part of shutdown
-       
+
         @travis_test
         def testDestructionIdempotence(self):
             # Jobstore is fully initialized
@@ -1027,7 +1029,7 @@ class AbstractJobStoreTest(object):
             self.jobstore_initialized.destroy()
             cleaner = self._createJobStore()
             cleaner.destroy()
-        
+
         @travis_test
         def testEmptyFileStoreIDIsReadable(self):
             """Simply creates an empty fileStoreID and attempts to read from it."""
@@ -1097,7 +1099,7 @@ class AbstractEncryptedJobStoreTest(object):
             with self.jobstore_initialized.readSharedFileStream(fileName) as f:
                 self.assertEqual(phrase, f.read())
 
-            #disable encryption
+            # disable encryption
             self.jobstore_initialized.config.sseKey = None
             self.jobstore_initialized.config.cseKey = None
             try:
@@ -1143,7 +1145,7 @@ class FileJobStoreTest(AbstractJobStoreTest.Test):
 
     def _cleanUpExternalStore(self, dirPath):
         shutil.rmtree(dirPath)
-    
+
     @travis_test
     def testPreserveFileName(self):
         "Check that the fileID ends with the given file name."
@@ -1207,7 +1209,6 @@ class GoogleJobStoreTest(AbstractJobStoreTest.Test):
 
 @needs_aws
 class AWSJobStoreTest(AbstractJobStoreTest.Test):
-
     def _createJobStore(self):
         from toil.jobStores.aws.jobStore import AWSJobStore
         partSize = self._partSize()
@@ -1216,7 +1217,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
     def _corruptJobStore(self):
         from toil.jobStores.aws.jobStore import AWSJobStore
         assert isinstance(self.jobstore_initialized, AWSJobStore)  # type hinting
-        self.jobstore_initialized.filesBucket.delete()
+        self.jobstore_initialized.destroy()
 
     def testSDBDomainsDeletedOnFailedJobstoreBucketCreation(self):
         """
@@ -1237,7 +1238,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
             testJobStoreUUID = str(uuid.uuid4())
             # Create the bucket at the external region
             s3 = S3Connection()
-            for attempt in retry_s3(delays=(2,5,10,30,60), timeout=600):
+            for attempt in retry_s3(delays=(2, 5, 10, 30, 60), timeout=600):
                 with attempt:
                     bucket = s3.create_bucket('domain-test-' + testJobStoreUUID + '--files',
                                               location=externalAWSLocation)
@@ -1281,21 +1282,15 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
                 with jobstore.readSharedFileStream('foo') as f:
                     self.assertEqual(s, f.read())
 
-    def testInaccessableLocation(self):
-        url = 's3://toil-no-location-bucket-dont-delete/README'
-        with patch('toil.jobStores.aws.jobStore.log') as mock_log:
-            jobStoreID = self.jobstore_initialized.importFile(url)
-            self.assertTrue(self.jobstore_initialized.fileExists(jobStoreID))
-
     def testOverlargeJob(self):
         jobstore = self.jobstore_initialized
         jobRequirements = dict(memory=12, cores=34, disk=35, preemptable=True)
         overlargeJobNode = JobNode(command='overlarge',
-                                    requirements=jobRequirements,
-                                    jobName='test-overlarge', unitName='onJobStore',
-                                    jobStoreID=None, predecessorNumber=0)
+                                   requirements=jobRequirements,
+                                   jobName='test-overlarge', unitName='onJobStore',
+                                   jobStoreID=None, predecessorNumber=0)
 
-        #Make the pickled size of the job larger than 256K
+        # Make the pickled size of the job larger than 256K
         with open("/dev/urandom", "r") as random:
             overlargeJobNode.jobName = random.read(512 * 1024)
         overlargeJob = jobstore.create(overlargeJobNode)
@@ -1388,7 +1383,7 @@ class AzureJobStoreTest(AbstractJobStoreTest.Test):
         from toil.jobStores.azureJobStore import maxAzureTablePropertySize
         command = os.urandom(maxAzureTablePropertySize * 2)
         jobNode1 = self.arbitraryJob
-        jobNode1.command=command
+        jobNode1.command = command
         job1 = self.jobstore_initialized.create(jobNode1)
         self.assertEqual(job1.command, command)
         job2 = self.jobstore_initialized.load(job1.jobStoreID)
@@ -1458,14 +1453,16 @@ class InvalidAzureJobStoreTest(ToilTest):
                           'toiltest:a_b')
 
 
-@needs_aws	
-@needs_encryption	
-@slow	
-class EncryptedAWSJobStoreTest(AWSJobStoreTest, AbstractEncryptedJobStoreTest.Test):	
-    pass	
+@needs_aws
+@needs_encryption
+@slow
+class EncryptedAWSJobStoreTest(AWSJobStoreTest, AbstractEncryptedJobStoreTest.Test):
+    pass
+
 
 class StubHttpRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     fileContents = 'A good programmer looks both ways before crossing a one-way street'
+
     def do_GET(self):
         self.send_response(200)
         self.send_header("Content-type", "text/plain")

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -1175,8 +1175,7 @@ class GoogleJobStoreTest(AbstractJobStoreTest.Test):
         url = 'gs://%s/%s' % (bucket.name, fileName)
         if size is None:
             return url
-        read_type = 'r' if USING_PYTHON2 else 'rb'
-        with open('/dev/urandom', read_type) as readable:
+        with open('/dev/urandom', 'r') as readable:
             contents = readable.read(size)
         GoogleJobStore._writeToUrl(StringIO(contents), urlparse.urlparse(url))
         return url, hashlib.md5(contents).hexdigest()

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -49,6 +49,7 @@ from toil.lib.exceptions import panic
 # (installed by `make prepare`)
 from mock import patch
 
+from toil.lib.compatibility import USING_PYTHON2
 from toil.common import Config, Toil
 from toil.fileStores import FileID
 from toil.job import Job, JobNode
@@ -519,13 +520,8 @@ class AbstractJobStoreTest(object):
 
             # Test stats and logging
             stats = None
-            one = 'one'
-            two = 'two'
-            three = 'three'
-            if sys.version_info >= (3, 0):
-                one = b'one'
-                two = b'two'
-                three = b'three'
+            one = b'one' if not USING_PYTHON2 else 'one'
+            two = b'two' if not USING_PYTHON2 else 'two'
 
             # Allows stats to be read/written to/from in read/writeStatsAndLogging.
             def callback(f2):
@@ -1179,7 +1175,8 @@ class GoogleJobStoreTest(AbstractJobStoreTest.Test):
         url = 'gs://%s/%s' % (bucket.name, fileName)
         if size is None:
             return url
-        with open('/dev/urandom', 'r') as readable:
+        read_type = 'r' if USING_PYTHON2 else 'rb'
+        with open('/dev/urandom', read_type) as readable:
             contents = readable.read(size)
         GoogleJobStore._writeToUrl(StringIO(contents), urlparse.urlparse(url))
         return url, hashlib.md5(contents).hexdigest()
@@ -1291,7 +1288,8 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
                                    jobStoreID=None, predecessorNumber=0)
 
         # Make the pickled size of the job larger than 256K
-        with open("/dev/urandom", "r") as random:
+        read_type = 'r' if USING_PYTHON2 else 'rb'
+        with open("/dev/urandom", read_type) as random:
             overlargeJobNode.jobName = random.read(512 * 1024)
         overlargeJob = jobstore.create(overlargeJobNode)
         self.assertTrue(jobstore.exists(overlargeJob.jobStoreID))

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -1303,7 +1303,8 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
         url = 's3://%s/%s' % (bucket.name, fileName)
         if size is None:
             return url
-        with open('/dev/urandom', 'r') as readable:
+        read_type = 'r' if USING_PYTHON2 else 'rb'
+        with open('/dev/urandom', read_type) as readable:
             bucket.new_key(fileName).set_contents_from_string(readable.read(size))
         return url, hashlib.md5(bucket.get_key(fileName).get_contents_as_string()).hexdigest()
 

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -29,8 +29,8 @@ import signal
 import socket
 import logging
 import shutil
-from threading import Thread
 
+from toil.lib.compatibility import USING_PYTHON2
 from toil.lib.expando import MagicExpando
 from toil.common import Toil, safeUnpickleFromStream
 from toil.fileStores.abstractFileStore import AbstractFileStore
@@ -501,7 +501,10 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
         statsDict.logs.messages = logMessages
 
     if (debugging or config.stats or statsDict.workers.logsToMaster) and not workerFailed:  # We have stats/logging to report back
-        jobStore.writeStatsAndLogging(json.dumps(statsDict, ensure_ascii=True))
+        if USING_PYTHON2:
+            jobStore.writeStatsAndLogging(json.dumps(statsDict, ensure_ascii=True))
+        else:
+            jobStore.writeStatsAndLogging(json.dumps(statsDict, ensure_ascii=True).encode())
 
     #Remove the temp dir
     cleanUp = config.cleanWorkDir


### PR DESCRIPTION
Python2.7 tests are working.  Hopefully python3.6 tests will now follow suit (python3.6 jobstores tests are working in #2749 but I didn't realize until I was a bit further in that they'd broken the python2.7 tests).  This PR should reconcile #2749 and the working python2.7 tests in `master` currently.