### PR TITLE
Consider pods that are very close to their memory limits to be stuck

### DIFF
--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -478,9 +478,16 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
 
         # Assume the first result is the right one, because of the selector
         # Assume it has exactly one pod, because we made it
+        containers = items[0].get('containers', [{}])
+        
+        if len(containers) == 0:
+            # If there are no containers (because none have started yet?), we can't say we're stuck OOM
+            return False
+        
+        # Otherwise, assume it just has one container.
         # Grab the memory usage string, like 123Ki, and convert to bytes.
         # If anything is missing, assume 0 bytes used.
-        bytesUsed = human2bytes(items[0].get('containers', [{}])[0].get('usage', {}).get('memory', '0'))
+        bytesUsed = human2bytes(containers[0].get('usage', {}).get('memory', '0'))
 
         # Also get the limit out of the pod object's spec
         bytesAllowed = human2bytes(podObject.spec.containers[0].resources.limits['memory'])

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -71,34 +71,14 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
         # reveal on CI.
         logging.getLogger('kubernetes').setLevel(logging.ERROR)
         logging.getLogger('requests_oauthlib').setLevel(logging.ERROR)
-
-        try:
-            # Load ~/.kube/config or KUBECONFIG
-            kubernetes.config.load_kube_config()
-            
-            # We loaded it; we need to figure out our namespace the config-file way
-            
-            # Find all contexts and the active context.
-            # The active context gets us our namespace.
-            contexts, activeContext = kubernetes.config.list_kube_config_contexts()
-            if not contexts:
-                raise RuntimeError("No Kubernetes contexts available in ~/.kube/config or $KUBECONFIG")
-                
-            # Identify the namespace to work in
-            self.namespace = activeContext.get('context', {}).get('namespace', 'default')
-            
-        except TypeError:
-            # Didn't work. Try pod-based credentials in case we are in a pod.
-            try:
-                kubernetes.config.load_incluster_config()
-                
-                # We got pod-based credentials. Our namespace comes from a particular file.
-                self.namespace = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", 'r').read().strip()
-                
-            except kubernetes.config.ConfigException:
-                raise RuntimeError('Could not load Kubernetes configuration from ~/.kube/config, $KUBECONFIG, or current pod.')
-
         
+        # This will hold the last time our Kubernetes credentials were refreshed
+        self.credential_time = None
+        # And this will hold our cache of API objects
+        self._apis = {}
+        
+        # Get our namespace (and our Kubernetes credentials to make sure they exist)
+        self.namespace = self._api('namespace')
 
         # Make a Kubernetes-acceptable version of our username: not too long,
         # and all lowercase letters, numbers, or - or .
@@ -125,11 +105,79 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
         # Set this to True to enable the experimental wait-for-job-update code
         self.enableWatching = True
 
-        # Required APIs needed from kubernetes
-        self.batchApi = kubernetes.client.BatchV1Api()
-        self.coreApi = kubernetes.client.CoreV1Api()
-    
         self.jobIds = set()
+        
+    def _api(self, kind, max_age_seconds = 5 * 60):
+        """
+        The Kubernetes module isn't clever enough to renew its credentials when
+        they are about to expire. See
+        https://github.com/kubernetes-client/python/issues/741.
+        
+        We work around this by making sure that every time we are about to talk
+        to Kubernetes, we have fresh credentials. And we do that by reloading
+        the config and replacing our Kubernetes API objects before we do any
+        Kubernetes things.
+        
+        TODO: We can still get in trouble if a single watch or listing loop
+        goes on longer than our credentials last, though.
+        
+        This method is the Right Way to get any Kubernetes API. You call it
+        with the API you want ('batch' or 'core') and it returns an API object
+        with guaranteed fresh credentials.
+        
+        It also recognizes 'namespace' and returns our namespace as a string.
+        
+        max_age_seconds needs to be << your cluster's credential expiry time.
+        """
+        
+        now = datetime.datetime.now()
+        
+        if self.credential_time is None or (now - self.credential_time).total_seconds() > max_age_seconds:
+            # Credentials need a refresh
+            try:
+                # Load ~/.kube/config or KUBECONFIG
+                kubernetes.config.load_kube_config()
+                # Worked. We're using kube config
+                config_source = 'kube'
+            except TypeError:
+                # Didn't work. Try pod-based credentials in case we are in a pod.
+                try:
+                    kubernetes.config.load_incluster_config()
+                    # Worked. We're using in_cluster config
+                    config_source = 'in_cluster'
+                except kubernetes.config.ConfigException:
+                    raise RuntimeError('Could not load Kubernetes configuration from ~/.kube/config, $KUBECONFIG, or current pod.')
+                  
+        
+        # Now fill in the API objects with these credentials
+        self._apis['batch'] = kubernetes.client.BatchV1Api()
+        self._apis['core'] = kubernetes.client.CoreV1Api()
+        
+        # And save the time
+        self.credential_time = now
+        
+        if kind == 'namespace':
+            # We just need the namespace string
+            if config_source == 'in_cluster':
+                # Our namespace comes from a particular file.
+                return open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", 'r').read().strip()
+            else:
+                # Find all contexts and the active context.
+                # The active context gets us our namespace.
+                contexts, activeContext = kubernetes.config.list_kube_config_contexts()
+                if not contexts:
+                    raise RuntimeError("No Kubernetes contexts available in ~/.kube/config or $KUBECONFIG")
+                    
+                # Identify the namespace to work in
+                return activeContext.get('context', {}).get('namespace', 'default')
+                
+        else:
+            # We need an API object
+            try:
+                return self._apis[kind]
+            except KeyError: 
+                raise RuntimeError("Unknown Kubernetes API type: {}".format(kind))
+        
 
     def setUserScript(self, userScript):
         logger.info('Setting user script for deployment: {}'.format(userScript))
@@ -240,7 +288,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                                           kind="Job")
             
             # Make the job
-            launched = self.batchApi.create_namespaced_job(self.namespace, job)
+            launched = self._api('batch').create_namespaced_job(self.namespace, job)
 
             logger.debug('Launched job: %s', jobName)
             
@@ -303,7 +351,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                 kwargs['field_selector'] = 'status.successful==1'
             if token is not None:
                 kwargs['_continue'] = token
-            results = self.batchApi.list_namespaced_job(self.namespace, **kwargs)
+            results = self._api('batch').list_namespaced_job(self.namespace, **kwargs)
             
             for job in results.items:
                 if self._isJobOurs(job):
@@ -348,7 +396,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
             kwargs = {'label_selector': query}
             if token is not None:
                 kwargs['_continue'] = token
-            results = self.coreApi.list_namespaced_pod(self.namespace, **kwargs)
+            results = self._api('core').list_namespaced_pod(self.namespace, **kwargs)
             
             for pod in results.items:
                 # Return the first pod we find
@@ -376,8 +424,8 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
 
         """
 
-        return self.coreApi.read_namespaced_pod_log(podObject.metadata.name,
-                                                    namespace=self.namespace)
+        return self._api('core').read_namespaced_pod_log(podObject.metadata.name,
+                                                         namespace=self.namespace)
    
     def _getIDForOurJob(self, jobObject):
         """
@@ -411,7 +459,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
 
             if self.enableWatching:
                 for j in self._ourJobObjects():
-                    for event in w.stream(self.coreApi.list_namespaced_pod, self.namespace, timeout_seconds=maxWait):
+                    for event in w.stream(self._api('core').list_namespaced_pod, self.namespace, timeout_seconds=maxWait):
                         pod = event['object']
                         if pod.metadata.name.startswith(self.jobPrefix):
                             if pod.status.phase == 'Failed' or pod.status.phase == 'Succeeded':
@@ -426,9 +474,9 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                                 terminated = pod.status.container_statuses[0].state.terminated
                                 runtime = (terminated.finished_at - terminated.started_at).total_seconds()
                                 result = (jobID, terminated.exit_code, runtime)
-                                self.batchApi.delete_namespaced_job(pod.metadata.owner_references[0].name,
-                                                                    self.namespace,
-                                                                    propagation_policy='Foreground')
+                                self._api('batch').delete_namespaced_job(pod.metadata.owner_references[0].name,
+                                                                         self.namespace,
+                                                                         propagation_policy='Foreground')
 
                                 self._waitForJobDeath(pod.metadata.owner_references[0].name)
                                 return result
@@ -598,9 +646,9 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
         
         try:
             # Delete the job and all dependents (pods)
-            self.batchApi.delete_namespaced_job(jobObject.metadata.name,
-                                                self.namespace,
-                                                propagation_policy='Foreground')
+            self._api('batch').delete_namespaced_job(jobObject.metadata.name,
+                                                     self.namespace,
+                                                     propagation_policy='Foreground')
                                                 
             # That just kicks off the deletion process. Foreground doesn't
             # actually block. See
@@ -632,7 +680,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
         while True:
             try:
                 # Look for the job
-                self.batchApi.read_namespaced_job(jobName, self.namespace)
+                self._api('batch').read_namespaced_job(jobName, self.namespace)
                 # If we didn't 404, wait a bit with exponential backoff
                 time.sleep(backoffTime)
                 if backoffTime < maxBackoffTime:
@@ -662,9 +710,9 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
             # Kill jobs whether they succeeded or failed
             try:
                 # Delete with background poilicy so we can quickly issue lots of commands
-                response = self.batchApi.delete_namespaced_job(jobName, 
-                                                               self.namespace, 
-                                                               propagation_policy='Background')
+                response = self._api('batch').delete_namespaced_job(jobName, 
+                                                                    self.namespace, 
+                                                                    propagation_policy='Background')
                 logger.debug('Killed job for shutdown: %s', jobName)
             except ApiException as e:
                 logger.error("Exception when calling BatchV1Api->delte_namespaced_job: %s" % e)
@@ -731,9 +779,9 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
 
             # Delete the requested job in the foreground.
             # This doesn't block, but it does delete expeditiously.
-            response = self.batchApi.delete_namespaced_job(jobName, 
-                                                           self.namespace, 
-                                                           propagation_policy='Foreground')
+            response = self._api('batch').delete_namespaced_job(jobName, 
+                                                                self.namespace, 
+                                                                propagation_policy='Foreground')
             logger.debug('Killed job by request: %s', jobName)
 
         for jobID in jobIDs:

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -47,6 +47,7 @@ from six.moves.queue import Empty, Queue
 from toil import applianceSelf, customDockerInitCmd
 from toil.batchSystems.abstractBatchSystem import (AbstractBatchSystem,
                                                    BatchSystemLocalSupport)
+from toil.lib.humanize import human2bytes
 from toil.resource import Resource
 
 logger = logging.getLogger(__name__)
@@ -122,8 +123,8 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
         goes on longer than our credentials last, though.
         
         This method is the Right Way to get any Kubernetes API. You call it
-        with the API you want ('batch' or 'core') and it returns an API object
-        with guaranteed fresh credentials.
+        with the API you want ('batch', 'core', or 'customObjects') and it
+        returns an API object with guaranteed fresh credentials.
         
         It also recognizes 'namespace' and returns our namespace as a string.
         
@@ -152,6 +153,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
         # Now fill in the API objects with these credentials
         self._apis['batch'] = kubernetes.client.BatchV1Api()
         self._apis['core'] = kubernetes.client.CoreV1Api()
+        self._apis['customObjects'] = kubernetes.client.CustomObjectsApi()
         
         # And save the time
         self.credential_time = now
@@ -426,7 +428,64 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
 
         return self._api('core').read_namespaced_pod_log(podObject.metadata.name,
                                                          namespace=self.namespace)
-   
+
+    def _isPodStuckOOM(self, podObject, minFreeBytes=1024 * 1024 * 2):
+        """
+        Poll the current memory usage for the pod from the cluster.
+
+        Return True if the pod looks to be in a soft/stuck out of memory (OOM)
+        state, where it is using too much memory to actually make progress, but
+        not enough to actually trigger the OOM killer to kill it. For some
+        large memory limits, on some Kubernetes clusters, pods can get stuck in
+        this state when their memory limits are high (approx. 200 Gi).
+
+        We operationalize "OOM" as having fewer than minFreeBytes bytes free.
+
+        We assume the pod has only one container, as Toil's pods do.
+
+        :param kubernetes.client.V1Pod podObject: a Kubernetes pod with one
+                                       container to check up on.
+        :param int minFreeBytes: Minimum free bytes to not be OOM.
+
+        :return: True if the pod is OOM, false otherwise.
+        :rtype: bool
+        """
+
+        # Compose a query to get just the pod we care about
+        query = 'metadata.name=' + podObject.metadata.name
+
+        # Look for it
+        # TODO: When the Kubernetes Python API actually wraps the metrics API, switch to that
+        response = self._api('customObjects').list_namespaced_custom_object('metrics.k8s.io', 'v1beta1',
+                                                                            self.namespace, 'pods',
+                                                                            field_selector=query)
+
+        # Pull out the items
+        items = response.get('items', [])
+
+        if len(items) == 0:
+            # If there's no statistics we can't say we're stuck OOM
+            return False
+
+        # Assume the first result is the right one, because of the selector
+        # Assume it has exactly one pod, because we made it
+        # Grab the memory usage string, like 123Ki, and convert to bytes.
+        # If anything is missing, assume 0 bytes used.
+        bytesUsed = human2bytes(items[0].get('containers', [{}])[0].get('usage', {}).get('memory', '0'))
+
+        # Also get the limit out of the pod object's spec
+        bytesAllowed = human2bytes(podObject.spec.containers[0].resources.limits['memory'])
+
+        if bytesAllowed - bytesUsed < minFreeBytes:
+            # This is too much!
+            logger.warning('Pod %s has used %d of %d bytes of memory; reporting as stuck due to OOM.',
+                           podObject.metadata.name, bytesUsed, bytesAllowed)
+
+            return True
+
+
+
+
     def _getIDForOurJob(self, jobObject):
         """
         Get the JobID number that belongs to the given job that we own.
@@ -543,8 +602,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                     break
 
         if jobObject is None:
-            # If no jobs are failed, look for jobs with pods with
-            # containers stuck in Waiting with reason ImagePullBackOff
+            # If no jobs are failed, look for jobs with pods that are stuck for various reasons.
             for j in self._ourJobObjects():
                 pod = self._getPodForJob(j)
 
@@ -552,6 +610,8 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                     # Skip jobs with no pod
                     continue
                     
+                # Containers can get stuck in Waiting with reason ImagePullBackOff
+
                 # Get the statuses of the pod's containers
                 containerStatuses = pod.status.container_statuses
                 if containerStatuses is None or len(containerStatuses) == 0:
@@ -572,8 +632,17 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                     logger.warning('Failing stuck job; did you try to run a non-existent Docker image?'
                                    ' Check TOIL_APPLIANCE_SELF.')
                     break
-       
-            
+
+                # Pods can also get stuck nearly but not quite out of memory,
+                # if their memory limits are high and they try to exhaust them.
+
+                if self._isPodStuckOOM(pod):
+                    # We found a job that probably should be OOM! Report it as stuck.
+                    # Polling function takes care of the logging.
+                    jobObject = j
+                    chosenFor = 'stuck'
+                    break
+
         if jobObject is None:
             # Say we couldn't find anything
             return None

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -239,7 +239,9 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
             # Add on a bit for Kubernetes overhead (Toil worker's memory, hot deployed
             # user scripts).
             # Kubernetes needs some lower limit of memory to run the pod at all without
-            # OOMing.
+            # OOMing. We also want to provision some extra space so that when
+            # we test _isPodStuckOOM we never get True unless the job has
+            # exceeded jobNode.memory.
             requirements_dict = {'cpu': jobNode.cores,
                                  'memory': jobNode.memory + 1024 * 1024 * 512,
                                  'ephemeral-storage': jobNode.disk + 1024 * 1024 * 512}


### PR DESCRIPTION
Since we bump up the Toil job's memory request when making the pod, we can safely look for pods that are almost at their memory limits and consider them to be stuck to fix #2858. We might catch some pods that will eventually finish, but those pods will be for Toil jobs that went over their requested memory, so we are allowed to fail them.