### PR TITLE
Increase SQLite DB timeout to 60s.

### DIFF
--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -217,7 +217,7 @@ class CachingFileStore(AbstractFileStore):
         # Connect to the cache database in there, or create it if not present
         self.dbPath = os.path.join(self.localCacheDir, 'cache-{}.db'.format(self.workflowAttemptNumber))
         # We need to hold onto both a connection (to commit) and a cursor (to actually use the database)
-        self.con = sqlite3.connect(self.dbPath)
+        self.con = sqlite3.connect(self.dbPath, timeout=60)
         self.cur = self.con.cursor()
         
         # Note that sqlite3 automatically starts a transaction when we go to


### PR DESCRIPTION
Related to issue #2910 : increasing the timeout dramatically reduces the "database is locked" errors (actually, I haven't seen the error since increasing the timeout; it's still possible that it'll get thrown for larger workflows though).

Default is 5s.