### PR TITLE
Add less and vim to docker.

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -47,6 +47,8 @@ dependencies = ' '.join(['libffi-dev',  # For client side encryption for extras 
                          'pkg-config',
                          'squashfs-tools',
                          'cryptsetup',
+                         'less',
+                         'vim',
                          'git'])
 
 


### PR DESCRIPTION
I've often found using `less` and `vi` when debugging things inside the Toil appliance image, and kinda annoying to have to install it every time. I figured since they don't really add much overhead to the image, we could just include them by default.

I didn't create an issue for this since it's a trivial change, but lemme know if you like one!