### PR TITLE
Add --writeLogsFromAllJobs option.

### DIFF
--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -78,9 +78,6 @@ class StatsAndLogging( object ):
         mainFileName = jobNames[0]
         extension = '.log'
 
-        assert not (config.writeLogs and config.writeLogsGzip), \
-            "Cannot use both --writeLogs and --writeLogsGzip at the same time."
-
         if config.writeLogs:
             path = config.writeLogs
             writeFn = open

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -40,6 +40,11 @@ from toil.lib.bioio import setLogLevel
 from toil.lib.bioio import getTotalCpuTime
 from toil.lib.bioio import getTotalCpuTimeAndMemoryUsage
 from toil.deferred import DeferredFunctionManager
+try:
+    from toil.cwl.cwltoil import CWL_INTERNAL_JOBS
+except ImportError:
+    # CWL extra not installed
+    CWL_INTERNAL_JOBS = ()
 
 
 logging.basicConfig()
@@ -489,7 +494,8 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
                 w.write(f.read().encode('utf-8')) # TODO load file using a buffer
         jobStore.update(jobGraph)
 
-    elif debugging and redirectOutputToLogFile:  # write log messages
+    elif ((debugging or (config.writeLogsFromAllJobs and not jobName.startswith(CWL_INTERNAL_JOBS)))
+          and redirectOutputToLogFile):  # write log messages
         with open(tempWorkerLogPath, 'r') as logFile:
             if os.path.getsize(tempWorkerLogPath) > logFileByteReportLimit != 0:
                 if logFileByteReportLimit > 0:


### PR DESCRIPTION
Useful option for debugging without enabling `--logDebug`. This is especially useful when trying to get raw logs from several thousand jobs (`--logDebug` is too verbose and slow).

Fixes #2779 