### PR TITLE
Mainly test python3.7.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,73 +19,22 @@ after_script:
   - stopdocker || true
 
 stages:
+  - basic_tests
   - main_tests
-  - test
   - integration
 
 
 # Python3.6
-batch_systems:
-  stage: test
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python -m pytest -s -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
-
-cwl_v1.0:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
-    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv10Test
-
-cwl_v1.1:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv11Test
-
-cwl_v1.2:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv12Test
-
-wdl:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest -s -r s src/toil/test/wdl/toilwdlTest.py
-
-jobstore_and_provisioning:
-  stage: test
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
-    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-
 main:
-  stage: main_tests
+  stage: basic_tests
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -s -r s src/toil/test/src
-    - python -m pytest -s -r s src/toil/test/utils
+    - python -m pytest --duration=0 -s -r s src/toil/test/src
+    - python -m pytest --duration=0 -s -r s src/toil/test/utils
 
 appliance_build:
-  stage: main_tests
+  stage: basic_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
@@ -93,40 +42,6 @@ appliance_build:
     # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
     - python setup_gitlab_docker.py
     - make push_docker
-
-integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - export TOIL_TEST_INTEGRATIVE=True
-    - export TOIL_AWS_KEYNAME=id_rsa
-    - export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - chmod 400 /root/.ssh/id_rsa
-    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
-
-provisioner_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-    - export LIBPROCESS_IP=127.0.0.1
-    - python setup_gitlab_docker.py
-    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - make push_docker
-    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
-    # - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
 
 
 # Python3.7
@@ -136,8 +51,8 @@ py37_batch_systems:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python -m pytest -s -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
   stage: test
@@ -146,7 +61,7 @@ py37_cwl_v1.0:
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
-    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv10Test
+    - python -m pytest --duration=0 -s -r s src/toil/test/cwl/cwlTest.py::CWLv10Test
 
 py37_cwl_v1.1:
   stage: test
@@ -154,7 +69,7 @@ py37_cwl_v1.1:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv11Test
+    - python -m pytest --duration=0 -s -r s src/toil/test/cwl/cwlTest.py::CWLv11Test
 
 py37_wdl:
   stage: test
@@ -162,7 +77,7 @@ py37_wdl:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest -s -r s src/toil/test/wdl/toilwdlTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/toilwdlTest.py
 
 py37_jobstore_and_provisioning:
   stage: test
@@ -170,25 +85,25 @@ py37_jobstore_and_provisioning:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
-    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
 # https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
 # guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
 
 py37_main:
-  stage: main_tests
+  stage: basic_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -s -r s src/toil/test/src
-    - python -m pytest -s -r s src/toil/test/utils
+    - python -m pytest --duration=0 -s -r s src/toil/test/src
+    - python -m pytest --duration=0 -s -r s src/toil/test/utils
 
 py37_appliance_build:
-  stage: main_tests
+  stage: basic_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
@@ -209,7 +124,7 @@ py37_integration:
     # This reads GITLAB_SECRET_FILE_SSH_KEYS
     - python setup_gitlab_ssh.py
     - chmod 400 /root/.ssh/id_rsa
-    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
 
 py37_provisioner_integration:
   stage: integration
@@ -225,72 +140,24 @@ py37_provisioner_integration:
     # This reads GITLAB_SECRET_FILE_SSH_KEYS
     - python setup_gitlab_ssh.py
     - make push_docker
-    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
-    # - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
+    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
     # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
     # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
 
 # Python3.8
-py38_batch_systems:
-  stage: test
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python -m pytest -s -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
-
-py38_cwl_v1.0:
-  stage: test
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
-    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv10Test
-
-py38_cwl_v1.1:
-  stage: test
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest -s -r s src/toil/test/cwl/cwlTest.py::CWLv11Test
-
-py38_wdl:
-  stage: test
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest -s -r s src/toil/test/wdl/toilwdlTest.py
-
-py38_jobstore_and_provisioning:
-  stage: test
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
-    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-
 py38_main:
-  stage: main_tests
+  stage: basic_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
     - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest -s -r s src/toil/test/src
-    - python -m pytest -s -r s src/toil/test/utils
+    - python -m pytest --duration=0 -s -r s src/toil/test/src
+    - python -m pytest --duration=0 -s -r s src/toil/test/utils
 
 py38_appliance_build:
-  stage: main_tests
+  stage: basic_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
@@ -298,37 +165,3 @@ py38_appliance_build:
     # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
     - python setup_gitlab_docker.py
     - make push_docker
-
-py38_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - export TOIL_TEST_INTEGRATIVE=True
-    - export TOIL_AWS_KEYNAME=id_rsa
-    - export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - chmod 400 /root/.ssh/id_rsa
-    - python -m pytest -s -r s src/toil/test/jobStores/jobStoreTest.py
-
-py38_provisioner_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-    - export LIBPROCESS_IP=127.0.0.1
-    - python setup_gitlab_docker.py
-    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - make push_docker
-    - python -m pytest -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest -s -r s src/toil/test/provisioners/clusterScalerTest.py
-    # - python -m pytest -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ appliance_build:
 
 # Python3.7
 py37_batch_systems:
-  stage: test
+  stage: main_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
@@ -55,7 +55,7 @@ py37_batch_systems:
     - python -m pytest --duration=0 -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
-  stage: test
+  stage: main_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
@@ -64,7 +64,7 @@ py37_cwl_v1.0:
     - python -m pytest --duration=0 -s -r s src/toil/test/cwl/cwlTest.py::CWLv10Test
 
 py37_cwl_v1.1:
-  stage: test
+  stage: main_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
@@ -72,7 +72,7 @@ py37_cwl_v1.1:
     - python -m pytest --duration=0 -s -r s src/toil/test/cwl/cwlTest.py::CWLv11Test
 
 py37_wdl:
-  stage: test
+  stage: main_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
@@ -80,7 +80,7 @@ py37_wdl:
     - python -m pytest --duration=0 -s -r s src/toil/test/wdl/toilwdlTest.py
 
 py37_jobstore_and_provisioning:
-  stage: test
+  stage: main_tests
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev


### PR DESCRIPTION
This keeps all python 3.7 tests, deletes python 3.6 and 3.8 tests except for the basic python `src`/`utils` tests.  This still tests building the appliance for python3.6, python3.7, and python3.8.

This also adds `--duration=0` so all test times will be displayed at the end of each run.  Ideally at some point we can log these in a data base and notice when we significantly increase test times.