### PR TITLE
Fixing Slurm sbatch command (resolves #2774)

### DIFF
--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -170,7 +170,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
         def prepareSbatch(self, cpu, mem, jobID):
             #  Returns the sbatch command line before the script to run
-            sbatch_line = ['sbatch', '-Q', '-J', 'toil_job_{}'.format(jobID)]
+            sbatch_line = ['sbatch', '-J', 'toil_job_{}'.format(jobID)]
 
             if self.boss.environment:
                 argList = []


### PR DESCRIPTION
Removed `-Q` (quiet) option from `sbatch` command in `submitJob` method.
This allows passing Slurm job id to Toil and succesful calling of `submitJob`.