### PR TITLE
Fix py3 spot market scaling

### DIFF
--- a/src/toil/lib/ec2.py
+++ b/src/toil/lib/ec2.py
@@ -184,7 +184,7 @@ def create_spot_instances(ec2, price, image_id, spec, num_instances=1, timeout=N
     :rtype: Iterator[list[Instance]]
     """
     def spotRequestNotFound(e):
-        return e.error_code == "InvalidSpotInstanceRequestID.NotFound"
+        return getattr(e, 'error_code', None) == "InvalidSpotInstanceRequestID.NotFound"
 
     for attempt in retry_ec2(retry_for=a_long_time,
                              retry_while=inconsistencies_detected):
@@ -231,9 +231,9 @@ def create_spot_instances(ec2, price, image_id, spec, num_instances=1, timeout=N
 
 
 def inconsistencies_detected(e):
-    if e.code == 'InvalidGroup.NotFound':
+    if getattr(e, 'code', None) == 'InvalidGroup.NotFound':
         return True
-    m = e.error_message.lower()
+    m = getattr(e, 'error_message', '').lower()
     return 'invalid iam instance profile' in m or 'no associated iam roles' in m
 
 

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -386,6 +386,10 @@ coreos:
 
 
     def _getCloudConfigUserData(self, role, masterPublicKey=None, keyPath=None, preemptable=False):
+        """
+        Return the text (not bytes) user data to pass to a provisioned node.
+        """
+
         if role == 'leader':
             entryPoint = 'mesos-master'
             mesosArgs = self.MESOS_LOG_DIR + self.LEADER_DOCKER_ARGS.format(name=self.clusterName)

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -532,8 +532,9 @@ class AWSProvisioner(AbstractProvisioner):
         root_vol = BlockDeviceType(delete_on_termination=True)
         root_vol.size = rootVolSize
         bdm["/dev/xvda"] = root_vol
-        # the first disk is already attached for us so start with 2nd.
-        for disk in range(1, instanceType.disks + 1):
+        # The first disk is already attached for us so start with 2nd.
+        # Disk count is weirdly a float in our instance database, so make it an int here.
+        for disk in range(1, int(instanceType.disks) + 1):
             bdm[bdtKeys[disk]] = BlockDeviceType(
                 ephemeral_name='ephemeral{}'.format(disk - 1))  # ephemeral counts start at 0
 

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -340,7 +340,12 @@ class ClusterScaler(object):
             minNodes = [0 for node in self.nodeTypes]
         maxNodes = config.maxNodes
         while len(maxNodes) < len(self.nodeTypes):
+            # Pad out the max node counts if we didn't get one per type.
             maxNodes.append(maxNodes[0])
+        while len(minNodes) < len(self.nodeTypes):
+            # Pad out the min node counts with 0s, so we can have fewer than
+            # the node types without crashing.
+            minNodes.append(0)
         self.minNodes = dict(zip(self.nodeShapes, minNodes))
         self.maxNodes = dict(zip(self.nodeShapes, maxNodes))
 


### PR DESCRIPTION
I ran 01036ae through with this Cactus test, and it finished successfully:

```
cactus --nodeTypes c5.xlarge:0.12,r5.xlarge --root mr --minNodes 0,0 --maxNodes 2,2 --provisioner aws --batchSystem mesos --logDebug --latest aws:us-west-2:adamnovak-jobstore ./examples/evolverMammals.txt adamnovak-output.hal  --logFile adamnovak-log
```

I think that this will fix @glennhickey's problems in https://github.com/DataBiosphere/toil/issues/2964#issuecomment-584636883

This fixes #2970.