### PR TITLE
Detect insufficient resources and deadlocks more usefully

### DIFF
--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -236,13 +236,18 @@ the logging module:
                         concurrently on preemptable nodes.
                         default=9223372036854775807
   --deadlockWait DEADLOCKWAIT
-                        The minimum number of seconds to observe the cluster
-                        stuck running only the same service jobs before
-                        throwing a deadlock exception. default=60
+                        Time, in seconds, to tolerate the workflow running only
+                        the same service jobs, with no jobs to use them, before
+                        declaring the workflow to be deadlocked and stopping.
+                        default=60
   --deadlockCheckInterval DEADLOCKCHECKINTERVAL
-                        The number of seconds to wait between deadlock
-                        detection checks. Should be shorter than
-                        --deadlockWait. default=30
+                        Time, in seconds, to wait between checks to see if the
+                        workflow is stuck running only service jobs, with no
+                        jobs to use them. Should be shorter than
+                        --deadlockWait. May need to be increased if the batch
+                        system cannot enumerate running jobs quickly enough, or
+                        if polling for running jobs is placing an unacceptable
+                        load on a shared cluster. default=30
   --statePollingWait STATEPOLLINGWAIT
                         Time, in seconds, to wait before doing a scheduler
                         query for job state. Return cached results if within

--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -239,6 +239,10 @@ the logging module:
                         The minimum number of seconds to observe the cluster
                         stuck running only the same service jobs before
                         throwing a deadlock exception. default=60
+  --deadlockCheckInterval DEADLOCKCHECKINTERVAL
+                        The number of seconds to wait between deadlock
+                        detection checks. Should be shorter than
+                        --deadlockWait. default=10
   --statePollingWait STATEPOLLINGWAIT
                         Time, in seconds, to wait before doing a scheduler
                         query for job state. Return cached results if within

--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -242,7 +242,7 @@ the logging module:
   --deadlockCheckInterval DEADLOCKCHECKINTERVAL
                         The number of seconds to wait between deadlock
                         detection checks. Should be shorter than
-                        --deadlockWait. default=10
+                        --deadlockWait. default=30
   --statePollingWait STATEPOLLINGWAIT
                         Time, in seconds, to wait before doing a scheduler
                         query for job state. Return cached results if within

--- a/src/toil/batchSystems/__init__.py
+++ b/src/toil/batchSystems/__init__.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from past.builtins import cmp
-from builtins import str
-from builtins import object
 import sys
 
-if sys.version_info >= (3, 0):
+from functools import total_ordering
 
-    # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
-    def cmp(a, b):
-        return (a > b) - (a < b)
-
-class MemoryString(object):
+@total_ordering
+class MemoryString:
+    """
+    Represents an amount of bytes, as a string, using suffixes for the unit.
+    
+    Comparable based on the actual number of bytes instead of string value.
+    """
     def __init__(self, string):
         if string[-1] == 'K' or string[-1] == 'M' or string[-1] == 'G' or string[-1] == 'T': #10K
             self.unit = string[-1]
@@ -55,8 +53,8 @@ class MemoryString(object):
         elif self.unit == 'T':
             return self.val * 1099511627776
 
-    def __cmp__(self, other):
-        return cmp(self.bytes, other.bytes)
+    def __eq__(self, other):
+        return self.bytes == other.bytes
 
-    def __gt__(self, other):
-        return self.bytes > other.bytes
+    def __lt__(self, other):
+        return self.bytes < other.bytes

--- a/src/toil/batchSystems/__init__.py
+++ b/src/toil/batchSystems/__init__.py
@@ -16,6 +16,21 @@ import sys
 
 from functools import total_ordering
 
+class DeadlockException(Exception):
+    """
+    Exception thrown by the Leader or BatchSystem when a deadlock is encountered due to insufficient
+    resources to run the workflow
+    """
+    def __init__(self, msg):
+        self.msg = "Deadlock encountered: " + msg
+        super().__init__()
+
+    def __str__(self):
+        """
+        Stringify the exception, including the message.
+        """
+        return self.msg
+
 @total_ordering
 class MemoryString:
     """

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -554,10 +554,10 @@ class InsufficientSystemResources(Exception):
 
     def __str__(self):
         if self.name is not None:
-            phrases = [('The job {} is requesting {}{}, more than '
-                        'the maximum of {} {} was configured '
-                        'with.'.format(self.name, self.requested, self.unit,
-                                       self.resource, self.available, self.batchSystem)]
+            phrases = [('The job {} is requesting {} {}{}, more than '
+                        'the maximum of {} {}{} that {} was configured '
+                        'with.'.format(self.name, self.requested, self.unit, self.resource,
+                                       self.available, self.unit, self.resource, self.batchSystem))]
         else:
             phrases = [('Requesting more {} than either physically available to {}, or enforced by --max{}. '
                         'Requested: {}, Available: {}'.format(self.resource, self.batchSystem,

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -180,6 +180,26 @@ class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
                  that were killed.
         """
         raise NotImplementedError()
+        
+    def getSchedulingHint(self):
+        """
+        Get a hint for the user about anything that might be going wrong in the
+        batch system, if available.
+        
+        If no hint is available, return None.
+        
+        This can be used to report what resource is the limiting factor when
+        scheduling jobs, for example. If the leader thinks the workflow is
+        stuck, the hint can be displayed to the user to help them diagnose why
+        it might be stuck.
+        
+        :rtype: str or None
+        :return: User-directed hint about scheduling state.
+        """
+        
+        # Default implementation returns None.
+        # Override to provide hints.
+        return None
 
     @abstractmethod
     def shutdown(self):

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
-from builtins import object
 from past.utils import old_div
 from contextlib import contextmanager
 import logging

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -99,8 +99,8 @@ class Config(object):
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
         self.maxPreemptableServiceJobs = sys.maxsize
         self.maxServiceJobs = sys.maxsize
-        self.deadlockWait = 60  # Number of seconds to wait before declaring a deadlock
-        self.deadlockCheckInterval = 10 # Minimum polling delay for deadlocks
+        self.deadlockWait = 60  # Number of seconds we must be stuck with all services before declaring a deadlock
+        self.deadlockCheckInterval = 30 # Minimum polling delay for deadlocks
         self.statePollingWait = 1  # Number of seconds to wait before querying job state
 
         # Resource requirements

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -100,6 +100,7 @@ class Config(object):
         self.maxPreemptableServiceJobs = sys.maxsize
         self.maxServiceJobs = sys.maxsize
         self.deadlockWait = 60  # Number of seconds to wait before declaring a deadlock
+        self.deadlockCheckInterval = 10 # Minimum polling delay for deadlocks
         self.statePollingWait = 1  # Number of seconds to wait before querying job state
 
         # Resource requirements
@@ -251,6 +252,7 @@ class Config(object):
         setOption("maxServiceJobs", int)
         setOption("maxPreemptableServiceJobs", int)
         setOption("deadlockWait", int)
+        setOption("deadlockCheckInterval", int)
         setOption("statePollingWait", int)
 
         # Resource requirements
@@ -477,6 +479,9 @@ def _addOptions(addGroupFn, config):
         addOptionFn("--deadlockWait", dest="deadlockWait", default=None, type=int,
                     help=(
                     "The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
+        addOptionFn("--deadlockCheckInterval", dest="deadlockCheckInterval", default=None, type=int,
+                    help=(
+                    "The number of seconds to wait between deadlock detection checks. Should be shorter than --deadlockWait. default=%s" % config.deadlockCheckInterval))
         addOptionFn("--statePollingWait", dest="statePollingWait", default=1, type=int,
                     help=("Time, in seconds, to wait before doing a scheduler query for job state. "
                           "Return cached results if within the waiting period."))

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -481,10 +481,17 @@ def _addOptions(addGroupFn, config):
                     "The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
         addOptionFn("--deadlockWait", dest="deadlockWait", default=None, type=int,
                     help=(
-                    "The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
+                    "Time, in seconds, to tolerate the workflow running only the same service "
+                    "jobs, with no jobs to use them, before declaring the workflow to be "
+                    "deadlocked and stopping. default=%s" % config.deadlockWait))
         addOptionFn("--deadlockCheckInterval", dest="deadlockCheckInterval", default=None, type=int,
                     help=(
-                    "The number of seconds to wait between deadlock detection checks. Should be shorter than --deadlockWait. default=%s" % config.deadlockCheckInterval))
+                    "Time, in seconds, to wait between checks to see if the workflow is stuck "
+                    "running only service jobs, with no jobs to use them. Should be shorter than "
+                    "--deadlockWait. May need to be increased if the batch system cannot "
+                    "enumerate running jobs quickly enough, or if polling for running jobs is "
+                    "placing an unacceptable load on a shared cluster. default=%s" %
+                    config.deadlockCheckInterval))
         addOptionFn("--statePollingWait", dest="statePollingWait", default=1, type=int,
                     help=("Time, in seconds, to wait before doing a scheduler query for job state. "
                           "Return cached results if within the waiting period."))

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -468,16 +468,16 @@ def _addOptions(addGroupFn, config):
             "Allows the specification of the maximum number of service jobs "
             "in a cluster. By keeping this limited "
             " we can avoid all the nodes being occupied with services, so causing a deadlock")
-        addOptionFn("--maxServiceJobs", dest="maxServiceJobs", default=None,
+        addOptionFn("--maxServiceJobs", dest="maxServiceJobs", default=None, type=int,
                     help=(
                     "The maximum number of service jobs that can be run concurrently, excluding service jobs running on preemptable nodes. default=%s" % config.maxServiceJobs))
-        addOptionFn("--maxPreemptableServiceJobs", dest="maxPreemptableServiceJobs", default=None,
+        addOptionFn("--maxPreemptableServiceJobs", dest="maxPreemptableServiceJobs", default=None, type=int,
                     help=(
                     "The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
-        addOptionFn("--deadlockWait", dest="deadlockWait", default=None,
+        addOptionFn("--deadlockWait", dest="deadlockWait", default=None, type=int,
                     help=(
                     "The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
-        addOptionFn("--statePollingWait", dest="statePollingWait", default=1,
+        addOptionFn("--statePollingWait", dest="statePollingWait", default=1, type=int,
                     help=("Time, in seconds, to wait before doing a scheduler query for job state. "
                           "Return cached results if within the waiting period."))
 

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -243,7 +243,6 @@ class FileJobStore(AbstractJobStore):
         # is in progress.
         for tempDir in self._jobDirectories():
             for i in os.listdir(tempDir):
-                logger.warning('Job Dir: %s' % i)
                 if i.startswith(self.JOB_DIR_PREFIX):
                     # This is a job instance directory
                     jobId = self._getJobIdFromDir(os.path.join(tempDir, i))

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -36,6 +36,7 @@ except ImportError:
     # CWL extra not installed
     CWL_INTERNAL_JOBS = ()
 from toil.jobStores.abstractJobStore import NoSuchJobException
+from toil.batchSystems import DeadlockException
 from toil.lib.throttle import LocalThrottle
 from toil.provisioners.clusterScaler import ScalerThread
 from toil.serviceManager import ServiceManager
@@ -91,22 +92,6 @@ class FailedJobsException(Exception):
         """
         return self.msg
     
-
-####################################################
-# Exception thrown by the Leader class when a deadlock is encountered due to insufficient
-# resources to run the workflow
-####################################################
-
-class DeadlockException(Exception):
-    def __init__(self, msg):
-        self.msg = "Deadlock encountered: " + msg
-        super().__init__()
-
-    def __str__(self):
-        """
-        Stringify the exception, including the message.
-        """
-        return self.msg
 
 ####################################################
 ##Following class represents the leader

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -615,19 +615,19 @@ class Leader(object):
             if len(runningServiceJobs) == totalRunningJobs:
                 # There could be trouble; we are 100% services.
                 # See if the batch system has anything to say for itself about its failure to run our jobs.
-                hint = self.batchSystem.getSchedulingHint()
-                if hint is not None:
-                    # Prepend something explaining the hint
-                    hint = "The batch system reports: {}".format(hint)
+                message = self.batchSystem.getSchedulingStatusMessage()
+                if message is not None:
+                    # Prepend something explaining the message
+                    message = "The batch system reports: {}".format(message)
                 else:
-                    # Use a generic hint if none is available
-                    hint = "Cluster may be too small."
+                    # Use a generic message if none is available
+                    message = "Cluster may be too small."
                     
             
                 # See if this is a new potential deadlock
                 if self.potentialDeadlockedJobs != runningServiceJobs:
                     logger.warning(("Potential deadlock detected! All %s running jobs are service jobs, "
-                                    "with no normal jobs to use them! %s"), totalRunningJobs, hint)
+                                    "with no normal jobs to use them! %s"), totalRunningJobs, message)
                     self.potentialDeadlockedJobs = runningServiceJobs
                     self.potentialDeadlockTime = time.time()
                 else:
@@ -643,7 +643,7 @@ class Leader(object):
                         waitingNormalJobs = self.getNumberOfJobsIssued() - totalServicesIssued
                         logger.warning(("Potentially deadlocked for %.0f seconds. Waiting at most %.0f more seconds "
                                         "for any of %d issued non-service jobs to schedule and start. %s"),
-                                       stuckFor, self.config.deadlockWait - stuckFor, waitingNormalJobs, hint)
+                                       stuckFor, self.config.deadlockWait - stuckFor, waitingNormalJobs, message)
             else:
                 # We have observed non-service jobs running, so reset the potential deadlock
                 
@@ -754,8 +754,9 @@ class Leader(object):
         Report the current status of the workflow to the user.
         """
         
-        # For now just log our status hint to the log.
-        # TODO: fancier UI?
+        # For now just log our scheduling status message to the log.
+        # TODO: make this update fast enought to put it in the progress
+        # bar/status line.
         logger.info(self._getStatusHint())
 
     def removeJob(self, jobBatchSystemID):

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -550,7 +550,8 @@ class Leader(object):
                 self.clusterScaler.check()
             
             if len(self.toilState.updatedJobs) == 0 and self.deadlockThrottler.throttle(wait=False):
-                # It's been long enough since we last checked. Check for deadlocks.
+                # Nothing happened this round and it's been long
+                # enough since we last checked. Check for deadlocks.
                 self.checkForDeadlocks()
                     
 

--- a/src/toil/lib/threading.py
+++ b/src/toil/lib/threading.py
@@ -43,6 +43,7 @@ class BoundedEmptySemaphore( BoundedSemaphore ):
     def __init__( self, value=1, verbose=None ):
         super( BoundedEmptySemaphore, self ).__init__( value, verbose )
         for i in range( value ):
+            # Empty out the semaphore
             assert self.acquire( blocking=False )
 
 

--- a/src/toil/lib/throttle.py
+++ b/src/toil/lib/throttle.py
@@ -19,11 +19,8 @@ from __future__ import absolute_import
 from builtins import object
 import time
 import threading
-import logging
 
 from toil.lib.threading import BoundedEmptySemaphore
-
-logger = logging.getLogger( __name__ )
 
 class GlobalThrottle(object):
     """
@@ -115,7 +112,6 @@ class LocalThrottle(object):
                     remainder = self.min_interval - interval
                     time.sleep( remainder )
                 else:
-                    logger.info("You must wait! Throttle ready in %d seconds", self.min_interval - interval)
                     return False
         self.per_thread.last_invocation = now
         return True

--- a/src/toil/lib/throttle.py
+++ b/src/toil/lib/throttle.py
@@ -19,9 +19,11 @@ from __future__ import absolute_import
 from builtins import object
 import time
 import threading
+import logging
 
 from toil.lib.threading import BoundedEmptySemaphore
 
+logger = logging.getLogger( __name__ )
 
 class GlobalThrottle(object):
     """
@@ -113,6 +115,7 @@ class LocalThrottle(object):
                     remainder = self.min_interval - interval
                     time.sleep( remainder )
                 else:
+                    logger.info("You must wait! Throttle ready in %d seconds", self.min_interval - interval)
                     return False
         self.per_thread.last_invocation = now
         return True

--- a/src/toil/lib/throttle.py
+++ b/src/toil/lib/throttle.py
@@ -22,6 +22,7 @@ import threading
 
 from toil.lib.threading import BoundedEmptySemaphore
 
+
 class GlobalThrottle(object):
     """
     A thread-safe rate limiter that throttles all threads globally. This should be used to


### PR DESCRIPTION
This fixes #3016. 
That issue is really caused by Cactus setting the deadlock checking time too high, so it takes us an hour to even see the oops-all-services deadlock, and another hour to do anything about it.

This PR changes Toil to separate the time we wait to terminate the workflow from the time we wait to see if there's a deadlock. It adds some warning-level log messages when the deadlock checker *starts* to think there's a deadlock, and it is able to pull a hint from the batch system (currently only implemented for `SingleMachineBatchSystem`) that can suggest to the user why the deadlock might be happening.

With Cactus installed, I did this to produce a service deadlock:

```
mkdir -p ~/mnt/tmpfs
sudo mount -t tmpfs -o size=2200000000 tmpfs ~/mnt/tmpfs
TMPDIR=$HOME/mnt/tmpfs cactus --workDir=$HOME/mnt/tmpfs ./tree examples/evolverMammals.txt examples/evolverMammals.hal --root mr
```

And now I get these messages about it:

```
Issued job 'CactusSetupPhase' kind-CactusSetupPhase/instance-juylrkhr with job batch system ID: 2 and cores: 1, disk: 2.0 G, and memory: 3.3 G
Potential deadlock detected! All 1 running jobs are service jobs, with no normal jobs to use them! The batch system reports: Not enough disk to run job 2
Potentially deadlocked for 30 seconds. Waiting at most 3570 more seconds for any of 1 issued non-service jobs to schedule and start. The batch system reports: Not enough disk to run job 2
Potentially deadlocked for 60 seconds. Waiting at most 3540 more seconds for any of 1 issued non-service jobs to schedule and start. The batch system reports: Not enough disk to run job 2
...
```

It might be noisy in big cluster runs, but you can (manually) up `--deadlockCheckInterval` if you know you're on a batch system that takes a while to schedule jobs and don't want to hear about it. It might make sense to up it (and the deadlock wait too) when running with autoscaling, automatically, if we can work out how.
