### PR TITLE
Drop the long-deprecated cwltoil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,6 @@ def runSetup():
             'console_scripts': [
                 'toil = toil.utils.toilMain:main',
                 '_toil_worker = toil.worker:main',
-                'cwltoil = toil.cwl.cwltoil:main [cwl]',
                 'toil-cwl-runner = toil.cwl.cwltoil:main [cwl]',
                 'toil-wdl-runner = toil.wdl.toilwdl:main',
                 '_toil_mesos_executor = toil.batchSystems.mesos.executor:main [mesos]',


### PR DESCRIPTION
Same entry point is provided by `toil-cwl-runner`