### PR TITLE
Change python3.6 ppa to deadsnakes.

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -77,7 +77,7 @@ print(heredoc('''
         > /etc/apt/sources.list.d/nodesource.list \
         && apt-key adv --keyserver keyserver.ubuntu.com --recv 68576280
 
-    RUN add-apt-repository -y ppa:jonathonf/python-3.6
+    RUN add-apt-repository -y ppa:deadsnakes/ppa
     
     RUN apt-get -y update --fix-missing && \
         DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \


### PR DESCRIPTION
The python3.6 package was recently made private by Jonathon: https://launchpad.net/~jonathonf , which leads to the following error when building the docker image:
```
Err:13 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
  403  Forbidden
Ign:14 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main all Packages
Fetched 16.3 MB in 2s (6208 kB/s)
Reading package lists...
W: The repository 'http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial Release' does not have a Release file.
E: Failed to fetch http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu/dists/xenial/main/binary-amd64/Packages  403  Forbidden
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

The deadsnakes ppa contains the required packages.

Fixes #2887