### PR TITLE
Fix cpu_count() to actually read quotas

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,8 @@ before_script:
   - docker info
   - cat /etc/hosts
   - export PYTHONIOENCODING=utf-8
+  - mkdir -p ~/.kube && cp "$GITLAB_SECRET_FILE_KUBE_CONFIG" ~/.kube/config
+  - mkdir -p ~/.aws && cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
 after_script:
   # We need to clean up any files that Toil may have made via Docker that
   # aren't deletable by the Gitlab user. If we don't do this, Gitlab will try
@@ -29,11 +31,6 @@ py2_batch_systems:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
     - virtualenv -p python2.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # Get Kubernetes credentials
-    - mkdir -p ~/.kube
-    - cp "$GITLAB_SECRET_FILE_KUBE_CONFIG" ~/.kube/config
-    - mkdir -p ~/.aws
-    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
     - python -m pytest -r s src/toil/test/batchSystems/batchSystemTest.py
     - python -m pytest -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
@@ -92,8 +89,6 @@ py2_integration_jobstore:
     - export TOIL_AWS_ZONE=us-west-2a
     # This reads GITLAB_SECRET_FILE_SSH_KEYS
     - python setup_gitlab_ssh.py
-    - mkdir -p ~/.aws
-    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
     - python -m pytest src/toil/test/jobStores/jobStoreTest.py
 
 py2_integration_sort:
@@ -107,8 +102,6 @@ py2_integration_sort:
     - export TOIL_AWS_ZONE=us-west-2a
     # This reads GITLAB_SECRET_FILE_SSH_KEYS
     - python setup_gitlab_ssh.py
-    - mkdir -p ~/.aws
-    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
     - python -m pytest src/toil/test/sort/sortTest.py
     - python -m pytest src/toil/test/provisioners/clusterScalerTest.py
 
@@ -123,8 +116,6 @@ py2_integration_sort:
 #    - export TOIL_AWS_ZONE=us-west-2a
 #    # This reads GITLAB_SECRET_FILE_SSH_KEYS
 #    - python setup_gitlab_ssh.py
-#    - mkdir -p ~/.aws
-#    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
 #    - python -m pytest src/toil/test/provisioners/aws/awsProvisionerTest.py
 
 
@@ -182,6 +173,4 @@ py3_main:
 #    - export TOIL_AWS_ZONE=us-west-2a
 #    # This reads GITLAB_SECRET_FILE_SSH_KEYS
 #    - python setup_gitlab_ssh.py
-#    - mkdir -p ~/.aws
-#    - cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
 #    - python -m pytest src/toil/test/jobStores/jobStoreTest.py

--- a/src/toil/lib/threading.py
+++ b/src/toil/lib/threading.py
@@ -21,6 +21,7 @@ import logging
 import math
 import sys
 import threading
+import traceback
 if sys.version_info >= (3, 0):
     from threading import BoundedSemaphore
 else:
@@ -121,9 +122,16 @@ def cpu_count():
     Ignores the cgroup's cpu shares value, because it's extremely difficult to
     interpret. See https://github.com/kubernetes/kubernetes/issues/81021.
 
+    Caches result for efficiency.
+
     :return: Integer count of available CPUs, minimum 1.
     :rtype: int
     """
+
+    cached = getattr(cpu_count, 'result', None)
+    if cached is not None:
+        # We already got a CPU count.    
+        return cached
 
     # Get the fallback answer of all the CPUs on the machine
     total_machine_size = psutil.cpu_count(logical=True)
@@ -133,7 +141,7 @@ def cpu_count():
     try:
         with open('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', 'r') as stream:
             # Read the quota
-            quota = int(stream.read)
+            quota = int(stream.read())
 
         log.debug('CPU quota: %d', quota)
 
@@ -143,7 +151,7 @@ def cpu_count():
 
         with open('/sys/fs/cgroup/cpu/cpu.cfs_period_us', 'r') as stream:
             # Read the period in which we are allowed to burn the quota
-            period = int(stream.read)
+            period = int(stream.read())
 
         log.debug('CPU quota period: %d', period)
 
@@ -154,10 +162,13 @@ def cpu_count():
 
     except:
         # We can't actually read these cgroup fields. Maybe we are a mac or something.
+        log.debug('Could not inspect cgroup: %s', traceback.format_exc())
         cgroup_size = float('inf')
 
     # Return the smaller of the actual thread count and the cgroup's limit, minimum 1.
     result = max(1, min(cgroup_size, total_machine_size))
     log.debug('cpu_count: %s', str(result))
+    # Make sure to remember it for the next call
+    setattr(cpu_count, 'result', result)
     return result
     

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -400,23 +400,6 @@ def needs_docker(test_item):
     else:
         return unittest.skip("Install docker to include this test.")(test_item)
 
-def needs_appliance(test_item):
-    """
-    Use as a decorator before test classes or methods to only run them if
-    the Toil appliance Docker image ought to be available.
-
-    For now, this just skips if running on Python 3.
-    TODO: When the appliance build is set up for Python 3 (when
-    https://github.com/DataBiosphere/toil/issues/2742 is fixed), this behavior
-    should be changed.
-    """
-
-    if sys.version_info[0] == 2:
-        return test_item
-    else:
-        return unittest.skip("Skipping test that needs Toil Appliance, available only for Python 2")(test_item)
-
-
 def needs_encryption(test_item):
     """
     Use as a decorator before test classes or methods to only run them if PyNaCl is installed
@@ -449,6 +432,10 @@ def needs_cwl(test_item):
 
 
 def needs_appliance(test_item):
+    """
+    Use as a decorator before test classes or methods to only run them if
+    the Toil appliance Docker image is downloaded.
+    """
     import json
     test_item = _mark_test('appliance', test_item)
     if os.getenv('TOIL_SKIP_DOCKER', '').lower() == 'true':
@@ -471,6 +458,23 @@ def needs_appliance(test_item):
             assert False, 'Expected `docker inspect` to return zero or one image.'
     else:
         return unittest.skip('Install Docker to include this test.')(test_item)
+    
+def needs_downloadable_appliance(test_item):
+    """
+    Use as a decorator before test classes or methods to only run them if
+    the Toil appliance Docker image ought to be available for download.
+
+    For now, this just skips if running on Python 3.
+    TODO: When the appliance build is set up for Python 3 (when
+    https://github.com/DataBiosphere/toil/issues/2742 is fixed), this behavior
+    should be changed.
+    """
+
+    if sys.version_info[0] == 2:
+        return test_item
+    else:
+        return unittest.skip("Skipping test that needs Toil Appliance, available only for Python 2")(test_item)
+
 
 
 def integrative(test_item):

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import signal
+import sys
 import tempfile
 import threading
 import time
@@ -398,6 +399,22 @@ def needs_docker(test_item):
         return test_item
     else:
         return unittest.skip("Install docker to include this test.")(test_item)
+
+def needs_appliance(test_item):
+    """
+    Use as a decorator before test classes or methods to only run them if
+    the Toil appliance Docker image ought to be available.
+
+    For now, this just skips if running on Python 3.
+    TODO: When the appliance build is set up for Python 3 (when
+    https://github.com/DataBiosphere/toil/issues/2742 is fixed), this behavior
+    should be changed.
+    """
+
+    if sys.version_info[0] == 2:
+        return test_item
+    else:
+        return unittest.skip("Skipping test that needs Toil Appliance, available only for Python 2")(test_item)
 
 
 def needs_encryption(test_item):

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -55,6 +55,7 @@ from toil.test import (ToilTest,
                        needs_slurm,
                        needs_torque,
                        needs_htcondor,
+                       needs_appliance,
                        slow,
                        tempFileContaining,
                        travis_test)
@@ -345,6 +346,7 @@ class hidden(object):
 
 @needs_kubernetes
 @needs_aws_s3
+@needs_appliance
 class KubernetesBatchSystemTest(hidden.AbstractBatchSystemTest):
     """
     Tests against the Kubernetes batch system

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -55,7 +55,7 @@ from toil.test import (ToilTest,
                        needs_slurm,
                        needs_torque,
                        needs_htcondor,
-                       needs_appliance,
+                       needs_downloadable_appliance,
                        slow,
                        tempFileContaining,
                        travis_test)
@@ -346,7 +346,7 @@ class hidden(object):
 
 @needs_kubernetes
 @needs_aws_s3
-@needs_appliance
+@needs_downloadable_appliance
 class KubernetesBatchSystemTest(hidden.AbstractBatchSystemTest):
     """
     Tests against the Kubernetes batch system

--- a/src/toil/test/docs/scriptsTest.py
+++ b/src/toil/test/docs/scriptsTest.py
@@ -51,7 +51,7 @@ class ToilDocumentationTest(ToilTest):
 
         # Check that the expected output is there
         index = outerr.find(expectedOutput)
-        self.assertGreater(index, -1, index)
+        self.assertGreater(index, -1, "Expected:\n{}\nOutput:\n{}".format(expectedOutput, outerr))
 
     """Check the exit code and look for a pattern"""
     def checkExpectedPattern(self, script, expectedPattern):
@@ -60,7 +60,7 @@ class ToilDocumentationTest(ToilTest):
         # Check that the expected output pattern is there
         pattern = re.compile(expectedPattern, re.DOTALL)
         n = re.search(pattern, outerr)
-        self.assertNotEqual(n, None, n)
+        self.assertNotEqual(n, None, "Pattern:\n{}\nOutput:\n{}".format(expectedPattern, outerr))
 
     @needs_cwl
     def testCwlexample(self):

--- a/src/toil/test/src/promisedRequirementTest.py
+++ b/src/toil/test/src/promisedRequirementTest.py
@@ -48,6 +48,7 @@ class hidden(object):
             Asserts that promised core resources are allocated properly using a dynamic Toil workflow
             """
             for coresPerJob in self.allocatedCores:
+                log.debug('Testing %d cores per job with CPU count %d', coresPerJob, self.cpuCount)
                 tempDir = self._createTempDir('testFiles')
                 counterPath = self.getCounterPath(tempDir)
 
@@ -63,6 +64,7 @@ class hidden(object):
             Asserts that promised core resources are allocated properly using a static DAG
             """
             for coresPerJob in self.allocatedCores:
+                log.debug('Testing %d cores per job with CPU count %d', coresPerJob, self.cpuCount)
                 tempDir = self._createTempDir('testFiles')
                 counterPath = self.getCounterPath(tempDir)
 


### PR DESCRIPTION
This will fix #2932 by making sure to actually read the quota files when trying to get CPU counts.

That should fix both the total cores it is expecting, and the number of jobs it actually attempts to run in parallel.