### PR TITLE
Up the disk to the default as well as the memory

### DIFF
--- a/src/toil/jobGraph.py
+++ b/src/toil/jobGraph.py
@@ -117,8 +117,13 @@ class JobGraph(JobNode):
         # batch system)
         if self.memory < config.defaultMemory:
             self._memory = config.defaultMemory
-            logger.warn("We have increased the default memory of the failed job %s to %s bytes",
+            logger.warn("We have increased the memory of the failed job %s to the default of %s bytes",
                         self, self.memory)
+            
+        if self.disk < config.defaultDisk:
+            self._disk = config.defaultDisk
+            logger.warn("We have increased the disk of the failed job %s to the default of %s bytes",
+                        self, self.disk)
 
     def restartCheckpoint(self, jobStore):
         """Restart a checkpoint after the total failure of jobs in its subtree.


### PR DESCRIPTION
This should fix #2879; you should be able to `--restart` with a higher `--defaultDisk` (and a nonzero number of retries) and at least eventually get your job to run through, after one more failure at the old disk limit.

What we might really want is a separation between the default job size and the max job size we will increase to, and some kind of doubling logic that is ideally aware of what limit a job hit when it failed. But this should at least allow recovering a stuck workflow.