### PR TITLE
Add support for --awsEc2ExtraSecurityGroupId.

### DIFF
--- a/docs/running/cloud/amazon.rst
+++ b/docs/running/cloud/amazon.rst
@@ -205,6 +205,12 @@ custom IAM role with all necessary permissions and set the ``--awsEc2ProfileArn`
 when launching the cluster. Note that your custom role must at least have
 :ref:`these permissions <minAwsPermissions>` in order for the Toil cluster to function properly.
 
+In addition, Toil creates a new security group with the same name as the cluster name with
+default rules (e.g. opens port 22 for SSH access). If you require additional security groups,
+you may use the ``--awsEc2ExtraSecurityGroupId`` parameter when launching the cluster.
+**Note:** Do not use the same name as the cluster name for the extra security groups as
+any security group matching the cluster name will be deleted once the cluster is destroyed.
+
 For more information on options try: ::
 
     (venv) $ toil launch-cluster --help

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -88,6 +88,10 @@ def main():
                         help="If provided, the specified ARN is used as the instance profile for EC2 instances."
                              "Useful for setting custom IAM profiles. If not specified, a new IAM role is created "
                              "by default with sufficient access to perform basic cluster operations.")
+    parser.add_argument('--awsEc2ExtraSecurityGroupId', dest='awsEc2ExtraSecurityGroupIds', default=[], action='append',
+                        help="Any additional security groups to attach to EC2 instances. Note that a security group "
+                             "with its name equal to the cluster name will always be created, thus ensure that "
+                             "the extra security groups do not have the same name as the cluster name.")
     config = parseBasicOptions(parser)
     tagsDict = None if config.tags is None else createTagsDict(config.tags)
     checkValidNodeTypes(config.provisioner, config.nodeTypes)
@@ -146,7 +150,8 @@ def main():
                           botoPath=config.botoPath,
                           userTags=tagsDict,
                           vpcSubnet=config.vpcSubnet,
-                          awsEc2ProfileArn=config.awsEc2ProfileArn)
+                          awsEc2ProfileArn=config.awsEc2ProfileArn,
+                          awsEc2ExtraSecurityGroupIds=config.awsEc2ExtraSecurityGroupIds)
 
     for nodeType, workers in zip(nodeTypes, numNodes):
         cluster.addNodes(nodeType=nodeType, numNodes=workers, preemptable=False)


### PR DESCRIPTION
Adds the ability to specify other predefined security groups for a Toil cluster (e.g. if a DB access is restricted to a set of security groups and cannot be dynamically modified).

Tested:
* Launched, ran, and destroyed a cluster with multiple `--awsEc2ExtraSecurityGroupId`
* Launched, ran, and destroyed a cluster without specifying `--awsEc2ExtraSecurityGroupId`

Resolves #2995 