### PR TITLE
Make Sphinx a make prepare component and not a dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,12 +208,12 @@ clean_docs: check_venv
 clean: clean_develop clean_sdist clean_docs
 
 check_build_reqs:
-	@$(python) -c 'import mock; import pytest' \
+	@($(python) -c 'import mock; import pytest' && which sphinx-build >/dev/null) \
 		|| ( printf "$(red)Build requirements are missing. Run 'make prepare' to install them.$(normal)\n" ; false )
 
 prepare: check_venv
 	$(pip) install mock==1.0.1 pytest==4.3.1 pytest-cov==2.6.1 stubserver==1.0.1 pytest-timeout==1.3.3 \
-	setuptools==45.3.0 cwltest mypy
+	setuptools==45.3.0 'sphinx>=2.4.4,<3' cwltest mypy
 
 check_venv:
 	@$(python) -c 'import sys, os; sys.exit( int( 0 if "VIRTUAL_ENV" in os.environ else 1 ) )' \

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ def runSetup():
     docker = 'docker==2.5.1'
     dateutil = 'python-dateutil'
     addict = 'addict<=2.2.0'
-    sphinx = 'sphinx>=2.4.4, <3'
     pathlib2 = 'pathlib2==2.3.2'
 
     core_reqs = [
@@ -65,7 +64,6 @@ def runSetup():
         dateutil,
         psutil,
         addict,
-        sphinx,
         pathlib2,
         pytz]
 


### PR DESCRIPTION
This will fix #3022 by convincing pip not to get docutils via Sphinx. I think
the new pip solver wouldn't really need it though.

This also will fix #3013 by making Sphinx not come along at runtime.