### PR TITLE
Issues/2808 head object 404 with encryption

### DIFF
--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -297,6 +297,10 @@ def copyKeyMultipart(srcBucketName, srcKeyName, srcKeyVersion, dstBucketName, ds
 
     dstObject.copy(copySource, ExtraArgs=copyEncryptionArgs)
 
+    # Wait until the object exists before calling head_object
+    object_summary = s3.ObjectSummary(dstObject.bucket_name, dstObject.key)
+    object_summary.wait_until_exists()
+
     # Unfortunately, boto3's managed copy doesn't return the version
     # that it actually copied to. So we have to check immediately
     # after, leaving open the possibility that it may have been

--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -299,7 +299,7 @@ def copyKeyMultipart(srcBucketName, srcKeyName, srcKeyVersion, dstBucketName, ds
 
     # Wait until the object exists before calling head_object
     object_summary = s3.ObjectSummary(dstObject.bucket_name, dstObject.key)
-    object_summary.wait_until_exists()
+    object_summary.wait_until_exists(**destEncryptionArgs)
 
     # Unfortunately, boto3's managed copy doesn't return the version
     # that it actually copied to. So we have to check immediately


### PR DESCRIPTION
This is a correction of PR 2810. Some of the tests in EncryptedAWSJobStoreTest class in jobStoreTest.py were failing. When encryption arguments are added, these pass. 