### PR TITLE
Improve Kubernetes job timing

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -154,9 +154,10 @@ class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
 
         :rtype: tuple(str, int, float) or None
         :return: If a result is available, returns a tuple (jobID, exitValue, wallTime).
-                 Otherwise it returns None. wallTime is the number of seconds (a float) in
-                 wall-clock time the job ran for or None if this batch system does not support
-                 tracking wall time. Returns None for jobs that were killed.
+                 Otherwise it returns None. wallTime is the number of seconds (a strictly 
+                 positive float) in wall-clock time the job ran for, or None if this
+                 batch system does not support tracking wall time. Returns None for jobs
+                 that were killed.
         """
         raise NotImplementedError()
 

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -178,6 +178,7 @@ class hidden(object):
             job3 = self.batchSystem.issueBatchJob(jobNode3)
 
             jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+            log.info('Third job completed: {} {} {}'.format(jobID, exitStatus, wallTime))
 
             # Since the first two jobs were killed, the only job in the updated jobs queue should
             # be job 3. If the first two jobs were (incorrectly) added to the queue, this will


### PR DESCRIPTION
The Kubernetes batch system should now always produce positive runtimes, even
when pods behave strangely. It also does a bit more work to come up with
meaningful runtimes for cases where pods don't formally end.

This should fix #2919.