### PR TITLE
Update Sphinx and let its version float

### DIFF
--- a/docs/vendor/sphinxcontrib/fulltoc.py
+++ b/docs/vendor/sphinxcontrib/fulltoc.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 #
 # Copyright © 2012 New Dream Network, LLC (DreamHost)
+# Copyright © 2020 Regents of the University of California
 #
 # Author: Doug Hellmann <doug.hellmann@dreamhost.com>
 #
@@ -39,31 +40,36 @@ def html_page_context(app, pagename, templatename, context, doctree):
         # json builder doesn't use toctree func, so nothing to replace
         return
 
-    def make_toctree(collapse=True):
+    def make_toctree(**kwargs):
+        kwargs['prune'] = False
         return get_rendered_toctree(app.builder,
                                     pagename,
-                                    prune=False,
-                                    collapse=collapse,
+                                    **kwargs,
                                     )
 
     context['toctree'] = make_toctree
 
 
-def get_rendered_toctree(builder, docname, prune=False, collapse=True):
+def get_rendered_toctree(builder, docname, **kwargs):
     """Build the toctree relative to the named document,
     with the given parameters, and then return the rendered
     HTML fragment.
     """
+    
+    if kwargs.get('prune', None) is None:
+        kwargs['prune'] = False
+    if kwargs.get('collapse', None) is None:
+        kwargs['collapse'] = True
+    
     fulltoc = build_full_toctree(builder,
                                  docname,
-                                 prune=prune,
-                                 collapse=collapse,
+                                 **kwargs
                                  )
     rendered_toc = builder.render_partial(fulltoc)['fragment']
     return rendered_toc
 
 
-def build_full_toctree(builder, docname, prune, collapse):
+def build_full_toctree(builder, docname, prune, collapse, **kwargs):
     """Return a single toctree starting from docname containing all
     sub-document doctrees.
     """
@@ -74,6 +80,7 @@ def build_full_toctree(builder, docname, prune, collapse):
         toctree = env.resolve_toctree(docname, builder, toctreenode,
                                       collapse=collapse,
                                       prune=prune,
+                                      **kwargs
                                       )
         toctrees.append(toctree)
     if not toctrees:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def runSetup():
     docker = 'docker==2.5.1'
     dateutil = 'python-dateutil'
     addict = 'addict<=2.2.0'
-    sphinx = 'sphinx==1.7.6'
+    sphinx = 'sphinx>=2.4.4, <3'
     pathlib2 = 'pathlib2==2.3.2'
 
     core_reqs = [

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def runSetup():
     docker = 'docker==2.5.1'
     dateutil = 'python-dateutil'
     addict = 'addict<=2.2.0'
-    sphinx = 'sphinx==1.7.5'
+    sphinx = 'sphinx==1.7.6'
     pathlib2 = 'pathlib2==2.3.2'
 
     core_reqs = [


### PR DESCRIPTION
This should fix #3010. I had to hack the Sphinx TOC hack we got from DreamHost, which I think was the thing holding us back on Sphinx <1.7.6. I've made it a bit more robust against new Sphinx kwargs being added, and I've relaxed the Sphinx constraint to anything between the current latest version (2.4.4) and 3.0, whatever that will be.

@rikardn does that work for you? Or is there a particular Sphinx version other than the very latest that you want us to support?