### PR TITLE
Make space accounting and directory removal less likely to fail a job

### DIFF
--- a/src/toil/lib/misc.py
+++ b/src/toil/lib/misc.py
@@ -56,6 +56,13 @@ def robust_rmtree(path):
             # Remove it if still present
             robust_rmtree(child_path)
             
+        try:
+            # Actually remove the directory once the children are gone
+            os.rmdir(path)
+        except FileNotFoundError:
+            # Directory went away
+            return
+            
     else:
         # It is not or was not a directory.
         try:

--- a/src/toil/lib/misc.py
+++ b/src/toil/lib/misc.py
@@ -37,8 +37,8 @@ def robust_rmtree(path):
     if not os.path.exists(path):
         # Nothing to do!
         return
-            
-    if os.path.isdir(path):
+        
+    if not os.path.islink(path) and os.path.isdir(path):
         # It is or has been a directory
         
         try:
@@ -54,7 +54,7 @@ def robust_rmtree(path):
             child_path = os.path.join(path, child)
             
             # Remove it if still present
-            robust_rmtree(path)
+            robust_rmtree(child_path)
             
     else:
         # It is not or was not a directory.

--- a/src/toil/lib/misc.py
+++ b/src/toil/lib/misc.py
@@ -4,7 +4,13 @@ from math import sqrt
 import errno
 import os
 import shutil
+import sys
 import time
+
+if sys.version_info[0] < 3:
+    # Define a usable FileNotFoundError as will be raised by os.remove on a
+    # nonexistent file.
+    FileNotFoundError = OSError
 
 
 def mkdir_p(path):
@@ -17,34 +23,47 @@ def mkdir_p(path):
         else:
             raise
 
-def robust_rmtree(path, max_retries=3):
-    """Robustly tries to delete paths.
+def robust_rmtree(path):
+    """
+    Robustly tries to delete paths.
 
-    Retries several times (with increasing delays) if an OSError
-    occurs.  If the final attempt fails, the Exception is propagated
-    to the caller.
-
-    Borrowing patterns from:
-    https://github.com/hashdist/hashdist
+    Continues silently if the path to be removed is already gone, or if it
+    goes away while this function is executing.
+    
+    May raise an error if a path changes between file and directory while the
+    function is executing, or if a permission error is encountered.
     """
     
     if not os.path.exists(path):
         # Nothing to do!
         return
-
-    delay = 1
-    for _ in range(max_retries):
+            
+    if os.path.isdir(path):
+        # It is or has been a directory
+        
         try:
-            shutil.rmtree(path)
-            break
-        except OSError:
-            time.sleep(delay)
-            delay *= 2
-
-    if os.path.exists(path):
-        # Final attempt, pass any Exceptions up to caller.
-        shutil.rmtree(path)
-
+            children = os.listdir(path)
+        except FileNotFoundError:
+            # Directory went away
+            return
+            
+        # We assume the directory going away while we have it open won't upset
+        # the listdir iterator.
+        for child in children:
+            # Get the path for each child item in the directory
+            child_path = os.path.join(path, child)
+            
+            # Remove it if still present
+            robust_rmtree(path)
+            
+    else:
+        # It is not or was not a directory.
+        try:
+            # Unlink it as a normal file
+            os.unlink(path)
+        except FileNotFoundError:
+            # File went away
+            return
 
 def mean(xs):
     """


### PR DESCRIPTION
This PR makes space estimation and cleanup of Toil temp dirs more proof against failing the job if the files we are looking at get deleted out from under us. This is intended to fix #2811, where background Singularity cleanup (which I don't know how to wait on) is still deleting stuff out of a job's temp directory when the job ends.

The downside is that we're willing to report a 0 size for things we fail to measure the size of. I've also changed `robust_rmtree` to do its own recursion, but there's no simple cross-Python way to distinguish File Not Found from other OSErrors, so on Python 2 we will swallow any OSError without retrying, while on Python 3 we will now pass anything other than file not found up to the caller.