### PR TITLE
Add moveExports option.

### DIFF
--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -66,6 +66,13 @@ def _singleMachineOptions(addOptionFn, config):
             "When not specified and as long as caching is enabled, Toil will "
             "protect the file automatically by changing the permissions to "
             "read-only.")
+        addOptionFn(
+            "--noMoveExports", dest="moveExports", default=True,
+            action='store_false', help="When using a filesystem based job "
+            "store, output files are by default moved to the output directory, "
+            "and a symlink to the moved exported file is created at the initial location. "                           
+            "Specifying this option instead copies the files into the output "
+            "directory.")
     else:
         addOptionFn(
             "--linkImports", dest="linkImports", default=False,
@@ -74,7 +81,12 @@ def _singleMachineOptions(addOptionFn, config):
             "this option saves space by sym-linking imported files. As long "
             "as caching is enabled Toil will protect the file "
             "automatically by changing the permissions to read-only.")
-
+        addOptionFn(
+            "--moveExports", dest="moveExports", default=False,
+            action='store_true', help="When using Toil's exportFile function "
+            "for staging, output files are copied to the output directory. Specifying "
+            "this option saves space by moving exported files, and making a symlink to "
+            "the exported file in the job store.")
 
 def _mesosOptions(addOptionFn, config=None):
     addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=getPublicIP() + ':5050',
@@ -153,6 +165,7 @@ def setDefaultOptions(config):
     # single machine
     config.scale = 1
     config.linkImports = False
+    config.moveExports = False
 
     # mesos
     config.mesosMasterAddress = '%s:5050' % getPublicIP()

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -72,7 +72,7 @@ def _singleMachineOptions(addOptionFn, config):
             "store, output files are by default moved to the output directory, "
             "and a symlink to the moved exported file is created at the initial location. "                           
             "Specifying this option instead copies the files into the output "
-            "directory.")
+            "directory. Applies to filesystem-based job stores only.")
     else:
         addOptionFn(
             "--linkImports", dest="linkImports", default=False,
@@ -86,7 +86,7 @@ def _singleMachineOptions(addOptionFn, config):
             action='store_true', help="When using Toil's exportFile function "
             "for staging, output files are copied to the output directory. Specifying "
             "this option saves space by moving exported files, and making a symlink to "
-            "the exported file in the job store.")
+            "the exported file in the job store. Applies to filesystem-based job stores only.")
 
 def _mesosOptions(addOptionFn, config=None):
     addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=getPublicIP() + ':5050',

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -220,6 +220,7 @@ class Config(object):
         setOption("parasolCommand")
         setOption("parasolMaxBatches", int, iC(1))
         setOption("linkImports")
+        setOption("moveExports")
         setOption("environment", parseSetEnv)
 
         # Autoscaling options

--- a/src/toil/fileStores/__init__.py
+++ b/src/toil/fileStores/__init__.py
@@ -15,7 +15,8 @@ from __future__ import absolute_import
 
 import os
 
-__all__ = ['fileStore', 'nonCachingFileStore', 'cachingFileStore']
+__all__ = ['fileStore', 'nonCachingFileStore', 'cachingFileStore', 'FileID']
+
 
 class FileID(str):
     """

--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -13,36 +13,23 @@
 # limitations under the License.
 
 from __future__ import absolute_import, print_function
+
 from future import standard_library
+
 standard_library.install_aliases()
-from builtins import map
-from builtins import str
-from builtins import range
 from builtins import object
 from abc import abstractmethod, ABCMeta
 from contextlib import contextmanager
-from fcntl import flock, LOCK_EX, LOCK_UN
-from functools import partial
-from hashlib import sha1
-from threading import Thread, Semaphore, Event
+from threading import Semaphore, Event
 from future.utils import with_metaclass
-from six.moves.queue import Empty, Queue
-import base64
 import dill
-import errno
 import logging
 import os
-import shutil
-import stat
 import tempfile
-import time
-import uuid
 
 from toil.lib.objects import abstractclassmethod
-from toil.lib.humanize import bytes2human
 from toil.lib.misc import WriteWatchingStream
-from toil.common import cacheDirName, getDirSizeRecursively, getFileSystemSize
-from toil.lib.bioio import makePublicDir
+from toil.common import cacheDirName
 
 from toil.fileStores import FileID
 
@@ -245,7 +232,7 @@ class AbstractFileStore(with_metaclass(ABCMeta, object)):
             # When the stream is written to, count the bytes
             def handle(numBytes):
                 # No scope problem here, because we don't assign to a fileID local
-                fileID.size += numBytes 
+                fileID.size += numBytes
             wrappedStream.onWrite(handle)
             
             yield wrappedStream, fileID

--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -13,21 +13,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import, print_function
+
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import map
 from builtins import str
-from builtins import range
-from builtins import object
-from abc import abstractmethod, ABCMeta
-from collections import namedtuple, defaultdict
 from contextlib import contextmanager
-from fcntl import flock, LOCK_EX, LOCK_UN
-from functools import partial
-from future.utils import with_metaclass
-from six.moves.queue import Empty, Queue
-import base64
-import dill
 import errno
 import hashlib
 import logging
@@ -35,7 +27,6 @@ import os
 import re
 import shutil
 import sqlite3
-import stat
 import sys
 import tempfile
 import threading
@@ -46,10 +37,8 @@ from toil.common import cacheDirName, getDirSizeRecursively, getFileSystemSize
 from toil.lib.bioio import makePublicDir
 from toil.lib.humanize import bytes2human
 from toil.lib.misc import mkdir_p, robust_rmtree, atomic_copy, atomic_copyobj
-from toil.lib.objects import abstractclassmethod
 from toil.lib.retry import retry
 from toil.lib.threading import get_process_name, process_name_exists
-from toil.resource import ModuleDescriptor
 from toil.fileStores.abstractFileStore import AbstractFileStore
 from toil.fileStores import FileID
 
@@ -59,6 +48,7 @@ if sys.version_info[0] < 3:
     # Define a usable FileNotFoundError as will be raised by os.remove on a
     # nonexistent file.
     FileNotFoundError = OSError
+
 
 # Use longer timeout to avoid hitting 'database is locked' errors.
 SQLITE_TIMEOUT_SECS = 60.0
@@ -111,6 +101,7 @@ class InvalidSourceCacheError(CacheError):
 
     def __init__(self, message):
         super(InvalidSourceCacheError, self).__init__(message)
+
 
 class CachingFileStore(AbstractFileStore):
     """

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -13,38 +13,27 @@
 # limitations under the License.
 
 from __future__ import absolute_import, print_function
+
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import map
 from builtins import str
-from builtins import range
-from builtins import object
-from abc import abstractmethod, ABCMeta
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 from contextlib import contextmanager
-from functools import partial
-from hashlib import sha1
-from future.utils import with_metaclass
-import base64
 import dill
 import errno
 import fcntl
 import logging
 import os
-import shutil
-import stat
 import sys
-import tempfile
-import time
 import uuid
 
 from toil.lib.misc import robust_rmtree
-from toil.lib.objects import abstractclassmethod
 from toil.lib.threading import get_process_name, process_name_exists
 from toil.lib.humanize import bytes2human
-from toil.common import cacheDirName, getDirSizeRecursively, getFileSystemSize
+from toil.common import getDirSizeRecursively, getFileSystemSize
 from toil.lib.bioio import makePublicDir
-from toil.resource import ModuleDescriptor
 from toil.fileStores.abstractFileStore import AbstractFileStore
 from toil.fileStores import FileID
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -362,6 +362,21 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
 
         :param urlparse.ParseResult url: The parsed URL of the file to export to.
         """
+        self._defaultExportFile(otherCls, jobStoreFileID, url)
+
+    def _defaultExportFile(self, otherCls, jobStoreFileID, url):
+        """
+        Refer to exportFile docstring for information about this method.
+
+        :param AbstractJobStore otherCls: The concrete subclass of AbstractJobStore that supports
+               exporting to the given URL. Note that the type annotation here is not completely
+               accurate. This is not an instance, it's a class, but there is no way to reflect
+               that in :pep:`484` type hints.
+
+        :param str jobStoreFileID: The id of the file that will be exported.
+
+        :param urlparse.ParseResult url: The parsed URL of the file to export to.
+        """
         with self.readFileStream(jobStoreFileID) as readable:
             otherCls._writeToUrl(readable, url)
 

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -435,7 +435,7 @@ class AWSJobStore(AbstractJobStore):
             finally:
                 dstKey.bucket.connection.close()
         else:
-            super(AWSJobStore, self)._exportFile(otherCls, jobStoreFileID, url)
+            super(AWSJobStore, self)._defaultExportFile(otherCls, jobStoreFileID, url)
 
     @classmethod
     def getSize(cls, url):

--- a/src/toil/lib/misc.py
+++ b/src/toil/lib/misc.py
@@ -68,7 +68,7 @@ def robust_rmtree(path):
 
         try:
             # Actually remove the directory once the children are gone
-            os.rmdir(path)
+            shutil.rmtree(path)
         except FileNotFoundError:
             # Directory went away
             return

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
-from builtins import next
-from builtins import str
+
+import datetime
 import logging
 import os
 import re
@@ -24,25 +24,27 @@ import threading
 import time
 import unittest
 import uuid
-import subprocess
-import datetime
-import pytz
-from future.utils import with_metaclass
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from inspect import getsource
+from shutil import which
 from textwrap import dedent
-from unittest.util import strclass
+
+import pytz
+from builtins import str
+from future.utils import with_metaclass
 from six import iteritems, itervalues
 from six.moves.urllib.request import urlopen
-from shutil import which
+from unittest.util import strclass
 
-from toil.lib.memoize import memoize
-from toil.lib.iterables import concat
-from toil.lib.threading import ExceptionalThread, cpu_count
-from toil.lib.misc import mkdir_p
-from toil.provisioners.aws import runningOnEC2
+from toil import subprocess
 from toil import toilPackageDirPath, applianceSelf
+from toil import which
+from toil.lib.iterables import concat
+from toil.lib.memoize import memoize
+from toil.lib.misc import mkdir_p
+from toil.lib.threading import ExceptionalThread, cpu_count
+from toil.provisioners.aws import runningOnEC2
 from toil.version import distVersion
 
 logging.basicConfig(level=logging.DEBUG)
@@ -582,18 +584,6 @@ def make_tests(generalMethod, targetClass, **kwargs):
     False
 
     """
-    def pop(d):
-        """
-        Pops an arbitrary key value pair from a given dict.
-
-        :param d: a dictionary
-
-        :return: the popped key, value tuple
-        """
-        k, v = next(iter(iteritems(kwargs)))
-        d.pop(k)
-        return k, v
-
     def permuteIntoLeft(left, rParamName, right):
         """
         Permutes values in right dictionary into each parameter: value dict pair in the left

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -710,16 +710,19 @@ class AbstractJobStoreTest(object):
                 dstUrl = other._prepareTestFile(store)
                 self.jobstore_initialized.exportFile(jobStoreFileID, dstUrl)
                 self.assertEqual(fileMD5, other._hashTestFile(dstUrl))
+
                 if otherCls.__name__ == 'FileJobStoreTest':
-                    jobStorePath = self.jobstore_initialized._getFilePathFromId(jobStoreFileID)
-                    jobStoreHasLink = os.path.islink(jobStorePath)
-                    if self.jobstore_initialized.moveExports:
-                        # Ensure the export performed a move / link
-                        self.assertTrue(jobStoreHasLink)
-                        self.assertEqual(os.path.realpath(jobStorePath), dstUrl[7:])
-                    else:
-                        # Ensure the export has not moved the job store file
-                        self.assertFalse(jobStoreHasLink)
+                    if isinstance(self.jobstore_initialized, FileJobStore):
+                        jobStorePath = self.jobstore_initialized._getFilePathFromId(jobStoreFileID)
+                        jobStoreHasLink = os.path.islink(jobStorePath)
+                        if self.jobstore_initialized.moveExports:
+                            # Ensure the export performed a move / link
+                            self.assertTrue(jobStoreHasLink)
+                            self.assertEqual(os.path.realpath(jobStorePath), dstUrl[7:])
+                        else:
+                            # Ensure the export has not moved the job store file
+                            self.assertFalse(jobStoreHasLink)
+
                     # Remove local Files
                     os.remove(srcUrl[7:])
                     os.remove(dstUrl[7:])

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 from __future__ import division
+
 from future import standard_library
 
 standard_library.install_aliases()
@@ -36,7 +37,6 @@ from stubserver import FTPStubServer
 from abc import abstractmethod, ABCMeta
 from itertools import chain, islice
 from threading import Thread
-from unittest import skip
 from six.moves.queue import Queue
 from six.moves import SimpleHTTPServer, StringIO
 from six import iteritems
@@ -47,7 +47,6 @@ from toil.lib.memoize import memoize
 from toil.lib.exceptions import panic
 # noinspection PyPackageRequirements
 # (installed by `make prepare`)
-from mock import patch
 
 from toil.lib.compatibility import USING_PYTHON2
 from toil.common import Config, Toil
@@ -682,7 +681,7 @@ class AbstractJobStoreTest(object):
                                        for testCls in testClasses
                                        if not getattr(testCls, '__unittest_skip__', False)}
 
-            def testImportExportFile(self, otherCls, size):
+            def testImportExportFile(self, otherCls, size, moveExports):
                 """
                 :param AbstractJobStoreTest.Test self: the current test case
 
@@ -693,6 +692,8 @@ class AbstractJobStoreTest(object):
                 """
                 # Prepare test file in other job store
                 self.jobstore_initialized.partSize = cls.mpTestPartSize
+                self.jobstore_initialized.moveExports = moveExports
+
                 # The string in otherCls() is arbitrary as long as it returns a class that has access
                 # to ._externalStore() and ._prepareTestFile()
                 other = otherCls('testSharedFiles')
@@ -709,7 +710,17 @@ class AbstractJobStoreTest(object):
                 dstUrl = other._prepareTestFile(store)
                 self.jobstore_initialized.exportFile(jobStoreFileID, dstUrl)
                 self.assertEqual(fileMD5, other._hashTestFile(dstUrl))
-                if otherCls.__name__ == 'FileJobStoreTest':  # Remove local Files
+                if otherCls.__name__ == 'FileJobStoreTest':
+                    jobStorePath = self.jobstore_initialized._getFilePathFromId(jobStoreFileID)
+                    jobStoreHasLink = os.path.islink(jobStorePath)
+                    if self.jobstore_initialized.moveExports:
+                        # Ensure the export performed a move / link
+                        self.assertTrue(jobStoreHasLink)
+                        self.assertEqual(os.path.realpath(jobStorePath), dstUrl[7:])
+                    else:
+                        # Ensure the export has not moved the job store file
+                        self.assertFalse(jobStoreHasLink)
+                    # Remove local Files
                     os.remove(srcUrl[7:])
                     os.remove(dstUrl[7:])
 
@@ -719,7 +730,8 @@ class AbstractJobStoreTest(object):
                                  oneMiB=2 ** 20,
                                  partSizeMinusOne=cls.mpTestPartSize - 1,
                                  partSize=cls.mpTestPartSize,
-                                 partSizePlusOne=cls.mpTestPartSize + 1))
+                                 partSizePlusOne=cls.mpTestPartSize + 1),
+                       moveExports={'deactivated': None, 'activated': True})
 
             def testImportSharedFile(self, otherCls):
                 """
@@ -1116,7 +1128,6 @@ class FileJobStoreTest(AbstractJobStoreTest.Test):
         shutil.rmtree(self.jobstore_initialized.jobStoreDir)
 
     def _prepareTestFile(self, dirPath, size=None):
-        import binascii
         fileName = 'testfile_%s' % uuid.uuid4()
         localFilePath = dirPath + fileName
         url = 'file://%s' % localFilePath


### PR DESCRIPTION
Toil currently has a "linkImports" parameter, used by fileJobStores only, to prevent copying of files present in the input into the job store and replacing the copy by a link.

This pull request introduces a "moveExports" parameter, also used in fileJobStores only, allowing to move the file from the job_store to the output directory, preventing the copy. In the job store, the file is replaced by a link to its new location in the output directory.