### PR TITLE
Improve and Unify Log Dumping

### DIFF
--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -60,7 +60,7 @@ class FileJobStore(AbstractJobStore):
 
     # What prefix should be on the per-job job directories, to distinguish them
     # from the spray directories?
-    JOB_DIR_PREFIX = 'instance'
+    JOB_DIR_PREFIX = 'instance-'
 
     # What prefix do we put on the per-job-name directories we sort jobs into?
     JOB_NAME_DIR_PREFIX = 'kind-'

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -75,13 +75,12 @@ class FailedJobsException(Exception):
             for jobNode in failedJobs:
                 job = jobStore.load(jobNode.jobStoreID)
                 if job.logJobStoreFileID:
-                    self.msg += "\n=========> Failed job %s \n" % jobNode
                     with job.getLogFileHandle(jobStore) as fH:
-                        self.msg += fH.read().decode('utf-8')
-                    self.msg += "<=========\n"
+                        self.msg += "\n" + StatsAndLogging.formatLogStream(fH, jobNode)
         # catch failures to prepare more complex details and only return the basics
         except:
             logger.exception('Exception when compiling information about failed jobs')
+        self.msg = self.msg.rstrip('\n')
         super().__init__()
         self.jobStoreLocator = jobStoreLocator
         self.numberOfFailedJobs = len(failedJobs)

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -152,7 +152,7 @@ class Resource(namedtuple('Resource', ('name', 'pathHash', 'url', 'contentHash')
             path_key = cls.resourceEnvNamePrefix + pathHash
             s = os.environ[path_key]
         except KeyError:
-            log.warning("'%s' may exist, but is not yet referenced by the worker (KeyError from os.environ[]).", str(path_key))
+            # Resources that don't actually exist but get looked up are normal; don't complain.
             return None
         else:
             self = cls.unpickle(s)

--- a/src/toil/test/docs/scripts/example_alwaysfail.py
+++ b/src/toil/test/docs/scripts/example_alwaysfail.py
@@ -3,6 +3,7 @@ import sys
 
 from toil.common import Toil
 from toil.job import Job
+from toil.leader import FailedJobsException
 
 def main():
     """

--- a/src/toil/test/docs/scripts/example_alwaysfail.py
+++ b/src/toil/test/docs/scripts/example_alwaysfail.py
@@ -1,0 +1,38 @@
+import argparse
+import sys
+
+from toil.common import Toil
+from toil.job import Job
+
+def main():
+    """
+    This workflow always fails.
+    
+    Invoke like:
+    
+        python examples/example_alwaysfail.py ./jobstore
+        
+    Then you can inspect the job store with tools like `toil status`:
+    
+        toil status --printLogs ./jobstore
+        
+    """
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    Job.Runner.addToilOptions(parser)
+    options = parser.parse_args(sys.argv[1:])
+
+    hello_job = Job.wrapJobFn(explode)
+
+    with Toil(options) as toil:
+        toil.start(hello_job)
+
+
+def explode(job):
+    sys.stderr.write('Something somewhere has gone terribly wrong\n')
+    raise RuntimeError('Boom!')
+    
+
+if __name__=="__main__":
+    main()
+
+    

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -400,8 +400,10 @@ class UtilsTest(ToilTest):
         # print log and check output
         status = ToilStatus(self.toilDir)
         status.printJobLog()
+        
+        # Make sure it printed some kind of complaint about the missing command.
         args, kwargs = mock_print.call_args
-        self.assertIn('LOG_FILE_OF_JOB', args[0])
+        self.assertIn('invalidcommand', args[0])
 
 
 def printUnicodeCharacter():

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -389,7 +389,6 @@ class UtilsTest(ToilTest):
         self.check_status('COMPLETED', status_fn=ToilStatus.getStatus)
 
     @needs_cwl
-    @needs_docker
     @patch('builtins.print')
     def testPrintJobLog(self, mock_print):
         """Test that ToilStatus.printJobLog() reads the log from a failed command without error."""

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -183,7 +183,7 @@ class UtilsTest(ToilTest):
 
             # `toil rsync-cluster`
             # Testing special characters - string.punctuation
-            fname = '!"#$%&\'()*+,-.;<=>:\ ?@[\\\\]^_`{|}~'
+            fname = r'!"#$%&\'()*+,-.;<=>:\ ?@[\\]^_`{|}~'
             testData = os.urandom(3 * (10**6))
             with tempfile.NamedTemporaryFile(suffix=fname) as tmpFile:
                 relpath = os.path.basename(tmpFile.name)

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -33,6 +33,7 @@ from toil.lib.bioio import parseBasicOptions
 from toil.common import Toil, jobStoreLocatorHelp, Config
 from toil.jobStores.abstractJobStore import NoSuchJobStoreException, NoSuchFileException
 from toil.job import JobException
+from toil.statsAndLogging import StatsAndLogging
 from toil.version import version
 
 logger = logging.getLogger(__name__)
@@ -78,13 +79,14 @@ class ToilStatus():
         """Takes a list of jobs, finds their log files, and prints them to the terminal."""
         for job in self.jobsToReport:
             if job.logJobStoreFileID is not None:
-                msg = "LOG_FILE_OF_JOB:%s LOG: =======>\n" % job
+                # TODO: This looks intended to be machine-readable, but the format is
+                # unspecified and no escaping is done. But keep these tags around.
+                msg = "LOG_FILE_OF_JOB:%s LOG:" % job
                 with job.getLogFileHandle(self.jobStore) as fH:
-                    msg += fH.read().decode('utf-8')
-                msg += "<========="
+                    msg += StatsAndLogging.formatLogStream(fH)
+                print(msg)
             else:
-                msg = "LOG_FILE_OF_JOB:%s LOG: Job has no log file" % job
-            print(msg)
+                print("LOG_FILE_OF_JOB:%s LOG: Job has no log file" % job)
 
     def printJobChildren(self):
         """Takes a list of jobs, and prints their successors."""


### PR DESCRIPTION
I think this will fix #3004.

I initially meant to make it print out a message encouraging the user to run `toil status --printLogs`, but it turns out FailedJobsException is supposed to dump the logs, and it wasn't doing it because of changes to exceptions in Python 3.

So I went through and made the job log dumping consistent in all the places I could find it happening. It now goes through a single method, and it should be easier to see in a noisy Toil log.

@arostamianfar The output from `toil status --printLogs` looks vaguely machine-readable, and I'm changing its format a bit. Will that upset your dashboards?

We might want to have a test for FailedJobsException and/or the leader dumping job logs, but I'm not quite sure where to put it.