### PR TITLE
Use an http-parser for pymesos that builds on 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ def runSetup():
     futures = 'futures==3.1.1'
     pycryptodome = 'pycryptodome==3.5.1'
     pymesos = 'pymesos==0.3.7'
+    # We need this specific http-parser that still claims to be version 0.8.3
+    # but which builds on Python 3.7+, to satisfy pymesos
+    http_parser = 'http-parser' + \
+                  '@https://github.com/adamnovak/http-parser/archive/190a17839ba229c635b59d960579451a81fe73f3.zip' + \
+                  '#sha256=3d30c84a426627e468657c44de199daee9d3210a48e392d4ad2e7497c5010949'
     psutil = 'psutil >= 3.0.1, <6'
     pynacl = 'pynacl==1.1.2'
     gcs = 'google-cloud-storage==1.6.0'
@@ -80,6 +85,7 @@ def runSetup():
     kubernetes_reqs = [
         kubernetes]
     mesos_reqs = [
+        http_parser,
         pymesos,
         psutil]
     wdl_reqs = []


### PR DESCRIPTION
This should fix #2924 (as long as your pip is new enough to respect [PEP 508](https://www.python.org/dev/peps/pep-0508/)).
If someone with permissions forked http-parser into databiosphere, or if https://github.com/benoitc/http-parser/pull/88 were to be merged, we could use a better place than my fork of `http-parser` as the source for this.