### PR TITLE
get wait duration is far too short of a rest for lsf.

### DIFF
--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -181,7 +181,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
 
     def getWaitDuration(self):
         """We give LSF a second to catch its breath (in seconds)"""
-        return 8
+        return 60
 
     @classmethod
     def obtainSystemConstants(cls):


### PR DESCRIPTION
We use LSF on prem and the 8 second wait duration has caused our HPC admins some headaches because bjobs is being polled to frequently which can cause lsf daemons to be occupied and not available to submit jobs. There is no reason to poll every 8 seconds, so I have changed it to 60 on prem. It has not had any negative consequences in terms of toil performance and it has since made our HPC admins happier.