### PR TITLE
fix python3 string/bytes error when using --printLogs

### DIFF
--- a/src/toil/test/cwl/alwaysfails.cwl
+++ b/src/toil/test/cwl/alwaysfails.cwl
@@ -1,0 +1,11 @@
+#!/usr/bin/env cwl-runner
+# Command that will always fail
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: invalidcommand
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs: []

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -40,7 +40,7 @@ from toil.utils.toilStats import getStats, processData
 from toil.common import Toil, Config
 from toil.provisioners import clusterFactory
 from toil.version import python
-from mock import patch, mock_open
+from mock import patch
 
 logger = logging.getLogger(__name__)
 

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -80,7 +80,7 @@ class ToilStatus():
             if job.logJobStoreFileID is not None:
                 msg = "LOG_FILE_OF_JOB:%s LOG: =======>\n" % job
                 with job.getLogFileHandle(self.jobStore) as fH:
-                    msg += fH.read()
+                    msg += fH.read().decode('utf-8')
                 msg += "<========="
             else:
                 msg = "LOG_FILE_OF_JOB:%s LOG: Job has no log file" % job


### PR DESCRIPTION
Adds `decode('utf-8')` method call to fix the following error:
```
  .../toil/utils/toilStatus.py", line 83, in printJobLog
    msg += fH.read()
TypeError: can only concatenate str (not "bytes") to str
```
This fix is already being used in leader.py FailedJobsException:
https://github.com/DataBiosphere/toil/blob/993be0c3d95c83ca969d783e708c48d918407b16/src/toil/leader.py#L79-L80
Let me know if you would prefer a new function to abstract out this duplication. 

For testing the bug I added an example CWL workflow that always fails.

Fixes problem raised in #3004 
