### PR TITLE
Ensure terminated ignored nodes are cleared from batch system.

### DIFF
--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -685,8 +685,8 @@ class ClusterScaler(object):
         #Remove any nodes that have already been terminated from the list
         # of ignored nodes
         allNodeIPs = [node.privateIP for node in nodeToNodeInfo]
-        terminatedIps = set([ip for ip in self.ignoredNodes if ip not in allNodeIPs])
-        for ip in terminatedIps:
+        terminatedIPs = set([ip for ip in self.ignoredNodes if ip not in allNodeIPs])
+        for ip in terminatedIPs:
             self.ignoredNodes.remove(ip)
             self.leader.batchSystem.unignoreNode(ip)
 

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -671,7 +671,7 @@ class ClusterScaler(object):
         logger.debug('Terminating %i instance(s).', len(nodeToNodeInfo))
         if nodeToNodeInfo:
             for node in nodeToNodeInfo:
-                if node in self.ignoredNodes:
+                if node.privateIP in self.ignoredNodes:
                     self.ignoredNodes.remove(node.privateIP)
                     self.leader.batchSystem.unignoreNode(node.privateIP)
             self.provisioner.terminateNodes(nodeToNodeInfo)
@@ -685,7 +685,10 @@ class ClusterScaler(object):
         #Remove any nodes that have already been terminated from the list
         # of ignored nodes
         allNodeIPs = [node.privateIP for node in nodeToNodeInfo]
-        self.ignoredNodes = set([ip for ip in self.ignoredNodes if ip in allNodeIPs])
+        terminatedIps = set([ip for ip in self.ignoredNodes if ip not in allNodeIPs])
+        for ip in terminatedIps:
+            self.ignoredNodes.remove(ip)
+            self.leader.batchSystem.unignoreNode(ip)
 
         logger.debug("There are %i nodes being ignored by the batch system, "
                     "checking if they can be terminated" % len(self.ignoredNodes))


### PR DESCRIPTION
* Fixes lookup by IP when checking ignored nodes.
* Fixes the case where an ignored worker is terminated externally (e.g. through spot instance termination), but appears with the same IP later (e.g. as part of scaling up).

Fixes #2788 
