### PR TITLE
Encode mtail stdin to utf-8 and flush.

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1231,7 +1231,8 @@ class ToilMetrics:
 
     def log(self, message):
         if self.mtailProc:
-            self.mtailProc.stdin.write(message + "\n")
+            self.mtailProc.stdin.write((message + "\n").encode("utf-8"))
+            self.mtailProc.stdin.flush()
 
     # Note: The mtail configuration (dashboard/mtail/toil.mtail) depends on these messages
     # remaining intact


### PR DESCRIPTION
Fixes #2977  about `a bytes-like object is required, not 'str'` and also flushes the stdin so that stats appear immediately on the dashboard (looks like the new subprocess module has a different buffer/flushing logic that results in 10+ min delay).