### PR TITLE
Dropping python2.7 announcement.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,8 @@
-ATTENTION: Toil will be dropping python 2.7 support on January 1, 2020 when python 2.7 itself is scheduled to die.  This is when the last release of python 2.7 compatible toil will be.
+ATTENTION: Toil is no longer supporting python 2.7 as of February 13, 2020.
+           The last working version of toil in python2.7 is 3.24.0, though
+           subsequent 3.24.x releases may be made for hotfixes.
+
+           Toil 4.0.0 will be our first release incompatible with python2.7 and will require python3.6+.
 
 Toil is a scalable, efficient, cross-platform (Linux & macOS) pipeline management system,
 written entirely in Python, and designed around the principles of functional
@@ -21,4 +25,5 @@ programming.
    :alt: Join the chat at https://gitter.im/bd2k-genomics-toil/Lobby
    :target: https://gitter.im/bd2k-genomics-toil/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
-Note: Toil moved from https://github.com/BD2KGenomics/toil to https://github.com/DataBiosphere/toil on July 5th, 2018.
+Notes: Toil moved from https://github.com/BD2KGenomics/toil to https://github.com/DataBiosphere/toil on July 5th, 2018.
+       Toil dropped python 2.7 support on February 13, 2020 (last working py2.7 version is 3.24.0).

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ def runSetup():
         description='Pipeline management software for clusters.',
         author='Benedict Paten',
         author_email='benedict@soe.usc.edu',
-        url="https://github.com/BD2KGenomics/toil",
+        url="https://github.com/DataBiosphere/toil",
         classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
We can start merging python2.7 incompatible code into `master` now.  I plan to merge a few in today.
