### PR TITLE
Pin setuptools during 'make prepare'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,8 @@ check_build_reqs:
 		|| ( printf "$(red)Build requirements are missing. Run 'make prepare' to install them.$(normal)\n" ; false )
 
 prepare: check_venv
-	$(pip) install mock==1.0.1 pytest==4.3.1 pytest-cov==2.6.1 stubserver==1.0.1 pytest-timeout==1.3.3 cwltest mypy
+	$(pip) install mock==1.0.1 pytest==4.3.1 pytest-cov==2.6.1 stubserver==1.0.1 pytest-timeout==1.3.3 \
+	setuptools==45.3.0 cwltest mypy
 
 check_venv:
 	@$(python) -c 'import sys, os; sys.exit( int( 0 if "VIRTUAL_ENV" in os.environ else 1 ) )' \


### PR DESCRIPTION
A temporary fix for https://github.com/DataBiosphere/toil/issues/3006 .  Unfortunately, I'm going to have to set up (hopefully temporary) separate pypi dependencies with our needed fixes for the related issue: https://github.com/DataBiosphere/toil/issues/2924.