### PR TITLE
Try service account configuration for Kubernetes

### DIFF
--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -730,7 +730,7 @@ def executor():
     logger.debug("Starting executor")
 
     if len(sys.argv) != 2:
-        log.error('Executor requires exactly one base64-encoded argument')
+        logger.error('Executor requires exactly one base64-encoded argument')
         sys.exit(1)
 
     # Take in a base64-encoded pickled dict as our first argument and decode it

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -500,9 +500,10 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                 # Get the statuses of the pod's containers
                 containerStatuses = pod.status.container_statuses
                 if containerStatuses is None or len(containerStatuses) == 0:
-                    # Pod exists but has no container statuses (containers creating or something?)
-                    logger.warning('Polled pod with no container statuses')
-                    logger.warning('Pod: %s', str(pod))
+                    # Pod exists but has no container statuses
+                    # This happens when the pod is just "Scheduled"
+                    # ("PodScheduled" status event) and isn't actually starting
+                    # to run yet.
                     # Can't be stuck in ImagePullBackOff
                     continue
 
@@ -539,7 +540,10 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                 containerStatuses = pod.status.container_statuses
                 
                 if containerStatuses is None or len(containerStatuses) == 0:
-                    # No statuses available
+                    # No statuses available.
+                    # This happens when a pod is "Scheduled". But how could a
+                    # 'done' or 'failed' pod be merely "Scheduled"?
+                    # Complain so we can find out.
                     logger.warning('Exit code and runtime unavailable; pod has no container statuses')
                     logger.warning('Pod: %s', str(pod))
                     exitCode = -1


### PR DESCRIPTION
`kubectl` is clever enough to pick up its config and credentials from an enclosing pod, but the `kubernetes` Python module can't do it by itself.

This PR adds some code to try and grab the Kubernetes configuration form the currently running pod if it can't be obtained from a config file.

This fixes #2850.