### PR TITLE
[easy] Raise and warn the user if using "cwltoil".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ def runSetup():
             'console_scripts': [
                 'toil = toil.utils.toilMain:main',
                 '_toil_worker = toil.worker:main',
+                'cwltoil = toil.cwl.cwltoil:cwltoil_is_deprecated [cwl]',
                 'toil-cwl-runner = toil.cwl.cwltoil:main [cwl]',
                 'toil-wdl-runner = toil.wdl.toilwdl:main',
                 '_toil_mesos_executor = toil.batchSystems.mesos.executor:main [mesos]',

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ def runSetup():
             'console_scripts': [
                 'toil = toil.utils.toilMain:main',
                 '_toil_worker = toil.worker:main',
-                'cwltoil = toil.cwl.cwltoil:cwltoil_is_deprecated [cwl]',
+                'cwltoil = toil.cwl.cwltoil:cwltoil_was_removed [cwl]',
                 'toil-cwl-runner = toil.cwl.cwltoil:main [cwl]',
                 'toil-wdl-runner = toil.wdl.toilwdl:main',
                 '_toil_mesos_executor = toil.batchSystems.mesos.executor:main [mesos]',

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -90,8 +90,8 @@ CWL_INTERNAL_JOBS = ("CWLJobWrapper", "CWLWorkflow", "CWLScatter", "CWLGather",
 # output object to the correct key of the input object.
 
 
-def cwltoil_is_deprecated():
-    raise RuntimeError('Please run with "toil-cwl-runner" instead of "cwltoil" (deprecated).')
+def cwltoil_was_removed():
+    raise RuntimeError('Please run with "toil-cwl-runner" instead of "cwltoil" (which has been removed).')
 
 
 class IndirectDict(dict):

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -90,6 +90,10 @@ CWL_INTERNAL_JOBS = ("CWLJobWrapper", "CWLWorkflow", "CWLScatter", "CWLGather",
 # output object to the correct key of the input object.
 
 
+def cwltoil_is_deprecated():
+    raise RuntimeError('Please run with "toil-cwl-runner" instead of "cwltoil" (deprecated).')
+
+
 class IndirectDict(dict):
     """Tag to indicate a dict is an IndirectDict that needs to resolved."""
     pass


### PR DESCRIPTION
Using `cwltoil` now can result in a confusing error (see: https://github.com/DataBiosphere/toil/issues/2987).

```
Traceback (most recent call last):
      File "/home/ubuntu/toil/src/toil/worker.py", line 366, in workerScript
          job._runner(jobGraph=jobGraph, jobStore=jobStore, fileStore=fileStore, defer=defer)
      File "/home/ubuntu/toil/src/toil/job.py", line 1392, in _runner
          returnValues = self._run(jobGraph, fileStore)
      File "/home/ubuntu/toil/src/toil/job.py", line 1329, in _run
          return self.run(fileStore)
      File "/home/ubuntu/toil/src/toil/cwl/cwltoil.py", line 809, in run
          if self.conditional.is_false(cwljob):
      AttributeError: 'CWLJob' object has no attribute 'conditional'
```

This adds a function to be called when `cwltoil` is run to raise and warn the user.