### PR TITLE
Cactus compatibility fixes

### DIFF
--- a/src/toil/fileStores/__init__.py
+++ b/src/toil/fileStores/__init__.py
@@ -21,6 +21,8 @@ class FileID(str):
     """
     A small wrapper around Python's builtin string class. It is used to represent a file's ID in the file store, and
     has a size attribute that is the file's size in bytes. This object is returned by importFile and writeGlobalFile.
+
+    Calls into the file store can use bare strings; size will be queried from the job store if unavailable in the ID.
     """
 
     def __new__(cls, fileStoreID, *args):

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -104,8 +104,8 @@ class NonCachingFileStore(AbstractFileStore):
 
     def readGlobalFile(self, fileStoreID, userPath=None, cache=True, mutable=False, symlink=False):
         if not isinstance(fileStoreID, FileID):
-            # Don't let the user forge File IDs.
-            raise TypeError('Received file ID not of type FileID: {}'.format(fileStoreID))
+            # Complain if the user forges File IDs.
+            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         if userPath is not None:
             localFilePath = self._resolveAbsoluteLocalPath(userPath)
             if os.path.exists(localFilePath):
@@ -120,8 +120,8 @@ class NonCachingFileStore(AbstractFileStore):
     @contextmanager
     def readGlobalFileStream(self, fileStoreID):
         if not isinstance(fileStoreID, FileID):
-            # Don't let the user forge File IDs.
-            raise TypeError('Received file ID not of type FileID: {}'.format(fileStoreID))
+            # Complain if the user forges File IDs.
+            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         with self.jobStore.readFileStream(fileStoreID) as f:
             yield f
 
@@ -130,8 +130,8 @@ class NonCachingFileStore(AbstractFileStore):
 
     def deleteLocalFile(self, fileStoreID):
         if not isinstance(fileStoreID, FileID):
-            # Don't let the user forge File IDs.
-            raise TypeError('Received file ID not of type FileID: {}'.format(fileStoreID))
+            # Complain if the user forges File IDs.
+            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         try:
             localFilePaths = self.localFileMap.pop(fileStoreID)
         except KeyError:
@@ -142,8 +142,8 @@ class NonCachingFileStore(AbstractFileStore):
 
     def deleteGlobalFile(self, fileStoreID):
         if not isinstance(fileStoreID, FileID):
-            # Don't let the user forge File IDs.
-            raise TypeError('Received file ID not of type FileID: {}'.format(fileStoreID))
+            # Complain if the user forges File IDs.
+            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         try:
             self.deleteLocalFile(fileStoreID)
         except OSError as e:

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -103,9 +103,6 @@ class NonCachingFileStore(AbstractFileStore):
         return FileID.forPath(fileStoreID, absLocalFileName)
 
     def readGlobalFile(self, fileStoreID, userPath=None, cache=True, mutable=False, symlink=False):
-        if not isinstance(fileStoreID, FileID):
-            # Complain if the user forges File IDs.
-            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         if userPath is not None:
             localFilePath = self._resolveAbsoluteLocalPath(userPath)
             if os.path.exists(localFilePath):
@@ -119,9 +116,6 @@ class NonCachingFileStore(AbstractFileStore):
 
     @contextmanager
     def readGlobalFileStream(self, fileStoreID):
-        if not isinstance(fileStoreID, FileID):
-            # Complain if the user forges File IDs.
-            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         with self.jobStore.readFileStream(fileStoreID) as f:
             yield f
 
@@ -129,9 +123,6 @@ class NonCachingFileStore(AbstractFileStore):
         self.jobStore.exportFile(jobStoreFileID, dstUrl)
 
     def deleteLocalFile(self, fileStoreID):
-        if not isinstance(fileStoreID, FileID):
-            # Complain if the user forges File IDs.
-            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         try:
             localFilePaths = self.localFileMap.pop(fileStoreID)
         except KeyError:
@@ -141,9 +132,6 @@ class NonCachingFileStore(AbstractFileStore):
                 os.remove(localFilePath)
 
     def deleteGlobalFile(self, fileStoreID):
-        if not isinstance(fileStoreID, FileID):
-            # Complain if the user forges File IDs.
-            logger.warning('Workflow will not work with caching! Received file ID not of type FileID: %s', str(fileStoreID))
         try:
             self.deleteLocalFile(fileStoreID)
         except OSError as e:
@@ -152,7 +140,7 @@ class NonCachingFileStore(AbstractFileStore):
                 pass
             else:
                 raise
-        self.filesToDelete.add(fileStoreID)
+        self.filesToDelete.add(str(fileStoreID))
 
     def waitForCommit(self):
         # there is no asynchronicity in this file store so no need to block at all

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -909,6 +909,22 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
         raise NotImplementedError()
 
     @abstractmethod
+    def getFileSize(self, jobStoreFileID):
+        """
+        Get the size of the given file in bytes, or 0 if it does not exist when queried.
+
+        Note that job stores which encrypt files might return overestimates of
+        file sizes, since the encrypted file may have been padded to the
+        nearest block, augmented with an initialization vector, etc.
+
+        :param str jobStoreFileID: an ID referencing the file to be checked
+
+        :rtype: int
+        """
+        raise NotImplementedError()
+        
+
+    @abstractmethod
     def updateFile(self, jobStoreFileID, localFilePath):
         """
         Replaces the existing version of a file in the job store. Throws an exception if the file

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -486,6 +486,22 @@ class FileJobStore(AbstractJobStore):
             raise NoSuchFileException(jobStoreFileID)
         return True
 
+    def getFileSize(self, jobStoreFileID):
+        # Duplicate a bunch of fileExists to save on stat calls
+        absPath = self._getFilePathFromId(jobStoreFileID)
+
+        if (not absPath.startswith(self.jobsDir) and
+            not absPath.startswith(self.filesDir) and
+            not absPath.startswith(self.jobFilesDir)):
+            # Don't even look for it, it is out of bounds.
+            raise NoSuchFileException(jobStoreFileID)
+            
+        try:
+            st = os.stat(absPath)
+        except os.error:
+            return 0
+        return st.st_size
+
     @contextmanager
     def updateFileStream(self, jobStoreFileID):
         self._checkJobStoreFileID(jobStoreFileID)

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -280,6 +280,12 @@ class GoogleJobStore(AbstractJobStore):
     def fileExists(self, jobStoreFileID):
         return self.bucket.blob(compat_bytes(jobStoreFileID), encryption_key=self.sseKey).exists()
 
+    @googleRetry
+    def getFileSize(self, jobStoreFileID):
+        if not self.fileExists(jobStoreFileID):
+            return 0
+        return self.bucket.get_blob(compat_bytes(jobStoreFileID), encryption_key=self.sseKey).size
+
     def updateFile(self, jobStoreFileID, localFilePath):
         with open(localFilePath) as f:
             self._writeFile(jobStoreFileID, f, update=True)

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -452,9 +452,11 @@ def buildElement(element, items, itemName):
     itemClocks = []
     itemMemory = []
     for item in items:
-        itemTimes.append(assertNonnegative(float(item["time"]), "time"))
-        itemClocks.append(assertNonnegative(float(item["clock"]), "clock"))
-        itemMemory.append(assertNonnegative(float(item["memory"]), "memory"))
+        # If something lacks an entry, assume it used none of that thing.
+        # This avoids crashing when jobs e.g. aren't done.
+        itemTimes.append(assertNonnegative(float(item.get("time", 0)), "time"))
+        itemClocks.append(assertNonnegative(float(item.get("clock", 0)), "clock"))
+        itemMemory.append(assertNonnegative(float(item.get("memory", 0)), "memory"))
     assert len(itemClocks) == len(itemTimes) == len(itemMemory)
 
     itemWaits=[]


### PR DESCRIPTION
Should fix #2854 by adapting Toil to still allow some of the things that Cactus does that we no longer allow.

This *should*, so far, allow Cactus to keep passing around strings as file IDs, by letting the FileStore recover file size information from the JobStore when it isn't passed along with the ID.