### PR TITLE
Support CWL 1.1 Listing.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ stages:
 
 
 # Python3.6
-main:
+py36_main:
   stage: basic_tests
   script:
     - pwd
@@ -33,7 +33,7 @@ main:
     - python -m pytest --duration=0 -s -r s src/toil/test/src
     - python -m pytest --duration=0 -s -r s src/toil/test/utils
 
-appliance_build:
+py36_appliance_build:
   stage: basic_tests
   script:
     - pwd

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -1412,7 +1412,36 @@ def remove_unprocessed_secondary_files(unfiltered_secondary_files: dict) -> list
     return final_secondary_files
 
 
-def determine_load_listing(tool):
+def determine_load_listing(tool: ToilCommandLineTool):
+    """
+    Determines the directory.listing feature in CWL.
+
+    In CWL, any input directory can have a DIRECTORY_NAME.listing (where DIRECTORY_NAME is any variable name) set to
+    one of the following three options:
+
+        no_listing: DIRECTORY_NAME.listing will be undefined.
+            e.g. inputs.DIRECTORY_NAME.listing == unspecified
+
+        shallow_listing: DIRECTORY_NAME.listing will return a list one level deep of DIRECTORY_NAME's contents.
+            e.g. inputs.DIRECTORY_NAME.listing == [items in directory]
+                 inputs.DIRECTORY_NAME.listing[0].listing == undefined
+                 inputs.DIRECTORY_NAME.listing.length == # of items in directory
+
+        deep_listing: DIRECTORY_NAME.listing will return a list of the entire contents of DIRECTORY_NAME.
+            e.g. inputs.DIRECTORY_NAME.listing == [items in directory]
+                 inputs.DIRECTORY_NAME.listing[0].listing == [items in subdirectory if it exists and is the first item listed]
+                 inputs.DIRECTORY_NAME.listing.length == # of items in directory
+
+    See: https://www.commonwl.org/v1.1/CommandLineTool.html#LoadListingRequirement
+         https://www.commonwl.org/v1.1/CommandLineTool.html#LoadListingEnum
+
+    DIRECTORY_NAME.listing should be determined first from loadListing.
+    If that's not specified, from LoadListingRequirement.
+    Else, default to "no_listing" if unspecified.
+
+    :param tool: ToilCommandLineTool
+    :return str: One of 'no_listing', 'shallow_listing', or 'deep_listing'.
+    """
     load_listing_req, _ = tool.get_requirement("LoadListingRequirement")
     load_listing_tool_req = load_listing_req.get("loadListing", "no_listing") if load_listing_req else "no_listing"
     load_listing = tool.tool.get("loadListing") or load_listing_tool_req

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -349,8 +349,8 @@ class CWLv11Test(ToilTest):
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 245
-            selected_tests = '1-212,214-235,237-244,246-253'
+            # TODO: we do not currently pass tests: 213, 236
+            selected_tests = '1-212,214-235,237-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
@@ -411,8 +411,8 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 245
-            selected_tests = '1-212,214-235,237-244,246-276'
+            # TODO: we do not currently pass tests: 213, 236
+            selected_tests = '1-212,214-235,237-276'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -360,8 +360,8 @@ class CWLv11Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
-            selected_tests = '1-212,214-235,237-241,247-248,250-253'
+            # TODO: we do not currently pass tests: 213, 236, 245, 249
+            selected_tests = '1-212,214-235,237-244,246-248,250-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
@@ -422,8 +422,8 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(2400)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 242, 243, 244, 245, 246, 249
-            selected_tests = '1-212,214-235,237-241,247-248,250-276'
+            # TODO: we do not currently pass tests: 213, 236, 245, 249
+            selected_tests = '1-212,214-235,237-244,246-248,250-276'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -35,6 +35,9 @@ from toil.test import (ToilTest, needs_cwl, slow, needs_docker, needs_lsf,
                        needs_torque)
 
 
+CONFORMANCE_TEST_TIMEOUT = 3600
+
+
 @needs_cwl
 class CWLv10Test(ToilTest):
     def setUp(self):
@@ -46,7 +49,7 @@ class CWLv10Test(ToilTest):
         self.workDir = os.path.join(self.cwlSpec, 'v1.0')
         # The latest cwl git commit hash from https://github.com/common-workflow-language/common-workflow-language.
         # Update it to get the latest tests.
-        testhash = '40fcfc01812046f012acf5153cc955ee848e69e3' # Date:   Tue Jan 21 07:36:37 2020 +0100
+        testhash = '40fcfc01812046f012acf5153cc955ee848e69e3'  # Date:   Tue Jan 21 07:36:37 2020 +0100
         url = 'https://github.com/common-workflow-language/common-workflow-language/archive/%s.zip' % testhash
         if not os.path.exists(self.cwlSpec):
             urlretrieve(url, 'spec.zip')
@@ -170,12 +173,12 @@ class CWLv10Test(ToilTest):
             pass
 
     @slow
-    @pytest.mark.timeout(2400)
+    @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance_with_caching(self):
         self.test_run_conformance(caching=True)
 
     @slow
-    @pytest.mark.timeout(2400)
+    @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
             cmd = ['cwltest', '--tool', 'toil-cwl-runner', '--test=conformance_test_v1.0.yaml',
@@ -336,14 +339,14 @@ class CWLv11Test(ToilTest):
         unittest.TestCase.tearDown(self)
 
     @slow
-    @pytest.mark.timeout(2400)
+    @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
     @pytest.mark.xfail
     def test_run_conformance_with_caching(self):
         self.test_run_conformance(caching=True)
 
     @slow
-    @pytest.mark.timeout(2400)
+    @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
             # TODO: we do not currently pass tests: 213, 236, 245
@@ -398,17 +401,17 @@ class CWLv12Test(ToilTest):
         unittest.TestCase.tearDown(self)
 
     @slow
-    @pytest.mark.timeout(2400)
+    @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
     @pytest.mark.xfail
     def test_run_conformance_with_caching(self):
         self.test_run_conformance(caching=True)
 
     @slow
-    @pytest.mark.timeout(2400)
+    @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236, 245, 249
+            # TODO: we do not currently pass tests: 213, 236, 245
             selected_tests = '1-212,214-235,237-244,246-276'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',


### PR DESCRIPTION
This adds support for the new listing behavior in CWL1.1+.  See tests 242-246.

CWL1.0 tests appear to be passing: https://ucsc-ci.com/databiosphere/toil/-/jobs/53988
CWL1.1 tests appear to pass but 2 fail when caching: https://ucsc-ci.com/databiosphere/toil/-/jobs/53989

The 2 caching failures appear on the master build, so I suppose I should just make an issue to fix it since it's not directly related to this PR: https://ucsc-ci.com/databiosphere/toil/-/jobs/54084