### PR TITLE
Make dependency on Python3.6+ machine-readable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ def runSetup():
           'Topic :: System :: Distributed Computing',
           'Topic :: Utilities'],
         license="Apache License v2.0",
+        python_requires=">=3.6",
         install_requires=core_reqs,
         extras_require={
             'aws': aws_reqs,


### PR DESCRIPTION
I don't want to pin to 3.6 exactly because we can work fine on newer versions without the Mesos extra.

This might make #3020 be magically solved by a Conda bot.