### PR TITLE
Raise default min CPU size of single machine jobs

### DIFF
--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -55,13 +55,14 @@ class SingleMachineBatchSystem(BatchSystemSupport):
 
     numCores = cpu_count()
 
-    minCores = 0.1
     """
     The minimal fractional CPU. Tasks with a smaller core requirement will be rounded up to this
     value. One important invariant of this class is that each worker thread represents a CPU
     requirement of minCores, meaning that we can never run more than numCores / minCores jobs
     concurrently.
     """
+    minCores = 1
+    
     physicalMemory = toil.physicalMemory()
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):


### PR DESCRIPTION
This should stop us spawning quite so many threads on single machine, and help with #2928. The cost is that jobs that ask for less than a core will get an entire core to themselves. A real solution without all these placeholder threads would address that, but this change is easy and should be a good stopgap.