### PR TITLE
Specify py3.6 or py3.x instead of just py3.

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -22,7 +22,7 @@ sdistName = os.environ['_TOIL_SDIST_NAME']
 
 # Make sure to install packages into the pip for the version of Python we are
 # building for.
-pip = 'pip{}'.format(sys.version_info[0])
+pip = 'python{}.{} -m pip'.format(sys.version_info[0], sys.version_info[1])
 
 
 dependencies = ' '.join(['libffi-dev',  # For client side encryption for extras with PyNACL
@@ -125,7 +125,7 @@ print(heredoc('''
     RUN {pip} install --upgrade virtualenv==15.0.3
 
     # Install s3am (--never-download prevents silent upgrades to pip, wheel and setuptools)
-    RUN virtualenv --python python3 --never-download /home/s3am \
+    RUN virtualenv --python python3.6 --never-download /home/s3am \
         && /home/s3am/bin/pip install s3am==2.0 \
         && ln -s /home/s3am/bin/s3am /usr/local/bin/
 

--- a/version_template.py
+++ b/version_template.py
@@ -67,13 +67,7 @@ def python():
     appliance is only built for particular Python versions, and we would like
     workflows to work with a variety of leader Python versions.
     """
-    import sys
-    
-    if sys.version_info[0] == 3:
-        # Ignore minor version
-        return 'python3'
-    else:
-        return exactPython() 
+    return exactPython()
 
 
 def _pythonVersionSuffix():
@@ -86,10 +80,7 @@ def _pythonVersionSuffix():
 
     # For now, we assume all Python 3 releases are intercompatible.
     # We also only tag the Python 2 releases specially, since Python 2 is old and busted.
-    if sys.version_info[0] == 3:
-        return ''
-    else:
-        return '-py{}'.format(sys.version_info[0])
+    return '-py{}.{}'.format(sys.version_info[0], sys.version_info[1])
 
       
 def dockerTag():


### PR DESCRIPTION
Should fix #2964, but needs to be tested.  The image I pushed is:
```quay.io/ucsc_cgl/toil:3.24.1a1-efeaa75465e9c6dd3df8e4535a810a47b17f0561-dirty-py3.6```
