### PR TITLE
Set up Gitlab testing for Kubernetes runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,40 +34,40 @@ py2_batch_systems:
     - cp "$GITLAB_SECRET_FILE_KUBE_CONFIG" ~/.kube/config
     - mkdir -p ~/.aws
     - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-    - python -m pytest -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest -r s src/toil/test/mesos/MesosDataStructuresTest.py
+    - python -m pytest -v -r s src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest -v -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py2_cwl:
   stage: test
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/cwl/cwlTest.py
+    - python -m pytest -v src/toil/test/cwl/cwlTest.py
 
 py2_wdl:
   stage: test
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/wdl/toilwdlTest.py
+    - python -m pytest -v src/toil/test/wdl/toilwdlTest.py
 
 py2_jobstore_and_provisioning:
   stage: test
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/sort/sortTest.py
-    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
-    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
+    - python -m pytest -v src/toil/test/sort/sortTest.py
+    - python -m pytest -v src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - python -m pytest -v src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest -v src/toil/test/provisioners/gceProvisionerTest.py
 
 py2_main:
   stage: main_tests
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -vv --timeout=1500 src/toil/test/src
-    - python -m pytest -vv --timeout=1500 src/toil/test/utils
+    - python -m pytest -v --timeout=1500 src/toil/test/src
+    - python -m pytest -v --timeout=1500 src/toil/test/utils
 
 py2_appliance_build:
   stage: main_tests
@@ -94,7 +94,7 @@ py2_integration_jobstore:
     - python setup_gitlab_ssh.py
     - mkdir -p ~/.aws
     - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest -v src/toil/test/jobStores/jobStoreTest.py
 
 py2_integration_sort:
   stage: integration
@@ -109,8 +109,8 @@ py2_integration_sort:
     - python setup_gitlab_ssh.py
     - mkdir -p ~/.aws
     - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-    - python -m pytest src/toil/test/sort/sortTest.py
-    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest -v src/toil/test/sort/sortTest.py
+    - python -m pytest -v src/toil/test/provisioners/clusterScalerTest.py
 
 #py2_integration_provisioner:
 #  stage: integration
@@ -125,7 +125,7 @@ py2_integration_sort:
 #    - python setup_gitlab_ssh.py
 #    - mkdir -p ~/.aws
 #    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-#    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    - python -m pytest -v src/toil/test/provisioners/aws/awsProvisionerTest.py
 
 
 # Python3.6
@@ -135,41 +135,41 @@ py3_batch_systems:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python -m pytest -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest -r s src/toil/test/mesos/MesosDataStructuresTest.py
+    - python -m pytest -v -r s src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest -v -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py3_cwl:
   stage: test
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/cwl/cwlTest.py
+    - python -m pytest -v src/toil/test/cwl/cwlTest.py
 
 py3_wdl:
   stage: test
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/wdl/toilwdlTest.py
+    - python -m pytest -v src/toil/test/wdl/toilwdlTest.py
 
 py3_jobstore_and_provisioning:
   stage: test
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
-    - python -m pytest src/toil/test/sort/sortTest.py
-    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
-    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
+    - python -m pytest -v src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest -v src/toil/test/sort/sortTest.py
+    - python -m pytest -v src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - python -m pytest -v src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest -v src/toil/test/provisioners/gceProvisionerTest.py
 
 py3_main:
   stage: main_tests
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -vv --timeout=1500 src/toil/test/src
-    - python -m pytest -vv --timeout=1500 src/toil/test/utils
+    - python -m pytest -v --timeout=1500 src/toil/test/src
+    - python -m pytest -v --timeout=1500 src/toil/test/utils
 
 #py3_integration:
 #  stage: integration
@@ -184,4 +184,4 @@ py3_main:
 #    - python setup_gitlab_ssh.py
 #    - mkdir -p ~/.aws
 #    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-#    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
+#    - python -m pytest -v src/toil/test/jobStores/jobStoreTest.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,41 +34,40 @@ py2_batch_systems:
     - cp "$GITLAB_SECRET_FILE_KUBE_CONFIG" ~/.kube/config
     - mkdir -p ~/.aws
     - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-    - python -m pytest -v -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest -v -r s src/toil/test/mesos/MesosDataStructuresTest.py
+    - python -m pytest -r s src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py2_cwl:
   stage: test
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v src/toil/test/cwl/cwlTest.py
+    - python -m pytest src/toil/test/cwl/cwlTest.py
 
 py2_wdl:
   stage: test
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v src/toil/test/wdl/toilwdlTest.py
+    - python -m pytest src/toil/test/wdl/toilwdlTest.py
 
 py2_jobstore_and_provisioning:
   stage: test
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v src/toil/test/sort/sortTest.py
-    - python -m pytest -v src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest -v src/toil/test/provisioners/clusterScalerTest.py
-    - python -m pytest -v src/toil/test/provisioners/gceProvisionerTest.py
+    - python -m pytest src/toil/test/sort/sortTest.py
+    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
 
 py2_main:
   stage: main_tests
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v -s --timeout 60 src/toil/test/src/deferredFunctionTest.py::DeferredFunctionTest::testNewJobsCanHandleOtherJobDeaths
-    - python -m pytest -v src/toil/test/src
-    - python -m pytest -v src/toil/test/utils
+    - python -m pytest src/toil/test/src
+    - python -m pytest src/toil/test/utils
 
 py2_appliance_build:
   stage: main_tests
@@ -95,7 +94,7 @@ py2_integration_jobstore:
     - python setup_gitlab_ssh.py
     - mkdir -p ~/.aws
     - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-    - python -m pytest -v src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
 
 py2_integration_sort:
   stage: integration
@@ -110,8 +109,8 @@ py2_integration_sort:
     - python setup_gitlab_ssh.py
     - mkdir -p ~/.aws
     - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-    - python -m pytest -v src/toil/test/sort/sortTest.py
-    - python -m pytest -v src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest src/toil/test/sort/sortTest.py
+    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
 
 #py2_integration_provisioner:
 #  stage: integration
@@ -126,7 +125,7 @@ py2_integration_sort:
 #    - python setup_gitlab_ssh.py
 #    - mkdir -p ~/.aws
 #    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-#    - python -m pytest -v src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
 
 
 # Python3.6
@@ -136,41 +135,41 @@ py3_batch_systems:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python -m pytest -v -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest -v -r s src/toil/test/mesos/MesosDataStructuresTest.py
+    - python -m pytest -r s src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py3_cwl:
   stage: test
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v src/toil/test/cwl/cwlTest.py
+    - python -m pytest src/toil/test/cwl/cwlTest.py
 
 py3_wdl:
   stage: test
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v src/toil/test/wdl/toilwdlTest.py
+    - python -m pytest src/toil/test/wdl/toilwdlTest.py
 
 py3_jobstore_and_provisioning:
   stage: test
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v src/toil/test/jobStores/jobStoreTest.py
-    - python -m pytest -v src/toil/test/sort/sortTest.py
-    - python -m pytest -v src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest -v src/toil/test/provisioners/clusterScalerTest.py
-    - python -m pytest -v src/toil/test/provisioners/gceProvisionerTest.py
+    - python -m pytest src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest src/toil/test/sort/sortTest.py
+    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
+    - python -m pytest src/toil/test/provisioners/gceProvisionerTest.py
 
 py3_main:
   stage: main_tests
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v src/toil/test/src
-    - python -m pytest -v src/toil/test/utils
+    - python -m pytest src/toil/test/src
+    - python -m pytest src/toil/test/utils
 
 #py3_integration:
 #  stage: integration
@@ -185,4 +184,4 @@ py3_main:
 #    - python setup_gitlab_ssh.py
 #    - mkdir -p ~/.aws
 #    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
-#    - python -m pytest -v src/toil/test/jobStores/jobStoreTest.py
+#    - python -m pytest src/toil/test/jobStores/jobStoreTest.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,11 +29,11 @@ py2_batch_systems:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # Get Kubernetes credentials before switching over to another AWS account
+    # Get Kubernetes credentials
     - mkdir -p ~/.kube
-    - aws secretsmanager get-secret-value --secret-id allspark/runner/kubeconfig --region us-west-2 | jq -r .SecretString > ~/.kube/config
+    - cp "$GITLAB_SECRET_FILE_KUBE_CONFIG" ~/.kube/config
     - mkdir -p ~/.aws
-    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
     - python -m pytest -r s src/toil/test/batchSystems/batchSystemTest.py
     - python -m pytest -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
@@ -75,6 +75,7 @@ py2_appliance_build:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
     - python setup_gitlab_docker.py
     - export TOIL_APPLIANCE_SELF=quay.io/ucsc_cgl/toil:$(python version_template.py dockerTag)
     - echo $TOIL_APPLIANCE_SELF
@@ -89,9 +90,10 @@ py2_integration_jobstore:
     - export TOIL_TEST_INTEGRATIVE=True
     - export TOIL_AWS_KEYNAME=id_rsa
     - export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
     - python setup_gitlab_ssh.py
     - mkdir -p ~/.aws
-    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
     - python -m pytest src/toil/test/jobStores/jobStoreTest.py
 
 py2_integration_sort:
@@ -103,9 +105,10 @@ py2_integration_sort:
     - export TOIL_TEST_INTEGRATIVE=True
     - export TOIL_AWS_KEYNAME=id_rsa
     - export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
     - python setup_gitlab_ssh.py
     - mkdir -p ~/.aws
-    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
     - python -m pytest src/toil/test/sort/sortTest.py
     - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
 
@@ -118,9 +121,10 @@ py2_integration_sort:
 #    - export TOIL_TEST_INTEGRATIVE=True
 #    - export TOIL_AWS_KEYNAME=id_rsa
 #    - export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
 #    - python setup_gitlab_ssh.py
 #    - mkdir -p ~/.aws
-#    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+#    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
 #    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
 
 
@@ -176,7 +180,8 @@ py3_main:
 #    - export TOIL_TEST_INTEGRATIVE=True
 #    - export TOIL_AWS_KEYNAME=id_rsa
 #    - export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
 #    - python setup_gitlab_ssh.py
 #    - mkdir -p ~/.aws
-#    - echo -e $(aws secretsmanager get-secret-value --secret-id allspark/runner/credentials --region us-west-2 | jq -r .SecretString) > ~/.aws/credentials
+#    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
 #    - python -m pytest src/toil/test/jobStores/jobStoreTest.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,8 +66,8 @@ py2_main:
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/src
-    - python -m pytest src/toil/test/utils
+    - python -m pytest -vv --timeout=1500 src/toil/test/src
+    - python -m pytest -vv --timeout=1500 src/toil/test/utils
 
 py2_appliance_build:
   stage: main_tests
@@ -168,8 +168,8 @@ py3_main:
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest src/toil/test/src
-    - python -m pytest src/toil/test/utils
+    - python -m pytest -vv --timeout=1500 src/toil/test/src
+    - python -m pytest -vv --timeout=1500 src/toil/test/utils
 
 #py3_integration:
 #  stage: integration

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,8 +66,9 @@ py2_main:
   script:
     - pwd
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v --timeout=1500 src/toil/test/src
-    - python -m pytest -v --timeout=1500 src/toil/test/utils
+    - python -m pytest -v -s --timeout 60 src/toil/test/src/deferredFunctionTest.py::DeferredFunctionTest::testNewJobsCanHandleOtherJobDeaths
+    - python -m pytest -v src/toil/test/src
+    - python -m pytest -v src/toil/test/utils
 
 py2_appliance_build:
   stage: main_tests
@@ -168,8 +169,8 @@ py3_main:
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -v --timeout=1500 src/toil/test/src
-    - python -m pytest -v --timeout=1500 src/toil/test/utils
+    - python -m pytest -v src/toil/test/src
+    - python -m pytest -v src/toil/test/utils
 
 #py3_integration:
 #  stage: integration

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,8 @@
+image: quay.io/vgteam/vg_ci_prebake:latest
+# Note that we must run in a priviliged container for our internal Docker daemon to come up.
+
 before_script:
+  - startdocker || true
   - docker info
   - cat /etc/hosts
   - export PYTHONIOENCODING=utf-8
@@ -9,6 +13,7 @@ after_script:
   # that next job.
   - pwd
   - sudo rm -rf tmp
+  - stopdocker || true
 
 
 stages:

--- a/Makefile
+++ b/Makefile
@@ -181,18 +181,24 @@ define tag_docker
 endef
 
 docker: docker/Dockerfile
+	# Pre-pull everything
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull ubuntu:16.04 && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull prom/prometheus:v2.0.0 && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull grafana/grafana && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull sscaling/mtail && break || sleep 60; done
+
 	@set -ex \
 	; cd docker \
 	; docker build --tag=$(docker_image):$(docker_tag) -f Dockerfile .
-
+	
 	@set -ex \
 	; cd dashboard/prometheus \
 	; docker build --tag=$(prometheus_image):$(docker_tag) -f Dockerfile .
-
+	
 	@set -ex \
 	; cd dashboard/grafana \
 	; docker build --tag=$(grafana_image):$(docker_tag) -f Dockerfile .
-
+	
 	@set -ex \
 	; cd dashboard/mtail \
 	; docker build --tag=$(mtail_image):$(docker_tag) -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -182,10 +182,10 @@ endef
 
 docker: docker/Dockerfile
 	# Pre-pull everything
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull ubuntu:16.04 && break || sleep 60; done
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull prom/prometheus:v2.0.0 && break || sleep 60; done
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull grafana/grafana && break || sleep 60; done
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker pull sscaling/mtail && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull ubuntu:16.04 && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull prom/prometheus:v2.0.0 && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull grafana/grafana && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull sscaling/mtail && break || sleep 60; done
 
 	@set -ex \
 	; cd docker \

--- a/Makefile
+++ b/Makefile
@@ -208,10 +208,11 @@ clean_docker:
 	-docker rmi $(docker_image):$(docker_tag)
 
 push_docker: docker
-	for i in $$(seq 1 5); do docker push $(docker_image):$(docker_tag) && break || sleep 60; done
-	for i in $$(seq 1 5); do docker push $(grafana_image):$(docker_tag) && break || sleep 60; done
-	for i in $$(seq 1 5); do docker push $(prometheus_image):$(docker_tag) && break || sleep 60; done
-	for i in $$(seq 1 5); do docker push $(mtail_image):$(docker_tag) && break || sleep 60; done
+	# Weird if logic is so we fail if all the pushes fail
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker push $(docker_image):$(docker_tag) && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker push $(grafana_image):$(docker_tag) && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker push $(prometheus_image):$(docker_tag) && break || sleep 60; done
+	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker push $(mtail_image):$(docker_tag) && break || sleep 60; done
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -182,10 +182,10 @@ endef
 
 docker: docker/Dockerfile
 	# Pre-pull everything
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull ubuntu:16.04 && break || sleep 60; done
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull prom/prometheus:v2.0.0 && break || sleep 60; done
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull grafana/grafana && break || sleep 60; done
-	for i in $$(seq 1 6); do if [[ $$i == "6" ]] ; then exit 1 ; fi ; docker info ; docker pull sscaling/mtail && break || sleep 60; done
+	for i in $$(seq 1 11); do if [[ $$i == "11" ]] ; then exit 1 ; fi ; docker pull ubuntu:16.04 && break || sleep 60; done
+	for i in $$(seq 1 11); do if [[ $$i == "11" ]] ; then exit 1 ; fi ; docker pull prom/prometheus:v2.0.0 && break || sleep 60; done
+	for i in $$(seq 1 11); do if [[ $$i == "11" ]] ; then exit 1 ; fi ; docker pull grafana/grafana && break || sleep 60; done
+	for i in $$(seq 1 11); do if [[ $$i == "11" ]] ; then exit 1 ; fi ; docker pull sscaling/mtail && break || sleep 60; done
 
 	@set -ex \
 	; cd docker \

--- a/setup_gitlab_docker.py
+++ b/setup_gitlab_docker.py
@@ -1,5 +1,6 @@
 import subprocess
 import json
+import sys
 
 p = subprocess.Popen('aws secretsmanager --region us-west-2 get-secret-value --secret-id /toil/gitlab/quay',
                      stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
@@ -17,3 +18,4 @@ try:
         raise RuntimeError
 except:
     print('While attempting to log into quay.io:\n' + str(stderr))
+    sys.exit(1)

--- a/setup_gitlab_docker.py
+++ b/setup_gitlab_docker.py
@@ -1,13 +1,14 @@
-import subprocess
 import json
+import os
+import subprocess
 import sys
 
-p = subprocess.Popen('aws secretsmanager --region us-west-2 get-secret-value --secret-id /toil/gitlab/quay',
-                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-stdout, stderr = p.communicate()
+stderr = 'Login was not attempted'
 
 try:
-    keys = json.loads(json.loads(stdout)['SecretString'])
+    with open(os.environ['GITLAB_SECRET_FILE_QUAY_CREDENTIALS'], 'r') as cred_json_file:
+        keys = json.loads(cred_json_file.read())
+    
     process = subprocess.Popen('docker login quay.io -u "{user}" --password-stdin'.format(user=keys['user']),
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE,
                                shell=True)
@@ -17,5 +18,5 @@ try:
     else:
         raise RuntimeError
 except:
-    print('While attempting to log into quay.io:\n' + str(stderr))
+    print('Error while attempting to log into quay.io:\n' + str(stderr))
     sys.exit(1)

--- a/setup_gitlab_docker.py
+++ b/setup_gitlab_docker.py
@@ -19,7 +19,7 @@ try:
         sys.exit(1)
         
     print('Opening key file...')
-    with open(env_var, 'r') as cred_json_file:
+    with open(filename, 'r') as cred_json_file:
         print('Reading keys...')
         keys = json.loads(cred_json_file.read())
         print('Read and decoded keys')

--- a/setup_gitlab_docker.py
+++ b/setup_gitlab_docker.py
@@ -5,13 +5,30 @@ import sys
 
 stderr = 'Login was not attempted'
 
+env_var = 'GITLAB_SECRET_FILE_QUAY_CREDENTIALS'
+
 try:
-    with open(os.environ['GITLAB_SECRET_FILE_QUAY_CREDENTIALS'], 'r') as cred_json_file:
+    if env_var not in os.environ:
+        print('Error: could not find environment variable ' + env_var)
+        sys.exit(1)
+
+    filename = os.environ[env_var]
+
+    if not os.path.exists(filename):
+        print('Error: could not find file referenced by ' + env_var)
+        sys.exit(1)
+        
+    print('Opening key file...')
+    with open(env_var, 'r') as cred_json_file:
+        print('Reading keys...')
         keys = json.loads(cred_json_file.read())
+        print('Read and decoded keys')
     
+    print('Starting login process...')
     process = subprocess.Popen('docker login quay.io -u "{user}" --password-stdin'.format(user=keys['user']),
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE,
                                shell=True)
+    print('Logging in...')
     stdout, stderr = process.communicate(input=keys['password'])
     if 'Login Succeeded' in stdout:
         print('Login Succeeded')

--- a/setup_gitlab_ssh.py
+++ b/setup_gitlab_ssh.py
@@ -1,19 +1,18 @@
-import subprocess
 import json
 import os
-
-p = subprocess.Popen('aws secretsmanager --region us-west-2 get-secret-value --secret-id /toil/gitlab/ssh_key',
-                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-stdout, stderr = p.communicate()
+import subprocess
+import sys
 
 good_spot = os.path.expanduser('~/.ssh')
 os.mkdir(good_spot)
 
 try:
-    keys = json.loads(json.loads(stdout)['SecretString'])
+    with open(os.environ['GITLAB_SECRET_FILE_SSH_KEYS'], 'r') as keys_json_file:
+        keys = json.loads(keys_json_file.read())
     with open(os.path.join(good_spot, 'id_rsa.pub'), 'w') as f:
         f.write(keys['public'])
     with open(os.path.join(good_spot, 'id_rsa'), 'w') as f:
         f.write(keys['private'])
 except:
-    print('While attempting to set up the ssh key:\n' + str(stderr))
+    print('While attempting to set up the ssh keys.')
+    sys.exit(1)

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -40,6 +40,7 @@ from pymesos import MesosExecutorDriver, Executor, decode_data, encode_data
 
 from toil import subprocess, pickle
 from toil.lib.expando import Expando
+from toil.lib.threading import cpu_count
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
 from toil.resource import Resource
 
@@ -132,7 +133,7 @@ class MesosExecutor(Executor):
             else:
                 message.nodeInfo = dict(coresUsed=float(psutil.cpu_percent()) * .01,
                                         memoryUsed=float(psutil.virtual_memory().percent) * .01,
-                                        coresTotal=psutil.cpu_count(),
+                                        coresTotal=cpu_count(),
                                         memoryTotal=psutil.virtual_memory().total,
                                         workers=len(self.runningTasks))
             log.debug("Send framework message: %s", message)

--- a/src/toil/batchSystems/mesos/test/__init__.py
+++ b/src/toil/batchSystems/mesos/test/__init__.py
@@ -9,7 +9,6 @@ import logging
 import shutil
 import threading
 from toil import subprocess
-import multiprocessing
 from past.builtins import basestring
 from six.moves.urllib.request import urlopen
 from contextlib import closing
@@ -17,7 +16,7 @@ import time
 
 from toil.lib.retry import retry
 from toil import which  # replace with shutil.which() directly; python3 only
-from toil.lib.threading import ExceptionalThread
+from toil.lib.threading import ExceptionalThread, cpu_count
 from future.utils import with_metaclass
 
 log = logging.getLogger(__name__)
@@ -30,7 +29,7 @@ class MesosTestSupport(object):
 
     def _startMesos(self, numCores=None):
         if numCores is None:
-            numCores = multiprocessing.cpu_count()
+            numCores = cpu_count()
         shutil.rmtree('/tmp/mesos', ignore_errors=True)
         self.master = self.MesosMasterThread(numCores)
         self.master.start()

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -13,11 +13,12 @@ from __future__ import absolute_import
 # See the License for the specific language governing permissions and
 #
 
+from toil.lib.threading import cpu_count
+
 from .registry import batchSystemFactoryFor, defaultBatchSystem, uniqueNames
 
 import socket
 from contextlib import closing
-import multiprocessing
 
 def getPublicIP():
     """Get the IP that this machine uses to contact the internet.
@@ -114,7 +115,7 @@ def addOptions(addOptionFn, config):
                 help=("Should auto-deployment of the user script be deactivated? If True, the user "
                       "script/package should be present at the same location on all workers. "
                       "default=false"))
-    localCores = multiprocessing.cpu_count()
+    localCores = cpu_count()
     addOptionFn("--maxLocalJobs", default=localCores,
                 help="For batch systems that support a local queue for "
                 "housekeeping jobs (Mesos, GridEngine, htcondor, lsf, slurm, "
@@ -146,7 +147,7 @@ def setDefaultOptions(config):
     config.disableAutoDeployment = False
     config.environment = {}
     config.statePollingWait = None  # if not set, will default to seconds in getWaitDuration()
-    config.maxLocalJobs = multiprocessing.cpu_count()
+    config.maxLocalJobs = cpu_count()
     config.manualMemArgs = False
 
     # single machine

--- a/src/toil/batchSystems/parasolTestSupport.py
+++ b/src/toil/batchSystems/parasolTestSupport.py
@@ -19,11 +19,11 @@ import tempfile
 import threading
 import time
 from toil import subprocess
-import multiprocessing
 import signal
 import os
 import errno
 from toil.lib.objects import InnerClass
+from toil.lib.threading import cpu_count
 
 from toil import physicalMemory
 
@@ -46,7 +46,7 @@ class ParasolTestSupport(object):
 
     def _startParasol(self, numCores=None, memory=None):
         if numCores is None:
-            numCores = multiprocessing.cpu_count()
+            numCores = cpu_count()
         if memory is None:
             memory = physicalMemory()
         self.numCores = numCores

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -22,7 +22,6 @@ from builtins import object
 from past.utils import old_div
 from contextlib import contextmanager
 import logging
-import multiprocessing
 import os
 import time
 import math
@@ -33,6 +32,7 @@ from six.moves.queue import Empty, Queue
 import toil
 from toil import subprocess
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
+from toil.lib.threading import cpu_count
 from toil import worker as toil_worker
 from toil.common import Toil
 
@@ -53,7 +53,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
     def supportsWorkerCleanup(cls):
         return True
 
-    numCores = multiprocessing.cpu_count()
+    numCores = cpu_count()
 
     minCores = 0.1
     """

--- a/src/toil/lib/threading.py
+++ b/src/toil/lib/threading.py
@@ -112,22 +112,38 @@ def cpu_count():
 
     Counts hyperthreads as CPUs.
 
-    Uses the system's actual CPU count, or the current v1 cgroup's CPU limit
-    (for things like Kubernetes).
+    Uses the system's actual CPU count, or the current v1 cgroup's quota per
+    period, if the quota is set.
+
+    Ignores the cgroup's cpu shares value, because it's extremely difficult to
+    interpret. See https://github.com/kubernetes/kubernetes/issues/81021.
 
     :return: Integer count of available CPUs, minimum 1.
     :rtype: int
     """
 
-    # See if we can get an answer from cgroups
-    
+    # Get the fallback answer of all the CPUs on the machine
+    total_machine_size = psutil.cpu_count(logical=True)
+
     try:
-        with open('/sys/fs/cgroup/cpu/cpu.shares', 'r') as stream:
-            # Parse, divide by 1024, cieling, and convert to integer.
-            cgroup_cpus =int(math.ceil(float(stream.read())/1024))
+        with open('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', 'r') as stream:
+            # Read the quota
+            quota = int(stream.read)
+
+        if quota == -1:
+            # Assume we can use the whole machine
+            return total_machine_size
+
+        with open('/sys/fs/cgroup/cpu/cpu.cfs_period_us', 'r') as stream:
+            # Read the period in which we are allowed to burn the quota
+            period = int(stream.read)
+
+        # The thread count is how many multiples of a wall clcok period we can burn in that period.
+        cgroup_size = int(math.ceil(float(quota)/float(period)))
     except:
-        cgroup_cpus = float('inf')
+        # We can't actually read these cgroup fields. Maybe we are a mac or something.
+        cgroup_size = float('inf')
 
     # Return the smaller of the actual thread count and the cgroup's limit, minimum 1.
-    return max(1, min(psutil.cpu_count(logical=True), cgroup_cpus))
+    return max(1, min(cgroup_size, total_machine_size))
     

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from builtins import next
 from builtins import str
 import logging
-import multiprocessing
 import os
 import re
 import shutil
@@ -36,7 +35,7 @@ from six.moves.urllib.request import urlopen
 
 from toil.lib.memoize import memoize
 from toil.lib.iterables import concat
-from toil.lib.threading import ExceptionalThread
+from toil.lib.threading import ExceptionalThread, cpu_count
 from toil.lib.misc import mkdir_p
 from toil.provisioners.aws import runningOnEC2
 from toil import subprocess
@@ -706,7 +705,7 @@ class ApplianceTestSupport(ToilTest):
                  representing the respective appliance containers
         """
         if numCores is None:
-            numCores = multiprocessing.cpu_count()
+            numCores = cpu_count()
         # The last container to stop (and the first to start) should clean the mounts.
         with self.LeaderThread(self, mounts, cleanMounts=True) as leader:
             with self.WorkerThread(self, mounts, numCores) as worker:

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -29,7 +29,6 @@ import itertools
 import tempfile
 from textwrap import dedent
 import time
-import multiprocessing
 import sys
 from toil import subprocess
 from unittest import skipIf
@@ -45,6 +44,7 @@ from toil.batchSystems.singleMachine import SingleMachineBatchSystem
 from toil.batchSystems.abstractBatchSystem import (InsufficientSystemResources,
                                                    BatchSystemSupport)
 from toil.job import Job, JobNode
+from toil.lib.threading import cpu_count
 from toil.test import (ToilTest,
                        needs_aws_s3,
                        needs_lsf,
@@ -136,7 +136,7 @@ class hidden(object):
             super(hidden.AbstractBatchSystemTest, self).tearDown()
         
         def testAvailableCores(self):
-            self.assertTrue(multiprocessing.cpu_count() >= numCores)
+            self.assertTrue(cpu_count() >= numCores)
         
         def testRunJobs(self):
             jobNode1 = JobNode(command='sleep 1000', jobName='test1', unitName=None,
@@ -277,7 +277,7 @@ class hidden(object):
         than using the batch system directly.
         """
 
-        cpuCount = multiprocessing.cpu_count()
+        cpuCount = cpu_count()
         allocatedCores = sorted({1, 2, cpuCount})
         sleepTime = 5
 

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -1216,6 +1216,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
         """
         from boto.sdb import connect_to_region
         from boto.s3.connection import Location, S3Connection
+        from boto.exception import S3ResponseError
         from toil.jobStores.aws.jobStore import BucketLocationConflictException
         from toil.jobStores.aws.utils import retry_s3
         externalAWSLocation = Location.USWest
@@ -1257,7 +1258,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
                     for attempt in retry_s3():
                         with attempt:
                             s3.delete_bucket(bucket=bucket)
-                except boto.exception.S3ResponseError as e:
+                except S3ResponseError as e:
                     if e.error_code == 404:
                         # The bucket doesn't exist; maybe a failed delete actually succeeded.
                         pass

--- a/src/toil/test/src/deferredFunctionTest.py
+++ b/src/toil/test/src/deferredFunctionTest.py
@@ -36,16 +36,11 @@ import os
 import random
 import signal
 import time
-import logging
-import multiprocessing
-import psutil
 import pytest
 
 # Python 3 compatibility imports
 from six.moves import xrange
 from future.utils import with_metaclass
-
-log = logging.getLogger(__name__)
 
 # Some tests take too long on the AWS jobstore and are unquitable for CI.  They can be
 # be run during manual tests by setting this to False.
@@ -80,7 +75,6 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
 
     # Tests for the various defer possibilities
     @travis_test
-    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithMethod(self):
         """
         Refer docstring in _testDeferredFunctionRuns.
@@ -89,7 +83,6 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         self._testDeferredFunctionRuns(_writeNonLocalFilesMethod)
 
     @travis_test
-    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithClassMethod(self):
         """
         Refer docstring in _testDeferredFunctionRuns.
@@ -98,7 +91,6 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         self._testDeferredFunctionRuns(_writeNonLocalFilesClassMethod)
 
     @travis_test
-    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithLambda(self):
         """
         Refer docstring in _testDeferredFunctionRuns.
@@ -128,7 +120,6 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         assert not os.path.exists(nonLocalFile2)
 
     @slow
-    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithFailures(self):
         """
         Create 2 non local filesto use as flags.  Create a job that registers a function that
@@ -160,7 +151,6 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         assert not os.path.exists(nonLocalFile2)
 
     @slow
-    @pytest.mark.timeout(60)
     def testNewJobsCanHandleOtherJobDeaths(self):
         """
         Create 2 non-local files and then create 2 jobs. The first job registers a deferred job
@@ -174,12 +164,6 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
 
         # Check to make sure we can run two jobs in parallel
         cpus = cpu_count()
-        mp_cpus = multiprocessing.cpu_count()
-        ps_cpus = psutil.cpu_count()
-
-        log.critical('CPU counts: {} {} {}'.format(cpus, mp_cpus, ps_cpus))
-        print('CPU counts: {} {} {}'.format(cpus, mp_cpus, ps_cpus))
-
         assert cpus >= 2, "Not enough CPUs to run two tasks at once"
 
         # There can be no retries
@@ -207,7 +191,6 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
             pass
 
     @travis_test
-    @pytest.mark.timeout(60)
     def testBatchSystemCleanupCanHandleWorkerDeaths(self):
         """
         Create a non-local files. Create a job that registers a deferred job to delete the file

--- a/src/toil/test/src/deferredFunctionTest.py
+++ b/src/toil/test/src/deferredFunctionTest.py
@@ -194,10 +194,10 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         files = [nonLocalFile1, nonLocalFile2]
         root = Job()
         # A and B here must run in parallel for this to work
-        A = Job.wrapJobFn(_testNewJobsCanHandleOtherJobDeaths_A, files=files, cores=0.1)
-        B = Job.wrapJobFn(_testNewJobsCanHandleOtherJobDeaths_B, files=files, cores=0.1)
+        A = Job.wrapJobFn(_testNewJobsCanHandleOtherJobDeaths_A, files=files, cores=1)
+        B = Job.wrapJobFn(_testNewJobsCanHandleOtherJobDeaths_B, files=files, cores=1)
         C = Job.wrapJobFn(_testNewJobsCanHandleOtherJobDeaths_C, files=files,
-                          expectedResult=False, cores=0.1)
+                          expectedResult=False, cores=1)
         root.addChild(A)
         root.addChild(B)
         B.addChild(C)

--- a/src/toil/test/src/deferredFunctionTest.py
+++ b/src/toil/test/src/deferredFunctionTest.py
@@ -177,8 +177,8 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         mp_cpus = multiprocessing.cpu_count()
         ps_cpus = psutil.cpu_count()
 
-        log.critical('CPU counts: {} {} {}'.format(cpus))
-        print('CPU counts: {} {} {}'.format(cpus))
+        log.critical('CPU counts: {} {} {}'.format(cpus, mp_cpus, ps_cpus))
+        print('CPU counts: {} {} {}'.format(cpus, mp_cpus, ps_cpus))
 
         assert cpus >= 2, "Not enough CPUs to run two tasks at once"
 

--- a/src/toil/test/src/deferredFunctionTest.py
+++ b/src/toil/test/src/deferredFunctionTest.py
@@ -74,6 +74,7 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
 
     # Tests for the various defer possibilities
     @travis_test
+    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithMethod(self):
         """
         Refer docstring in _testDeferredFunctionRuns.
@@ -82,6 +83,7 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         self._testDeferredFunctionRuns(_writeNonLocalFilesMethod)
 
     @travis_test
+    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithClassMethod(self):
         """
         Refer docstring in _testDeferredFunctionRuns.
@@ -90,6 +92,7 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         self._testDeferredFunctionRuns(_writeNonLocalFilesClassMethod)
 
     @travis_test
+    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithLambda(self):
         """
         Refer docstring in _testDeferredFunctionRuns.
@@ -119,6 +122,7 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         assert not os.path.exists(nonLocalFile2)
 
     @slow
+    @pytest.mark.timeout(60)
     def testDeferredFunctionRunsWithFailures(self):
         """
         Create 2 non local filesto use as flags.  Create a job that registers a function that
@@ -150,6 +154,7 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
         assert not os.path.exists(nonLocalFile2)
 
     @slow
+    @pytest.mark.timeout(60)
     def testNewJobsCanHandleOtherJobDeaths(self):
         """
         Create 2 non-local files and then create 2 jobs. The first job registers a deferred job
@@ -184,6 +189,7 @@ class DeferredFunctionTest(with_metaclass(ABCMeta, ToilTest)):
             pass
 
     @travis_test
+    @pytest.mark.timeout(60)
     def testBatchSystemCleanupCanHandleWorkerDeaths(self):
         """
         Create a non-local files. Create a job that registers a deferred job to delete the file

--- a/src/toil/test/src/systemTest.py
+++ b/src/toil/test/src/systemTest.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from functools import partial
 
+from toil.lib.threading import cpu_count
 from toil.test import ToilTest, travis_test
 
 
@@ -21,7 +22,7 @@ class SystemTest(ToilTest):
             # Use processes (as opposed to threads) to prevent GIL from ordering things artificially
             pool = multiprocessing.Pool()
             try:
-                numTasks = multiprocessing.cpu_count() * 10
+                numTasks = cpu_count() * 10
                 grandChildIds = pool.map_async(
                     func=partial(_testAtomicityOfNonEmptyDirectoryRenamesTask, parent, child),
                     iterable=list(range(numTasks)))


### PR DESCRIPTION
This will fix #2902.

When nobody else is using CI, I am going to want to manually pause the non-Kubernetes runner, unpause the Kubernetes runner, and verify that these changes are indeed sufficient to make jobs run through on the Kubernetes runner. I'm not sure if I want to do that before or after we merge this; there should be no trouble with these changes on the existing non-Kubernetes runner.