### PR TITLE
Include jobNode.jobName in submitted slurm job name

### DIFF
--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -60,7 +60,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
         def killJob(self, jobID):
             subprocess.check_call(['qdel', self.getBatchSystemID(jobID)])
 
-        def prepareSubmission(self, cpu, memory, jobID, command):
+        def prepareSubmission(self, cpu, memory, jobID, command, jobName):
             return self.prepareQsub(cpu, memory, jobID) + [command]
 
         def submitJob(self, subLine):

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -67,7 +67,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
         def killJob(self, jobID):
             subprocess.check_call(['bkill', self.getBatchSystemID(jobID)])
 
-        def prepareSubmission(self, cpu, memory, jobID, command):
+        def prepareSubmission(self, cpu, memory, jobID, command, jobName):
             return self.prepareBsub(cpu, memory, jobID) + [command]
 
         def submitJob(self, subLine):

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -28,50 +28,13 @@ from six.moves.queue import Empty, Queue
 from six import iteritems
 
 from toil.batchSystems import MemoryString
-from toil.batchSystems.abstractGridEngineBatchSystem import AbstractGridEngineBatchSystem, with_retries
+from toil.batchSystems.abstractGridEngineBatchSystem import AbstractGridEngineBatchSystem
 
 logger = logging.getLogger(__name__)
 
 class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
     class Worker(AbstractGridEngineBatchSystem.Worker):
-
-        # Override the issueBatchJob method so we can provide a descriptive slurm job name
-        def createJobs(self, newJob):
-            """
-            Create a new job with the Toil job ID.
-
-            Implementation-specific; called by AbstractGridEngineWorker.run()
-
-            :param string newJob: Toil job ID
-            """
-            activity = False
-            # Load new job id if present:
-            if newJob is not None:
-                self.waitingJobs.append(newJob)
-            # Launch jobs as necessary:
-            while len(self.waitingJobs) > 0 and \
-                    len(self.runningJobs) < int(self.boss.config.maxLocalJobs):
-                activity = True
-                jobID, cpu, memory, command, jobName = self.waitingJobs.pop(0)
-
-                # prepare job submission command
-                subLine = self.prepareSubmission(cpu, memory, jobID, command, jobName)
-                logger.debug("Running %r", subLine)
-                batchJobID = with_retries(self.submitJob, subLine)
-                logger.debug("Submitted job %s", str(batchJobID))
-
-                # Store dict for mapping Toil job ID to batch job ID
-                # TODO: Note that this currently stores a tuple of (batch system
-                # ID, Task), but the second value is None by default and doesn't
-                # seem to be used
-                self.batchJobIDs[jobID] = (batchJobID, None)
-
-                # Add to queue of running jobs
-                with self.runningJobsLock:
-                    self.runningJobs.add(jobID)
-
-            return activity
 
         def getRunningJobIDs(self):
             # Should return a dictionary of Job IDs and number of seconds
@@ -259,21 +222,6 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
     """
     The interface for SLURM
     """
-
-    # Override the issueBatchJob method so we can provide a descriptive slurm job name
-    def issueBatchJob(self, jobNode):
-        # Avoid submitting internal jobs to the batch queue, handle locally
-        localID = self.handleLocalJob(jobNode)
-        if localID:
-            return localID
-        else:
-            self.checkResourceRequest(jobNode.memory, jobNode.cores, jobNode.disk)
-            jobID = self.getNextJobID()
-            self.currentJobs.add(jobID)
-            self.newJobsQueue.put((jobID, jobNode.cores, jobNode.memory, jobNode.command, jobNode.jobName))
-            logger.debug("Issued the job command: %s with job id: %s and job name %s", jobNode.command, str(jobID),
-                         jobNode.jobName)
-        return jobID
 
     @classmethod
     def getWaitDuration(cls):

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -122,7 +122,7 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
         def killJob(self, jobID):
             subprocess.check_call(['qdel', self.getBatchSystemID(jobID)])
 
-        def prepareSubmission(self, cpu, memory, jobID, command):
+        def prepareSubmission(self, cpu, memory, jobID, command, jobName):
             return self.prepareQsub(cpu, memory, jobID) + [self.generateTorqueWrapper(command, jobID)]
 
         def submitJob(self, subLine):


### PR DESCRIPTION
Updates SlurmBatchSystem to include a more descriptive slurm job name, particularly handy for monitoring workflows on slurm clusters

Before: `toil_job_4`
After: `toil_job_4_tools/picard/picard-BedToIntervalList.cwl`


