### PR TITLE
Revert "Add wait_until_exists before calling head_object, resolves #2808"

### DIFF
--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -297,10 +297,6 @@ def copyKeyMultipart(srcBucketName, srcKeyName, srcKeyVersion, dstBucketName, ds
 
     dstObject.copy(copySource, ExtraArgs=copyEncryptionArgs)
 
-    # Wait until the object exists before calling head_object
-    object_summary = s3.ObjectSummary(dstObject.bucket_name, dstObject.key)
-    object_summary.wait_until_exists()
-
     # Unfortunately, boto3's managed copy doesn't return the version
     # that it actually copied to. So we have to check immediately
     # after, leaving open the possibility that it may have been


### PR DESCRIPTION
Reverts DataBiosphere/toil#2810

This should hopefully fix our Python 2 integration tests, until we figure out why we keep getting WaitErrors due to "Bad Request"s.