### PR TITLE
Stop CWL from trying to copy downloaded directories from somewhere local

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -674,9 +674,9 @@ def prepareDirectoryForUpload(directory_metadata: dict,
                 
     # The metadata for a directory is all we need to keep around for it. It
     # doesn't have a real location. But each directory needs a unique location
-    # or CWL won't ship the metadata along. CWL takes "_:" as a signal to make
-    # directories instead of copying from somewhere. So we give every directory
-    # a unique _: location and CWL's machinery Just Works.
+    # or cwltool won't ship the metadata along. cwltool takes "_:" as a signal
+    # to make directories instead of copying from somewhere. So we give every
+    # directory a unique _: location and cwltool's machinery Just Works.
     directory_metadata["location"] = "_:" + directory_metadata["location"]
     
     logger.debug("Sending directory: %s", directory_metadata)

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -171,8 +171,6 @@ class CWLv10Test(ToilTest):
 
     @slow
     @pytest.mark.timeout(2400)
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_run_conformance_with_caching(self):
         self.test_run_conformance(caching=True)
 
@@ -206,48 +204,36 @@ class CWLv10Test(ToilTest):
     @slow
     @needs_lsf
     @unittest.skip
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_lsf_cwl_conformance_with_caching(self):
         return self.test_run_conformance(batchSystem="LSF", caching=True)
 
     @slow
     @needs_slurm
     @unittest.skip
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_slurm_cwl_conformance_with_caching(self):
         return self.test_run_conformance(batchSystem="Slurm", caching=True)
 
     @slow
     @needs_torque
     @unittest.skip
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_torque_cwl_conformance_with_caching(self):
         return self.test_run_conformance(batchSystem="Torque", caching=True)
 
     @slow
     @needs_gridengine
     @unittest.skip
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_gridengine_cwl_conformance_with_caching(self):
         return self.test_run_conformance(batchSystem="gridEngine", caching=True)
 
     @slow
     @needs_mesos
     @unittest.skip
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_mesos_cwl_conformance_with_caching(self):
         return self.test_run_conformance(batchSystem="mesos", caching=True)
 
     @slow
     @needs_parasol
     @unittest.skip
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_parasol_cwl_conformance_with_caching(self):
         return self.test_run_conformance(batchSystem="parasol", caching=True)
 

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -360,8 +360,8 @@ class CWLv11Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
-            selected_tests = '1-212,214-235,237-241,247-248,250-253'
+            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246
+            selected_tests = '1-212,214-235,237-241,247-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
@@ -422,8 +422,8 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
-            selected_tests = '1-212,214-235,237-241,247-248,250-276'
+            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246
+            selected_tests = '1-212,214-235,237-241,247-276'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',


### PR DESCRIPTION
[`cwltool` seems to treat `_:` as a special protocol for directories that need to be created rather than resolved to a filesystem path that gets copied.](https://github.com/common-workflow-language/cwltool/blob/9f3b9e7b74d5a904b12674dfd1300b56a48c3d33/cwltool/process.py#L311-L313) Since the Toil file store only stores files, and CWL ships around the whole metadata tree of files and directories needed to fulfill an InitialWorkDir input, we can just tell CWL that all the directories in the metadata come from the `_:` protocol.

For some reason, we can't just set all the directories' locations to just `_:`. They need to be unique for the `PathMapper` to be able to keep them straight. So I'm just prefixing `_:` onto the source `file:` URL that the directory had on the originating machine. This seems to be enough for CWL to both know that the directories are themselves and know that they don't need to be copied from anywhere.

I haven't tested this with any CWL workflows that actually drag along files in their directories (CI tests that, right?), but it works with the empty directory test from #2801. This should fix #2801.