### PR TITLE
Update gridengine.py

### DIFF
--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -127,7 +127,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
 
             stdoutfile = self.boss.formatStdOutErrPath(jobID, 'gridengine', '$JOB_ID', 'std_output')
             stderrfile = self.boss.formatStdOutErrPath(jobID, 'gridengine', '$JOB_ID', 'std_error')
-            sbatch_line.extend(['-o', stdoutfile, '-e', stderrfile])
+            qsubline.extend(['-o', stdoutfile, '-e', stderrfile])
 
             return qsubline
 


### PR DESCRIPTION
noticed this typo trying to run cactus on gridEngine