### PR TITLE
Eliminate sleep time on --restart

### DIFF
--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -40,6 +40,7 @@ import uuid
 
 from toil.lib.objects import abstractclassmethod
 from toil.lib.humanize import bytes2human
+from toil.lib.misc import WriteWatchingStream
 from toil.common import cacheDirName, getDirSizeRecursively, getFileSystemSize
 from toil.lib.bioio import makePublicDir
 
@@ -243,6 +244,7 @@ class AbstractFileStore(with_metaclass(ABCMeta, object)):
             
             # When the stream is written to, count the bytes
             def handle(numBytes):
+                # No scope problem here, because we don't assign to a fileID local
                 fileID.size += numBytes 
             wrappedStream.onWrite(handle)
             
@@ -463,61 +465,4 @@ class AbstractFileStore(with_metaclass(ABCMeta, object)):
         raise NotImplementedError()
 
 
-class WriteWatchingStream(object):
-    """
-    A stream wrapping class that calls any functions passed to onWrite() with the number of bytes written for every write.
-    
-    Not seekable.
-    """
-    
-    def __init__(self, backingStream):
-        """
-        Wrap the given backing stream.
-        """
-        
-        self.backingStream = backingStream
-        # We have no write listeners yet
-        self.writeListeners = []
-        
-    def onWrite(self, listener):
-        """
-        Call the given listener with the number of bytes written on every write.
-        """
-        
-        self.writeListeners.append(listener)
-        
-    # Implement the file API from https://docs.python.org/2.4/lib/bltin-file-objects.html
-        
-    def write(self, data):
-        """
-        Write the given data to the file.
-        """
-        
-        # Do the write
-        self.backingStream.write(data)
-        
-        for listener in self.writeListeners:
-            # Send out notifications
-            listener(len(data))
-            
-    def writelines(self, datas):
-        """
-        Write each string from the given iterable, without newlines.
-        """
-        
-        for data in datas:
-            self.write(data)
-            
-    def flush(self):
-        """
-        Flush the backing stream.
-        """
-        
-        self.backingStream.flush()
-        
-    def close(self):
-        """
-        Close the backing stream.
-        """
-        
-        self.backingStream.close()
+

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -452,6 +452,7 @@ class AWSJobStore(AbstractJobStore):
             srcKey.get_contents_to_file(writable)
         finally:
             srcKey.bucket.connection.close()
+        return srcKey.size
 
     @classmethod
     def _writeToUrl(cls, readable, url):

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -309,9 +309,13 @@ class FileJobStore(AbstractJobStore):
         :param str url: A path as a string of the file to be read from.
         :param object writable: An open file object to write to.
         """
+        
         # we use a ~10Mb buffer to improve speed
         with open(cls._extractPathFromUrl(url), 'rb') as readable:
             shutil.copyfileobj(readable, writable, length=cls.BUFFER_SIZE)
+            # Return the number of bytes we read when we reached EOF.
+            return readable.tell()
+        
 
     @classmethod
     def _writeToUrl(cls, readable, url):

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -643,7 +643,6 @@ class FileJobStore(AbstractJobStore):
         if not self.restart:
             if not self.waitForExists(jobStoreID,30):
                 raise NoSuchJobException(jobStoreID)
-        raise NoSuchJobException(jobStoreID)
 
     def _getFilePathFromId(self, jobStoreFileID):
         """

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -248,7 +248,6 @@ class FileJobStore(AbstractJobStore):
                     try:
                         if self.exists(jobId):
                             yield self.load(jobId)
-                        raise NoSuchJobException(jobId)
                     except NoSuchJobException:
                         # An orphaned job may leave an empty or incomplete job file which we can safely ignore
                         pass

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -33,7 +33,6 @@ except ImportError:
     import pickle
 
 # toil dependencies
-from toil.job import Toil
 from toil.fileStores import FileID
 from toil.lib.bioio import absSymPath
 from toil.lib.misc import mkdir_p, robust_rmtree, AtomicFileCreate, atomic_copy, atomic_copyobj

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -95,8 +95,6 @@ class FileJobStore(AbstractJobStore):
 
         self.linkImports = None
 
-        self.restart = False
-
     def __repr__(self):
         return 'FileJobStore({})'.format(self.jobStoreDir)
 
@@ -174,7 +172,6 @@ class FileJobStore(AbstractJobStore):
         over the course of large workflows with a jobStore on a busy NFS."""
         for iTry in range(1,maxTries+1):
             jobFile = self._getJobFileName(jobStoreID)
-            logging.debug("being called waitforexists for {}".format(jobStoreID))
             if os.path.exists(jobFile):
                 return True
             if iTry >= maxTries:
@@ -251,8 +248,7 @@ class FileJobStore(AbstractJobStore):
                     try:
                         if self.exists(jobId):
                             yield self.load(jobId)
-                        else:
-                            raise NoSuchFileException(jobId)
+                        raise NoSuchJobException(jobId)
                     except NoSuchJobException:
                         # An orphaned job may leave an empty or incomplete job file which we can safely ignore
                         pass

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -33,6 +33,7 @@ except ImportError:
     import pickle
 
 # toil dependencies
+from toil.job import Toil
 from toil.fileStores import FileID
 from toil.lib.bioio import absSymPath
 from toil.lib.misc import mkdir_p, robust_rmtree, AtomicFileCreate, atomic_copy, atomic_copyobj
@@ -112,6 +113,7 @@ class FileJobStore(AbstractJobStore):
         mkdir_p(self.jobFilesDir)
         mkdir_p(self.sharedFilesDir)
         self.linkImports = config.linkImports
+        self.restart = config.restart
         super(FileJobStore, self).initialize(config)
 
     def resume(self):
@@ -172,6 +174,7 @@ class FileJobStore(AbstractJobStore):
         over the course of large workflows with a jobStore on a busy NFS."""
         for iTry in range(1,maxTries+1):
             jobFile = self._getJobFileName(jobStoreID)
+            logging.debug("being called waitforexists for {}".format(jobStoreID))
             if os.path.exists(jobFile):
                 return True
             if iTry >= maxTries:
@@ -636,8 +639,10 @@ class FileJobStore(AbstractJobStore):
         """
         Raises a NoSuchJobException if the job with ID jobStoreID does not exist.
         """
-        if not self.waitForExists(jobStoreID,30):
-            raise NoSuchJobException(jobStoreID)
+        if not self.restart:
+            if not self.waitForExists(jobStoreID,30):
+                raise NoSuchJobException(jobStoreID)
+        raise NoSuchJobException(jobStoreID)
 
     def _getFilePathFromId(self, jobStoreFileID):
         """

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -114,7 +114,6 @@ class FileJobStore(AbstractJobStore):
         mkdir_p(self.jobFilesDir)
         mkdir_p(self.sharedFilesDir)
         self.linkImports = config.linkImports
-        self.restart = config.restart
         super(FileJobStore, self).initialize(config)
 
     def resume(self):
@@ -248,8 +247,12 @@ class FileJobStore(AbstractJobStore):
                 logger.warning('Job Dir: %s' % i)
                 if i.startswith(self.JOB_DIR_PREFIX):
                     # This is a job instance directory
+                    jobId = self._getJobIdFromDir(os.path.join(tempDir, i))
                     try:
-                        yield self.load(self._getJobIdFromDir(os.path.join(tempDir, i)))
+                        if self.exists(jobId):
+                            yield self.load(jobId)
+                        else:
+                            raise NoSuchFileException(jobId)
                     except NoSuchJobException:
                         # An orphaned job may leave an empty or incomplete job file which we can safely ignore
                         pass
@@ -640,9 +643,8 @@ class FileJobStore(AbstractJobStore):
         """
         Raises a NoSuchJobException if the job with ID jobStoreID does not exist.
         """
-        if not self.restart:
-            if not self.waitForExists(jobStoreID,30):
-                raise NoSuchJobException(jobStoreID)
+        if not self.waitForExists(jobStoreID,30):
+            raise NoSuchJobException(jobStoreID)
 
     def _getFilePathFromId(self, jobStoreFileID):
         """

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -95,6 +95,8 @@ class FileJobStore(AbstractJobStore):
 
         self.linkImports = None
 
+        self.restart = False
+
     def __repr__(self):
         return 'FileJobStore({})'.format(self.jobStoreDir)
 

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -349,6 +349,7 @@ class GoogleJobStore(AbstractJobStore):
     def _readFromUrl(cls, url, writable):
         blob = cls._getBlobFromURL(url, exists=True)
         blob.download_to_file(writable)
+        return blob.size
 
     @classmethod
     def _supportsUrl(cls, url, export=False):

--- a/src/toil/lib/misc.py
+++ b/src/toil/lib/misc.py
@@ -244,3 +244,62 @@ def atomic_copyobj(src_fh, dest_path, length=16384):
     with AtomicFileCreate(dest_path) as dest_path_tmp:
         with open(dest_path_tmp, 'wb') as dest_path_fh:
             shutil.copyfileobj(src_fh, dest_path_fh, length=length)
+
+class WriteWatchingStream(object):
+    """
+    A stream wrapping class that calls any functions passed to onWrite() with the number of bytes written for every write.
+    
+    Not seekable.
+    """
+    
+    def __init__(self, backingStream):
+        """
+        Wrap the given backing stream.
+        """
+        
+        self.backingStream = backingStream
+        # We have no write listeners yet
+        self.writeListeners = []
+        
+    def onWrite(self, listener):
+        """
+        Call the given listener with the number of bytes written on every write.
+        """
+        
+        self.writeListeners.append(listener)
+        
+    # Implement the file API from https://docs.python.org/2.4/lib/bltin-file-objects.html
+        
+    def write(self, data):
+        """
+        Write the given data to the file.
+        """
+        
+        # Do the write
+        self.backingStream.write(data)
+        
+        for listener in self.writeListeners:
+            # Send out notifications
+            listener(len(data))
+            
+    def writelines(self, datas):
+        """
+        Write each string from the given iterable, without newlines.
+        """
+        
+        for data in datas:
+            self.write(data)
+            
+    def flush(self):
+        """
+        Flush the backing stream.
+        """
+        
+        self.backingStream.flush()
+        
+    def close(self):
+        """
+        Close the backing stream.
+        """
+        
+        self.backingStream.close()


### PR DESCRIPTION
This should pass the stage of needing to check for jobstore on `--restart`. 