### PR TITLE
Add a Cactus Kubernetes test to the integration tests on Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,3 +165,29 @@ py38_appliance_build:
     # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
     - python setup_gitlab_docker.py
     - make push_docker
+
+# Cactus-on-Kubernetes integration (as a script and not a pytest test)
+py37_cactus_integration:
+  stage: integration
+  script:
+    - set -e
+    - export TOIL_KUBERNETES_OWNER=toiltest
+    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+    - export TOIL_WORKDIR=/var/lib/toil
+    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+    - BUCKET_NAME=toil-test-$(uuid)
+    - cd
+    - virtualenv --system-site-packages --python python3 venv
+    - . venv/bin/activate
+    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
+    - cd cactus
+    - git fetch origin
+    - git checkout b78fad4cf91f5ac91717796d4357ca8d85b4f7d1
+    - git submodule update --init --recursive
+    - pip install --upgrade setuptools pip
+    - pip install --upgrade .
+    - toil clean aws:us-west-2:${BUCKET_NAME}
+    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
+
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,6 +180,7 @@ py37_cactus_integration:
     - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
     - export TOIL_WORKDIR=/var/lib/toil
     - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+    - mkdir -p ${TOIL_WORKDIR}
     - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
     - cd
     - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,7 +176,7 @@ py37_cactus_integration:
     - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
     - export TOIL_WORKDIR=/var/lib/toil
     - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-    - BUCKET_NAME=toil-test-$(uuid)
+    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
     - cd
     - virtualenv --system-site-packages --python python3 venv
     - . venv/bin/activate

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,6 +171,9 @@ py37_cactus_integration:
   stage: integration
   script:
     - set -e
+    - virtualenv --system-site-packages --python python3.7 venv
+    - . venv/bin/activate
+    - pip install .[aws,kubernetes]
     - export TOIL_KUBERNETES_OWNER=toiltest
     - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
     - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
@@ -178,8 +181,6 @@ py37_cactus_integration:
     - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
     - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
     - cd
-    - virtualenv --system-site-packages --python python3 venv
-    - . venv/bin/activate
     - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
     - cd cactus
     - git fetch origin

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,6 +171,7 @@ py37_cactus_integration:
   stage: integration
   script:
     - set -e
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
     - virtualenv --system-site-packages --python python3.7 venv
     - . venv/bin/activate
     - pip install .[aws,kubernetes]


### PR DESCRIPTION
This should fix #1739, although I think the test still is going to take half an hour longer than we want it to.
I'm just running the test as a Gitlab test, rather than writing a pytest test that tries to talk to a real Kubernetes and clone Cactus.