### PR TITLE
Add --enableUnlimitedPreemptableRetries option.

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -37,6 +37,10 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Special (fake) exit code for jobs that are lost due to preemption.
+# We use a code that is outside of the normal 0-255 range on purpose here to ensure it
+# doesn't conflict with other exit codes.
+LOST_JOB_EXIT_STATUS = 2550
 
 # A class containing the information required for worker cleanup on shutdown of the batch system.
 WorkerCleanupInfo = namedtuple('WorkerCleanupInfo', (

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -40,7 +40,9 @@ logger = logging.getLogger(__name__)
 
 UpdatedBatchJobInfo = namedtuple('UpdatedBatchJobInfo', (
     'jobID',
-    'exitStatus',  # The exit status (integer value) of the job. 0 implies successful.
+    # The exit status (integer value) of the job. 0 implies successful.
+    # EXIT_STATUS_UNAVAILABLE_VALUE is used when the exit status is not available (e.g. job is lost).
+    'exitStatus',
     'exitReason',  # The exit reason, if available. One of BatchJobExitReason enum.
     'wallTime'))
 
@@ -52,6 +54,9 @@ class BatchJobExitReason(enum.Enum):
     KILLED = 4  # Job killed before finishing.
     ERROR = 5  # Internal error.
 
+
+# Value to use as exitStatus in UpdatedBatchJobInfo.exitStatus when status is not available.
+EXIT_STATUS_UNAVAILABLE_VALUE = 255
 
 # A class containing the information required for worker cleanup on shutdown of the batch system.
 WorkerCleanupInfo = namedtuple('WorkerCleanupInfo', (

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -568,7 +568,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                                 logger.debug("FINISHED")
                                 if containerStatuses is None or len(containerStatuses) == 0: 
                                     logger.debug("No job container statuses for job %s" % (pod.metadata.owner_references[0].name))
-                                    return UpdatedBatchJobInfo(jobID=int(pod.metadata.owner_references[0].name[len(self.jobPrefix):]), exitStatus=-1, wallTime=0)
+                                    return UpdatedBatchJobInfo(jobID=int(pod.metadata.owner_references[0].name[len(self.jobPrefix):]), exitStatus=-1, wallTime=0, exitReason=None)
 
                                 # Get termination onformation from the pod
                                 termination = pod.status.container_statuses[0].state.terminated

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -47,6 +47,7 @@ from six.moves.queue import Empty, Queue
 from toil import applianceSelf, customDockerInitCmd
 from toil.batchSystems.abstractBatchSystem import (AbstractBatchSystem,
                                                    BatchSystemLocalSupport,
+                                                   EXIT_STATUS_UNAVAILABLE_VALUE,
                                                    UpdatedBatchJobInfo)
 from toil.lib.humanize import human2bytes
 from toil.resource import Resource
@@ -568,7 +569,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                                 logger.debug("FINISHED")
                                 if containerStatuses is None or len(containerStatuses) == 0: 
                                     logger.debug("No job container statuses for job %s" % (pod.metadata.owner_references[0].name))
-                                    return UpdatedBatchJobInfo(jobID=int(pod.metadata.owner_references[0].name[len(self.jobPrefix):]), exitStatus=-1, wallTime=0, exitReason=None)
+                                    return UpdatedBatchJobInfo(jobID=int(pod.metadata.owner_references[0].name[len(self.jobPrefix):]), exitStatus=EXIT_STATUS_UNAVAILABLE_VALUE, wallTime=0, exitReason=None)
 
                                 # Get termination onformation from the pod
                                 termination = pod.status.container_statuses[0].state.terminated
@@ -732,7 +733,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                     # Complain so we can find out.
                     logger.warning('Exit code and runtime unavailable; pod has no container statuses')
                     logger.warning('Pod: %s', str(pod))
-                    exitCode = -1
+                    exitCode = EXIT_STATUS_UNAVAILABLE_VALUE
                     # Say it stopped now and started when it was scheduled/submitted.
                     # We still need a strictly positive runtime.
                     runtime = slow_down((utc_now() - startTime).totalSeconds())
@@ -742,7 +743,7 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                     if terminatedInfo is None:
                         logger.warning('Exit code and runtime unavailable; pod stopped without container terminating')
                         logger.warning('Pod: %s', str(pod))
-                        exitCode = -1
+                        exitCode = EXIT_STATUS_UNAVAILABLE_VALUE
                         # Say it stopped now and started when it was scheduled/submitted.
                         # We still need a strictly positive runtime.
                         runtime = slow_down((utc_now() - startTime).totalSeconds())
@@ -770,13 +771,13 @@ class KubernetesBatchSystem(BatchSystemLocalSupport):
                 assert chosenFor == 'stuck'
                 
                 # Synthesize an exit code
-                exitCode = -1
+                exitCode = EXIT_STATUS_UNAVAILABLE_VALUE
                 # Say it ran from when the job was submitted to when the pod got stuck
                 runtime = slow_down((utc_now() - jobSubmitTime).totalSeconds())
         else:
             # The pod went away from under the job.
             logging.warning('Exit code and runtime unavailable; pod vanished')
-            exitCode = -1
+            exitCode = EXIT_STATUS_UNAVAILABLE_VALUE
             # Say it ran from when the job was submitted to when the pod vanished
             runtime = slow_down((utc_now() - jobSubmitTime).totalSeconds())
         

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -46,9 +46,10 @@ from toil import pickle
 from toil.lib.memoize import strict_bool
 from toil import resolveEntryPoint
 from toil.batchSystems.abstractBatchSystem import (AbstractScalableBatchSystem,
+                                                   BatchJobExitReason,
                                                    BatchSystemLocalSupport,
-                                                   LOST_JOB_EXIT_STATUS,
-                                                   NodeInfo)
+                                                   NodeInfo,
+                                                   UpdatedBatchJobInfo)
 from toil.batchSystems.mesos import ToilJob, MesosShape, TaskData, JobQueue
 
 log = logging.getLogger(__name__)
@@ -273,15 +274,14 @@ class MesosBatchSystem(BatchSystemLocalSupport,
                 item = self.updatedJobsQueue.get(timeout=maxWait)
             except Empty:
                 return None
-            jobId, exitValue, wallTime = item
             try:
-                self.intendedKill.remove(jobId)
+                self.intendedKill.remove(item.jobID)
             except KeyError:
-                log.debug('Job %s ended with status %i, took %s seconds.', jobId, exitValue,
-                          '???' if wallTime is None else str(wallTime))
+                log.debug('Job %s ended with status %i, took %s seconds.', item.jobID, item.exitStatus,
+                          '???' if item.wallTime is None else str(item.wallTime))
                 return item
             else:
-                log.debug('Job %s ended naturally before it could be killed.', jobId)
+                log.debug('Job %s ended naturally before it could be killed.', item.jobID)
 
     def nodeInUse(self, nodeIP):
         return nodeIP in self.hostToJobIDs
@@ -590,11 +590,11 @@ class MesosBatchSystem(BatchSystemLocalSupport,
         jobID = int(update.task_id.value)
         log.debug("Job %i is in state '%s' due to reason '%s'.", jobID, update.state, update.reason)
         
-        def jobEnded(_exitStatus, wallTime=None):
+        def jobEnded(_exitStatus, wallTime=None, exitReason=None):
             """
             Notify external observers of the job ending.
             """
-            self.updatedJobsQueue.put((jobID, _exitStatus, wallTime))
+            self.updatedJobsQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=_exitStatus, wallTime=wallTime, exitReason=exitReason))
             agentIP = None
             try:
                 agentIP = self.runningJobMap[jobID].agentIP
@@ -633,7 +633,7 @@ class MesosBatchSystem(BatchSystemLocalSupport,
                     wallTime = float(label['value'])
                     break
             assert(wallTime is not None)
-            jobEnded(0, wallTime=wallTime)
+            jobEnded(0, wallTime=wallTime, exitReason=BatchJobExitReason.FINISHED)
         elif update.state == 'TASK_FAILED':
             try:
                 exitStatus = int(update.message)
@@ -648,14 +648,14 @@ class MesosBatchSystem(BatchSystemLocalSupport,
                             update.message, update.reason,
                             update.executor_id, update.agent_id)
             
-            jobEnded(exitStatus)
+            jobEnded(exitStatus, exitReason=BatchJobExitReason.FAILED)
         elif update.state == 'TASK_LOST':
             log.warning("Job %i is lost. Retrying.", jobID)
-            jobEnded(LOST_JOB_EXIT_STATUS)
+            jobEnded(255, exitReason=BatchJobExitReason.LOST)
         elif update.state in ('TASK_KILLED', 'TASK_ERROR'):
             log.warning("Job %i is in unexpected state %s with message '%s' due to reason '%s'.",
                         jobID, update.state, update.message, update.reason)
-            jobEnded(255)
+            jobEnded(255, exitReason=(BatchJobExitReason.KILLED if update.state == 'TASK_KILLED' else BatchJobExitReason.ERROR))
 
         if 'limitation' in update:
             log.warning("Job limit info: %s" % update.limitation)

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -32,7 +32,7 @@ from threading import Lock, Condition
 from six.moves.queue import Empty, Queue
 
 import toil
-from toil.batchSystems.abstractBatchSystem import BatchSystemSupport, UpdatedBatchJobInfo
+from toil.batchSystems.abstractBatchSystem import BatchSystemSupport, EXIT_STATUS_UNAVAILABLE_VALUE, UpdatedBatchJobInfo
 from toil.lib.threading import cpu_count
 from toil import worker as toil_worker
 from toil.common import Toil
@@ -381,8 +381,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
                         log.error('Could not start job %s: %s', jobID, traceback.format_exc())
                         
                         # Report as failed.
-                        # TODO: what should the exit code be?
-                        self.outputQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=-1, wallTime=0, exitReason=None))
+                        self.outputQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=EXIT_STATUS_UNAVAILABLE_VALUE, wallTime=0, exitReason=None))
 
                         # Free resources
                         self.coreFractions.release(coreFractions)

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -32,7 +32,7 @@ from threading import Lock, Condition
 from six.moves.queue import Empty, Queue
 
 import toil
-from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
+from toil.batchSystems.abstractBatchSystem import BatchSystemSupport, UpdatedBatchJobInfo
 from toil.lib.threading import cpu_count
 from toil import worker as toil_worker
 from toil.common import Toil
@@ -337,7 +337,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
 
         self.runningJobs.pop(jobID)
         if not info.killIntended:
-            self.outputQueue.put((jobID, 0, time.time() - info.time))
+            self.outputQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=0, wallTime=time.time() - info.time, exitReason=None))
 
     def _startChild(self, jobCommand, jobID, coreFractions, jobMemory, jobDisk, environment):
         """
@@ -382,7 +382,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
                         
                         # Report as failed.
                         # TODO: what should the exit code be?
-                        self.outputQueue.put((jobID, -1, 0))
+                        self.outputQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=-1, wallTime=0, exitReason=None))
 
                         # Free resources
                         self.coreFractions.release(coreFractions)
@@ -453,7 +453,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
         if not info.killIntended:
             # Report if the job failed and we didn't kill it.
             # If we killed it then it shouldn't show up in the queue.
-            self.outputQueue.put((jobID, statusCode, time.time() - info.time))
+            self.outputQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=statusCode, wallTime=time.time() - info.time, exitReason=None))
 
         # Free up the job's resources.
         self.coreFractions.release(coreFractions)
@@ -555,10 +555,9 @@ class SingleMachineBatchSystem(BatchSystemSupport):
             item = self.outputQueue.get(timeout=maxWait)
         except Empty:
             return None
-        jobID, exitValue, wallTime = item
-        jobCommand = self.jobs.pop(jobID)
-        log.debug("Ran jobID: %s with exit value: %i", jobID, exitValue)
-        return jobID, exitValue, wallTime
+        self.jobs.pop(item.jobID)
+        log.debug("Ran jobID: %s with exit value: %i", item.jobID, item.exitStatus)
+        return item
 
     @classmethod
     def setOptions(cls, setOption):

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -114,6 +114,7 @@ class Config(object):
 
         # Retrying/rescuing jobs
         self.retryCount = 1
+        self.enableUnlimitedPreemptableRetries = False
         self.maxJobDuration = sys.maxsize
         self.rescueJobsFrequency = 3600
 
@@ -263,6 +264,7 @@ class Config(object):
 
         # Retrying/rescuing jobs
         setOption("retryCount", int, iC(1))
+        setOption("enableUnlimitedPreemptableRetries")
         setOption("maxJobDuration", int, iC(1))
         setOption("rescueJobsFrequency", int, iC(1))
 
@@ -524,6 +526,11 @@ def _addOptions(addGroupFn, config):
     addOptionFn("--retryCount", dest="retryCount", default=None,
                 help=("Number of times to retry a failing job before giving up and "
                       "labeling job failed. default=%s" % config.retryCount))
+    addOptionFn("--enableUnlimitedPreemptableRetries", dest="enableUnlimitedPreemptableRetries",
+                action='store_true', default=False,
+                help=("If set, preemptable failures (or any failure due to an instance getting "
+                      "unexpectedly terminated) would not count towards job failures and "
+                      "--retryCount."))
     addOptionFn("--maxJobDuration", dest="maxJobDuration", default=None,
                 help=("Maximum runtime of a job (in seconds) before we kill it "
                       "(this is a lower bound, and the actual time before killing "

--- a/src/toil/jobGraph.py
+++ b/src/toil/jobGraph.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 import logging
 
+from toil.batchSystems.abstractBatchSystem import BatchJobExitReason
 from toil.job import JobNode
 
 logger = logging.getLogger(__name__)
@@ -103,19 +104,19 @@ class JobGraph(JobNode):
     def __hash__(self):
         return hash(self.jobStoreID)
 
-    def setupJobAfterFailure(self, config, decrementRetryCount=True):
+    def setupJobAfterFailure(self, config, exitReason=None):
         """
-        Reduce the remainingRetryCount if greater than zero (if decrementRetryCount==True)
-        and set the memory to be at least as big as the default memory (in case of
-        exhaustion of memory, which is common).
+        Reduce the remainingRetryCount if greater than zero and set the memory
+        to be at least as big as the default memory (in case of exhaustion of memory,
+        which is common).
         """
-        if decrementRetryCount:
+        if config.enableUnlimitedPreemptableRetries and exitReason == BatchJobExitReason.LOST:
+            logger.info("*Not* reducing retry count (%s) of job %s with ID %s",
+                        self.remainingRetryCount, self, self.jobStoreID)
+        else:
             self.remainingRetryCount = max(0, self.remainingRetryCount - 1)
             logger.warning("Due to failure we are reducing the remaining retry count of job %s with ID %s to %s",
                         self, self.jobStoreID, self.remainingRetryCount)
-        else:
-            logger.info("*Not* reducing retry count (%s) of job %s with ID %s",
-                         self.remainingRetryCount, self, self.jobStoreID)
         # Set the default memory to be at least as large as the default, in
         # case this was a malloc failure (we do this because of the combined
         # batch system)

--- a/src/toil/jobGraph.py
+++ b/src/toil/jobGraph.py
@@ -103,15 +103,19 @@ class JobGraph(JobNode):
     def __hash__(self):
         return hash(self.jobStoreID)
 
-    def setupJobAfterFailure(self, config):
+    def setupJobAfterFailure(self, config, decrementRetryCount=True):
         """
-        Reduce the remainingRetryCount if greater than zero and set the memory
-        to be at least as big as the default memory (in case of exhaustion of memory,
-        which is common).
+        Reduce the remainingRetryCount if greater than zero (if decrementRetryCount==True)
+        and set the memory to be at least as big as the default memory (in case of
+        exhaustion of memory, which is common).
         """
-        self.remainingRetryCount = max(0, self.remainingRetryCount - 1)
-        logger.warning("Due to failure we are reducing the remaining retry count of job %s with ID %s to %s",
-                    self, self.jobStoreID, self.remainingRetryCount)
+        if decrementRetryCount:
+            self.remainingRetryCount = max(0, self.remainingRetryCount - 1)
+            logger.warning("Due to failure we are reducing the remaining retry count of job %s with ID %s to %s",
+                        self, self.jobStoreID, self.remainingRetryCount)
+        else:
+            logger.info("*Not* reducing retry count (%s) of job %s with ID %s",
+                         self.remainingRetryCount, self, self.jobStoreID)
         # Set the default memory to be at least as large as the default, in
         # case this was a malloc failure (we do this because of the combined
         # batch system)

--- a/src/toil/jobGraph.py
+++ b/src/toil/jobGraph.py
@@ -116,19 +116,19 @@ class JobGraph(JobNode):
         else:
             self.remainingRetryCount = max(0, self.remainingRetryCount - 1)
             logger.warning("Due to failure we are reducing the remaining retry count of job %s with ID %s to %s",
-                        self, self.jobStoreID, self.remainingRetryCount)
+                           self, self.jobStoreID, self.remainingRetryCount)
         # Set the default memory to be at least as large as the default, in
         # case this was a malloc failure (we do this because of the combined
         # batch system)
         if self.memory < config.defaultMemory:
             self._memory = config.defaultMemory
             logger.warning("We have increased the default memory of the failed job %s to %s bytes",
-                        self, self.memory)
+                           self, self.memory)
             
         if self.disk < config.defaultDisk:
             self._disk = config.defaultDisk
             logger.warning("We have increased the disk of the failed job %s to the default of %s bytes",
-                        self, self.disk)
+                           self, self.disk)
 
     def restartCheckpoint(self, jobStore):
         """Restart a checkpoint after the total failure of jobs in its subtree.

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -35,7 +35,6 @@ try:
 except ImportError:
     # CWL extra not installed
     CWL_INTERNAL_JOBS = ()
-from toil.batchSystems.abstractBatchSystem import LOST_JOB_EXIT_STATUS
 from toil.jobStores.abstractJobStore import NoSuchJobException
 from toil.lib.throttle import LocalThrottle
 from toil.provisioners.clusterScaler import ScalerThread
@@ -481,7 +480,9 @@ class Leader(object):
 
     def _gatherUpdatedJobs(self, updatedJobTuple):
         """Gather any new, updated jobGraph from the batch system"""
-        jobID, result, wallTime = updatedJobTuple
+        jobID, exitStatus, exitReason, wallTime = (
+            updatedJobTuple.jobID, updatedJobTuple.exitStatus, updatedJobTuple.exitReason,
+            updatedJobTuple.wallTime)
         # easy, track different state
         try:
             updatedJob = self.jobBatchSystemIDToIssuedJob[jobID]
@@ -489,7 +490,7 @@ class Leader(object):
             logger.warning("A result seems to already have been processed "
                         "for job %s", jobID)
         else:
-            if result == 0:
+            if exitStatus == 0:
                 cur_logger = (logger.debug if str(updatedJob.jobName).startswith(CWL_INTERNAL_JOBS)
                               else logger.info)
                 cur_logger('Job ended: %s', updatedJob)
@@ -497,8 +498,8 @@ class Leader(object):
                     self.toilMetrics.logCompletedJob(updatedJob)
             else:
                 logger.warning('Job failed with exit value %i: %s',
-                            result, updatedJob)
-            self.processFinishedJob(jobID, result, wallTime=wallTime)
+                               exitStatus, updatedJob)
+            self.processFinishedJob(jobID, exitStatus, wallTime=wallTime, exitReason=exitReason)
 
     def _processLostJobs(self):
         """Process jobs that have gone awry"""
@@ -760,7 +761,7 @@ class Leader(object):
                         "job %s seems to have finished and been removed", issuedJob)
         self._updatePredecessorStatus(issuedJob.jobStoreID)
 
-    def processFinishedJob(self, batchSystemID, resultStatus, wallTime=None):
+    def processFinishedJob(self, batchSystemID, resultStatus, wallTime=None, exitReason=None):
         """
         Function reads a processed jobGraph file and updates its state.
         """
@@ -834,9 +835,7 @@ class Leader(object):
                             else:
                                 logger.warning('The batch system left an empty file %s' % batchSystemFile)
 
-                # Do not decrement retry count for lost jobs (i.e. due to preemptable failures).
-                decrementRetryCount = not self.config.enableUnlimitedPreemptableRetries or resultStatus != LOST_JOB_EXIT_STATUS
-                jobGraph.setupJobAfterFailure(self.config, decrementRetryCount=decrementRetryCount)
+                jobGraph.setupJobAfterFailure(self.config, exitReason=exitReason)
                 self.jobStore.update(jobGraph)
             elif jobStoreID in self.toilState.hasFailedSuccessors:
                 # If the job has completed okay, we can remove it from the list of jobs with failed successors

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -178,7 +178,8 @@ class hidden(object):
                                jobStoreID='3', requirements=defaultRequirements)
             job3 = self.batchSystem.issueBatchJob(jobNode3)
 
-            jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+            jobUpdateInfo = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+            jobID, exitStatus, wallTime = jobUpdateInfo.jobID, jobUpdateInfo.exitStatus, jobUpdateInfo.wallTime
             log.info('Third job completed: {} {} {}'.format(jobID, exitStatus, wallTime))
 
             # Since the first two jobs were killed, the only job in the updated jobs queue should
@@ -212,7 +213,8 @@ class hidden(object):
             jobNode4 = JobNode(command=command, jobName='test4', unitName=None,
                                jobStoreID='4', requirements=defaultRequirements)
             job4 = self.batchSystem.issueBatchJob(jobNode4)
-            jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+            jobUpdateInfo = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+            jobID, exitStatus, wallTime = jobUpdateInfo.jobID, jobUpdateInfo.exitStatus, jobUpdateInfo.wallTime
             self.assertEqual(exitStatus, 42)
             self.assertEqual(jobID, job4)
             # Now set the variable and ensure that it is present
@@ -220,9 +222,9 @@ class hidden(object):
             jobNode5 = JobNode(command=command, jobName='test5', unitName=None,
                                jobStoreID='5', requirements=defaultRequirements)
             job5 = self.batchSystem.issueBatchJob(jobNode5)
-            jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
-            self.assertEqual(exitStatus, 23)
-            self.assertEqual(jobID, job5)
+            jobUpdateInfo = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+            self.assertEqual(jobUpdateInfo.exitStatus, 23)
+            self.assertEqual(jobUpdateInfo.jobID, job5)
         
         def testCheckResourceRequest(self):
             if isinstance(self.batchSystem, BatchSystemSupport):
@@ -527,7 +529,7 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                             while jobIds:
                                 job = bs.getUpdatedBatchJob(maxWait=10)
                                 self.assertIsNotNone(job)
-                                jobId, status, wallTime = job
+                                jobId, status, wallTime = job.jobID, job.exitStatus, job.wallTime
                                 self.assertEqual(status, 0)
                                 # would raise KeyError on absence
                                 jobIds.remove(jobId)


### PR DESCRIPTION
This change adds the option to set `--retryCount` to a low value since spot/premptable terminations no longer count as failures.

I decided to use `2550` as the exit code for lost jobs, but open to other suggestions as well! Rationale:
* Using anything but an int can result in unexpected bugs, since there could be assumptions in the code about the nature of the arg (now or in the future).
* Using anything in 0-255 can be problematic as it can conflict with other values.
* Using `-1` is also a good option, but I figured it's a 'common' special value and someone else could use it for something else accidentally.

Tested with and without `--enableUnlimitedPreemptableRetries` on a pipeline and forced terminations.

Fixes #2890 