### PR TITLE
don't list specific CWL features, try them all (and fix some CWL running bugs)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,13 @@ cwl_v1.1:
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv11Test
 
+cwl_v1.2:
+  stage: test
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv12Test
+
 wdl:
   stage: test
   script:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def runSetup():
     gcs = 'google-cloud-storage==1.6.0'
     gcs_oauth2_boto_plugin = 'gcs_oauth2_boto_plugin==1.14'
     apacheLibcloud = 'apache-libcloud==2.2.1'
-    cwltool = 'cwltool<=3.0.20200317203547'
+    cwltool = 'cwltool==3.0.20200324120055'
     galaxyToolUtil = 'galaxy-tool-util'
     htcondor = 'htcondor>=8.6.0'
     kubernetes = 'kubernetes>=10, <11'

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def runSetup():
     gcs = 'google-cloud-storage==1.6.0'
     gcs_oauth2_boto_plugin = 'gcs_oauth2_boto_plugin==1.14'
     apacheLibcloud = 'apache-libcloud==2.2.1'
-    cwltool = 'cwltool<=2.0.20200126090152'
+    cwltool = 'cwltool<=3.0.20200317203547'
     galaxyToolUtil = 'galaxy-tool-util'
     htcondor = 'htcondor>=8.6.0'
     kubernetes = 'kubernetes>=10, <11'

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -69,7 +69,7 @@ from cwltool.loghandler import _logger as cwllogger
 from cwltool.loghandler import defaultStreamHandler
 from cwltool.pathmapper import (PathMapper, adjustDirObjs, adjustFileObjs,
                                 get_listing, MapperEnt, visit_class,
-                                normalizeFilesDirs)
+                                normalizeFilesDirs, downloadHttpFile)
 from cwltool.process import (shortname, fill_in_defaults, compute_checksums,
                              add_sizes, Process)
 from cwltool.secrets import SecretStore

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -1287,15 +1287,6 @@ class CWLWorkflow(Job):
         return UnresolvedDict(outobj)
 
 
-cwltool.process.supportedProcessRequirements = (
-    "DockerRequirement", "ExpressionEngineRequirement",
-    "InlineJavascriptRequirement", "InitialWorkDirRequirement",
-    "SchemaDefRequirement", "EnvVarRequirement", "CreateFileRequirement",
-    "SubworkflowFeatureRequirement", "ScatterFeatureRequirement",
-    "ShellCommandRequirement", "MultipleInputFeatureRequirement",
-    "StepInputExpressionRequirement", "ResourceRequirement")
-
-
 def visitSteps(cmdline_tool: Union[cwltool.command_line_tool.CommandLineTool, cwltool.workflow.Workflow],
                op: Any) -> None:
     if isinstance(cmdline_tool, cwltool.workflow.Workflow):

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -22,10 +22,12 @@ import os
 import tempfile
 import json
 import sys
+import stat
 import logging
 import copy
 import functools
 import uuid
+import urllib
 import datetime
 from typing import (Text,
                     Mapping,
@@ -46,6 +48,7 @@ from six.moves.urllib import parse as urlparse
 
 from schema_salad import validate
 from schema_salad.schema import Names
+from schema_salad.sourceline import SourceLine
 import schema_salad.ref_resolver
 
 import cwltool.errors
@@ -491,20 +494,48 @@ class ToilPathMapper(PathMapper):
 
         elif obj["class"] == "File":
             path = obj["location"]
-            if "contents" in obj and obj["location"].startswith("_:"):
+            ab = cwltool.stdfsaccess.abspath(path, basedir)
+            if "contents" in obj and path.startswith("_:"):
                 self._pathmap[path] = MapperEnt(
                     obj["contents"],
                     tgt,
-                    "CreateFile",  # TODO: Allow "WritableFile" here; see base class
+                    "CreateWritableFile" if copy else "CreateFile",
+                    # "CreateFile",  # TODO: Allow "WritableFile" here; see base class
                     staged)
             else:
-                resolved = self.get_file(path) if self.get_file else path
-                if resolved.startswith("file:"):
-                    resolved = schema_salad.ref_resolver.uri_file_path(resolved)
-                self._pathmap[path] = MapperEnt(
-                    resolved, tgt, "WritableFile" if copy else "File", staged)
-                self.visitlisting(obj.get("secondaryFiles", []),
-                                  stagedir, basedir, copy=copy, staged=staged)
+                with SourceLine(
+                    obj,
+                    "location",
+                    validate.ValidationException,
+                    cwllogger.isEnabledFor(logging.DEBUG),
+                ):
+                    deref = self.get_file(path) if self.get_file else ab
+                    if deref.startswith("file:"):
+                        deref = schema_salad.ref_resolver.uri_file_path(deref)
+                    if urllib.parse.urlsplit(deref).scheme in ["http", "https"]:
+                        deref = downloadHttpFile(path)
+                    elif urllib.parse.urlsplit(deref).scheme != 'toilfs':
+                        # Dereference symbolic links
+                        st = os.lstat(deref)
+                        while stat.S_ISLNK(st.st_mode):
+                            rl = os.readlink(deref)
+                            deref = (
+                                rl
+                                if os.path.isabs(rl)
+                                else os.path.join(os.path.dirname(deref), rl)
+                            )
+                            st = os.lstat(deref)
+
+                    self._pathmap[path] = MapperEnt(
+                        deref, tgt, "WritableFile" if copy else "File", staged
+                    )
+            self.visitlisting(
+                obj.get("secondaryFiles", []),
+                stagedir,
+                basedir,
+                copy=copy,
+                staged=staged,
+            )
 
 
 class ToilCommandLineTool(cwltool.command_line_tool.CommandLineTool):
@@ -689,7 +720,7 @@ def toilStageFiles(file_store: AbstractFileStore,
 
         if not os.path.exists(os.path.dirname(p.target)):
             os.makedirs(os.path.dirname(p.target), 0o0755)
-        if p.type == "File":
+        if p.type == "File" and not os.path.exists(p.target):
             file_store.exportFile(FileID.unpack(p.resolved[7:]), "file://" + p.target)
         elif p.type == "Directory" and not os.path.exists(p.target):
             os.makedirs(p.target, 0o0755)

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -422,15 +422,14 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # # TODO: we do not currently pass tests: 55, 213, 236, 242, 243, 244, 245, 246, 249
-            # selected_tests = '1-212,214-235,237-241,247-248,250-276'
+            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
+            selected_tests = '1-212,214-235,237-241,247-248,250-276'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
                    f'--timeout=2400',
                    f'--basedir={self.cwlSpec}',
-                   '--verbose']
-                   # f'-n={selected_tests}']
+                   f'-n={selected_tests}']
             if batchSystem:
                 cmd.extend(["--batchSystem", batchSystem])
 

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -422,18 +422,23 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
-            selected_tests = '1-212,214-235,237-241,247-248,250-276'
+            # # TODO: we do not currently pass tests: 55, 213, 236, 242, 243, 244, 245, 246, 249
+            # selected_tests = '1-212,214-235,237-241,247-248,250-276'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
                    f'--timeout=2400',
                    f'--basedir={self.cwlSpec}',
-                   f'-n={selected_tests}']
+                   '--verbose']
+                   # f'-n={selected_tests}']
             if batchSystem:
                 cmd.extend(["--batchSystem", batchSystem])
+
+            args_passed_directly_to_toil = ['--enable-dev']
             if caching:
-                cmd.extend(['--', '--disableCaching="False"'])
+                args_passed_directly_to_toil.extend(['--disableCaching="False"'])
+            cmd.extend(['--'] + args_passed_directly_to_toil)
+
             subprocess.check_output(cmd, cwd=self.cwlSpec, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             only_unsupported = False

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -360,8 +360,8 @@ class CWLv11Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246
-            selected_tests = '1-212,214-235,237-241,247-253'
+            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
+            selected_tests = '1-212,214-235,237-241,247-248,250-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
@@ -422,8 +422,8 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246
-            selected_tests = '1-212,214-235,237-241,247-253'
+            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
+            selected_tests = '1-212,214-235,237-241,247-248,250-276'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -388,3 +388,65 @@ class CWLv11Test(ToilTest):
             if not only_unsupported:
                 print(error_log)
                 raise e
+
+@needs_cwl
+class CWLv12Test(ToilTest):
+    @classmethod
+    def setUpClass(cls):
+        """Runs anew before each test to create farm fresh temp dirs."""
+        cls.outDir = f'/tmp/toil-cwl-v1_2-test-{str(uuid.uuid4())}'
+        os.makedirs(cls.outDir)
+        cls.rootDir = cls._projectRootPath()
+        cls.cwlSpec = os.path.join(cls.rootDir, 'src/toil/test/cwl/spec_v12')
+        cls.test_yaml = os.path.join(cls.cwlSpec, 'conformance_tests.yaml')
+        # TODO: Use a commit zip in case someone decides to rewrite master's history?
+        url = 'https://github.com/common-workflow-language/cwl-v1.2.git'
+        commit = 'fca122ef126d03da8c8091111ef5d0cf75763382'
+        p = subprocess.Popen(f'git clone {url} {cls.cwlSpec} && cd {cls.cwlSpec} && git checkout {commit}', shell=True)
+        p.communicate()
+
+    def tearDown(self):
+        """Clean up outputs."""
+        if os.path.exists(self.outDir):
+            shutil.rmtree(self.outDir)
+        unittest.TestCase.tearDown(self)
+
+    @slow
+    @pytest.mark.timeout(2400)
+    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
+    @pytest.mark.xfail
+    def test_run_conformance_with_caching(self):
+        self.test_run_conformance(caching=True)
+
+    @slow
+    @pytest.mark.timeout(2400)
+    def test_run_conformance(self, batchSystem=None, caching=False):
+        try:
+            # TODO: we do not currently run tests: 55, 213, 236, 242, 243, 244, 245, 246
+            selected_tests = '1-54,56-212,214-235,237-241,247-253'
+            cmd = [f'cwltest',
+                   f'--tool=toil-cwl-runner',
+                   f'--test={self.test_yaml}',
+                   f'--timeout=2400',
+                   f'--basedir={self.cwlSpec}',
+                   f'-n={selected_tests}']
+            if batchSystem:
+                cmd.extend(["--batchSystem", batchSystem])
+            if caching:
+                cmd.extend(['--', '--disableCaching="False"'])
+            subprocess.check_output(cmd, cwd=self.cwlSpec, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            only_unsupported = False
+            # check output -- if we failed but only have unsupported features, we're okay
+            p = re.compile(r"(?P<failures>\d+) failures, (?P<unsupported>\d+) unsupported features")
+
+            error_log = e.output.decode('utf-8')
+            for line in error_log.split('\n'):
+                m = p.search(line)
+                if m:
+                    if int(m.group("failures")) == 0 and int(m.group("unsupported")) > 0:
+                        only_unsupported = True
+                        break
+            if not only_unsupported:
+                print(error_log)
+                raise e

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -46,7 +46,7 @@ class CWLv10Test(ToilTest):
         self.workDir = os.path.join(self.cwlSpec, 'v1.0')
         # The latest cwl git commit hash from https://github.com/common-workflow-language/common-workflow-language.
         # Update it to get the latest tests.
-        testhash = '9ddfa5bd2c432fb426087ad938113d4b32a0b36a'
+        testhash = '40fcfc01812046f012acf5153cc955ee848e69e3' # Date:   Tue Jan 21 07:36:37 2020 +0100
         url = 'https://github.com/common-workflow-language/common-workflow-language/archive/%s.zip' % testhash
         if not os.path.exists(self.cwlSpec):
             urlretrieve(url, 'spec.zip')
@@ -360,8 +360,8 @@ class CWLv11Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently run tests: 213, 242, 244, 246, 249
-            selected_tests = '1-212,214-241,243,245,247-248,250-253'
+            # TODO: we do not currently run tests: 55, 213, 236, 242, 243, 244, 245, 246
+            selected_tests = '1-54,56-212,214-235,237-241,247-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -360,8 +360,8 @@ class CWLv11Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently run tests: 55, 213, 236, 242, 243, 244, 245, 246
-            selected_tests = '1-54,56-212,214-235,237-241,247-253'
+            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246
+            selected_tests = '1-212,214-235,237-241,247-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
@@ -422,8 +422,8 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently run tests: 55, 213, 236, 242, 243, 244, 245, 246
-            selected_tests = '1-54,56-212,214-235,237-241,247-253'
+            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246
+            selected_tests = '1-212,214-235,237-241,247-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',


### PR DESCRIPTION
When running all the CWL v1.1 conformance tests, there are 9 more tests that successfully pass:

`246 tests passed, 7 failures, 0 unsupported features`

(4 "unsupported features" are now failing tests)

- [x] investigate regression of test 55 (fails in v1.0 as well)