### PR TITLE
Unify logging format

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -18,6 +18,7 @@ import errno
 import logging
 import os
 import requests
+import socket
 import sys
 import time
 from datetime import datetime
@@ -415,7 +416,7 @@ def logProcessContext(config):
     # toil.version.version (string) cannot be imported at top level because it conflicts with
     # toil.version (module) and Sphinx doesn't like that.
     from toil.version import version
-    log.info("Running Toil version %s.", version)
+    log.info("Running Toil version %s on host %s.", version, socket.gethostname())
     log.debug("Configuration: %s", config.__dict__)
 
 

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -53,6 +53,8 @@ from toil.batchSystems.abstractBatchSystem import (AbstractBatchSystem,
                                                    EXIT_STATUS_UNAVAILABLE_VALUE,
                                                    UpdatedBatchJobInfo)
 from toil.common import Toil
+from toil.lib.bioio import configureRootLogger
+from toil.lib.bioio import setLogLevel
 from toil.lib.humanize import human2bytes
 from toil.lib.threading import LastProcessStandingArena
 from toil.resource import Resource
@@ -1039,7 +1041,8 @@ def executor():
 
     """
 
-    logging.basicConfig(level=logging.DEBUG)
+    configureRootLogger()
+    setLogLevel("DEBUG")
     logger.debug("Starting executor")
     
     # If we don't manage to run the child, what should our exit code be?

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -40,6 +40,8 @@ import addict
 from pymesos import MesosExecutorDriver, Executor, decode_data, encode_data
 
 from toil import pickle
+from toil.lib.bioio import configureRootLogger
+from toil.lib.bioio import setLogLevel
 from toil.lib.expando import Expando
 from toil.lib.threading import cpu_count
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
@@ -240,8 +242,8 @@ class MesosExecutor(Executor):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
-    log.debug("Starting executor")
+    configureRootLogger()
+    setLogLevel("DEBUG")
 
     if not os.environ.get("MESOS_AGENT_ENDPOINT"):
         # Some Mesos setups in our tests somehow lack this variable. Provide a

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -153,7 +153,7 @@ def configureRootLogger():
     
     formatStr = ' '.join(['[%(asctime)s]', '[%(threadName)-10s]',
                           '[%(levelname).1s]', '[%(name)s]', '%(message)s'])
-    logging.basicConfig(format=formatStr)
+    logging.basicConfig(format=formatStr, datefmt='%Y-%m-%dT%H:%M:%S%z')
     rootLogger.setLevel(defaultLogLevel)
 
 def setLoggingFromOptions(options):

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 
 from builtins import range
 from builtins import object
-import socket
 import sys
 import os
 import logging
@@ -152,8 +151,7 @@ def configureRootLogger():
     entry point tries to log anything, to ensure consistent formatting.
     """
     
-    formatStr = ' '.join([socket.gethostname(), '%(asctime)s', '%(threadName)s',
-                          '%(levelname)s', '%(name)s:', '%(message)s'])
+    formatStr = ' '.join(['[%(asctime)s]', '[%(threadName)-10.10s]', '[%(levelname).1s]', '[%(name)s]', '%(message)s'])
     logging.basicConfig(format=formatStr)
     rootLogger.setLevel(defaultLogLevel)
 

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -151,7 +151,7 @@ def configureRootLogger():
     entry point tries to log anything, to ensure consistent formatting.
     """
     
-    formatStr = ' '.join(['[%(asctime)s]', '[%(threadName)-10.10s]',
+    formatStr = ' '.join(['[%(asctime)s]', '[%(threadName)-10s]',
                           '[%(levelname).1s]', '[%(name)s]', '%(message)s'])
     logging.basicConfig(format=formatStr)
     rootLogger.setLevel(defaultLogLevel)

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -144,14 +144,24 @@ def _addLoggingOptions(addOptionFn):
     addOptionFn("--rotatingLogging", dest="logRotating", action="store_true", default=False,
                 help="Turn on rotating logging, which prevents log files getting too big.")
 
-def setLoggingFromOptions(options):
+def configureRootLogger():
     """
-    Sets the logging from a dictionary of name/value options.
+    Set up the root logger with handlers and formatting.
+    
+    Should be called (either by itself or via setLoggingFromOptions) before any
+    entry point tries to log anything, to ensure consistent formatting.
     """
+    
     formatStr = ' '.join([socket.gethostname(), '%(asctime)s', '%(threadName)s',
                           '%(levelname)s', '%(name)s:', '%(message)s'])
     logging.basicConfig(format=formatStr)
     rootLogger.setLevel(defaultLogLevel)
+
+def setLoggingFromOptions(options):
+    """
+    Sets the logging from a dictionary of name/value options.
+    """
+    configureRootLogger()
     if options.logLevel is not None:
         setLogLevel(options.logLevel)
     else:

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -151,7 +151,8 @@ def configureRootLogger():
     entry point tries to log anything, to ensure consistent formatting.
     """
     
-    formatStr = ' '.join(['[%(asctime)s]', '[%(threadName)-10.10s]', '[%(levelname).1s]', '[%(name)s]', '%(message)s'])
+    formatStr = ' '.join(['[%(asctime)s]', '[%(threadName)-10.10s]',
+                          '[%(levelname).1s]', '[%(name)s]', '%(message)s'])
     logging.basicConfig(format=formatStr)
     rootLogger.setLevel(defaultLogLevel)
 

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -36,6 +36,7 @@ from toil.common import Toil, safeUnpickleFromStream
 from toil.fileStores.abstractFileStore import AbstractFileStore
 from toil import logProcessContext
 from toil.job import Job
+from toil.lib.bioio import configureRootLogger
 from toil.lib.bioio import setLogLevel
 from toil.lib.bioio import getTotalCpuTime
 from toil.lib.bioio import getTotalCpuTimeAndMemoryUsage
@@ -46,8 +47,6 @@ except ImportError:
     # CWL extra not installed
     CWL_INTERNAL_JOBS = ()
 
-
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 def nextChainableJobGraph(jobGraph, jobStore):
@@ -116,7 +115,8 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
     
     :return int: 1 if a job failed, or 0 if all jobs succeeded
     """
-    logging.basicConfig()
+    
+    configureRootLogger()
     setLogLevel(config.logLevel)
 
     ##########################################


### PR DESCRIPTION
This fixes #3072 by making sure that messages logged in the worker have timestamps on them.

I'm also trying to follow the recommendations at https://reflectoring.io/logging-format/ for "Human-Readable Logging Formats" by reformatting the logging messages. I've made them look like this on both the leader and the worker:

```
[2020-05-27 14:43:04,578] [MainThread] [W] [toil.resource] Can't globalize module ModuleDescriptor(dirPath='/z/home/anovak/workspace/cactus/venv/lib/python3.6/site-packages', name='cactus.progressive.cactus_progressive', fromVirtualEnv=True).
```

The thread name is clipped at/padded to 10 characters, and the level is reduced to a single character. All the fixed-length fields come first so they are lined up. All the metadata is in `[]` to distinguish it visually from the messages. The hostname is removed since I don't think it bought us anything; it doesn't look like it reflects the source hostname for real-time logging messages. I've made the workers log their hostnames when they log the Toil version, in case we want to see what host a weird worker's log came from.