### PR TITLE
Test python3.8 and build a python3.8 appliance.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,7 +229,7 @@ py38_batch_systems:
   stage: test
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
     - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
     - python -m pytest -s -r s src/toil/test/batchSystems/batchSystemTest.py
     - python -m pytest -s -r s src/toil/test/mesos/MesosDataStructuresTest.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 image: quay.io/vgteam/vg_ci_prebake:latest
-# Note that we must run in a priviliged container for our internal Docker daemon to come up.
+# Note that we must run in a privileged container for our internal Docker daemon to come up.
 
 before_script:
   - startdocker || true
@@ -210,6 +210,108 @@ py37_provisioner_integration:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
+    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
+    - export LIBPROCESS_IP=127.0.0.1
+    - python setup_gitlab_docker.py
+    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - make push_docker
+    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
+    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
+    # - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
+    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
+
+# Python3.8
+py38_batch_systems:
+  stage: test
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - python -m pytest -s -r s src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
+
+py38_cwl_v1.0:
+  stage: test
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
+    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv10Test
+
+py38_cwl_v1.1:
+  stage: test
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv11Test
+
+py38_wdl:
+  stage: test
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - python -m pytest -s -r s src/toil/test/wdl/toilwdlTest.py
+
+py38_jobstore_and_provisioning:
+  stage: test
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
+    - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
+#    - python -m pytest -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
+# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
+
+py38_main:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest -s -r s src/toil/test/src
+    - python -m pytest -s -r s src/toil/test/utils
+
+py38_appliance_build:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+py38_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - export TOIL_TEST_INTEGRATIVE=True
+    - export TOIL_AWS_KEYNAME=id_rsa
+    - export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - chmod 400 /root/.ssh/id_rsa
+    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
+
+py38_provisioner_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
     - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
     - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
     - export LIBPROCESS_IP=127.0.0.1

--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -27,14 +27,9 @@ pip = f'{python} -m pip'
 
 
 dependencies = ' '.join(['libffi-dev',  # For client side encryption for extras with PyNACL
-                         'python3.6',
-                         'python3.6-dev',
-                         'python3.7',
-                         'python3.7-dev',
-                         'python3.8',
-                         'python3.8-dev',
-                         'python-dev',  # For installing Python packages with native code
-                         'python-pip',  # Bootstrap pip, but needs upgrading, see below
+                         python,
+                         f'{python}-dev',
+                         'python3.8-distutils' if python == 'python3.8' else '',
                          'python3-pip',
                          'libcurl4-openssl-dev',
                          'libssl-dev',
@@ -45,7 +40,7 @@ dependencies = ' '.join(['libffi-dev',  # For client side encryption for extras 
                          "nodejs",  # CWL support for javascript expressions
                          'rsync',
                          'screen',
-                         'build-essential', # We need a build environment to build Singularity 3.
+                         'build-essential',  # We need a build environment to build Singularity 3.
                          'uuid-dev',
                          'libgpgme11-dev',
                          'libseccomp-dev',
@@ -121,6 +116,9 @@ print(heredoc('''
     ADD customDockerInit.sh /usr/bin/customDockerInit.sh
 
     RUN chmod 777 /usr/bin/waitForKey.sh && chmod 777 /usr/bin/customDockerInit.sh
+    
+    # fixes an incompatibility updating pip on Ubuntu 16 w/ python3.8
+    RUN sed -i "s/platform.linux_distribution()/('Ubuntu', '16.04', 'xenial')/g" /usr/lib/python3/dist-packages/pip/download.py
     
     # The stock pip is too old and can't install from sdist with extras
     RUN {pip} install --upgrade pip==20.0.2

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def runSetup():
     htcondor = 'htcondor>=8.6.0'
     kubernetes = 'kubernetes>=10, <11'
     pytz = 'pytz>=2012'
-    dill = 'dill==0.2.7.1'
+    dill = 'dill==0.3.1.1'
     six = 'six>=1.10.0'
     future = 'future'
     requests = 'requests>=2, <3'


### PR DESCRIPTION
After tests run and pass, ~~I'd like to remove all but the `main` tests for python3.6 and python3.7 and begin running toil in python3.8.~~

Edit: Hmmm... the `main` tests pass with the updated `dill` package, but it's concerning to me that the run times seem to be:

`python3.6`: 20 minutes 49 seconds (https://ucsc-ci.com/databiosphere/toil/-/jobs/48177)
`python3.7`: 23 minutes 36 seconds (https://ucsc-ci.com/databiosphere/toil/-/jobs/48179)
`python3.8`: 45 minutes 18 seconds (https://ucsc-ci.com/databiosphere/toil/-/jobs/48181)

Maybe we should stick to python3.7 as our main test version for the moment and create an issue to log more fine-grained test times as a summary at the end of each run so that we know exactly which tests are taking longer.