### PR TITLE
Eliminate recursion in root finding to fix #3080

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1205,6 +1205,7 @@ class Job(BaseJob):
                 jobGraph.services.append([])
 
             # Recursively call to process child services
+            # TODO: What if service nesting depth is more than max Python stack depth?
             for childServiceJob in serviceJob.service._childServices:
                 processService(childServiceJob, depth+1)
 
@@ -1282,6 +1283,7 @@ class Job(BaseJob):
                 def setForServices(serviceJob):
                     serviceJob.prepareForPromiseRegistration(jobStore)
                     for childServiceJob in serviceJob.service._childServices:
+                        # TODO: What if service nesting depth is more than max Python stack depth?
                         setForServices(childServiceJob)
                 for serviceJob in job._services:
                     setForServices(serviceJob)

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -24,6 +24,7 @@ from builtins import super
 import collections
 import importlib
 import inspect
+import itertools
 import logging
 import sys
 import os
@@ -618,18 +619,23 @@ class Job(BaseJob):
         """
         roots = set()
         visited = set()
-        #Function to get the roots of a job
-        def getRoots(job):
+        todo = [self]
+        
+        while len(todo) > 0:
+            # Until we've finished the graph traversal
+            job = todo[-1]
+            todo.pop()
             if job not in visited:
                 visited.add(job)
                 if len(job._directPredecessors) > 0:
-                    list(map(lambda p : getRoots(p), job._directPredecessors))
+                    for other in job._directPredecessors:
+                        todo.append(other)
                 else:
                     roots.add(job)
-                #The following call ensures we explore all successor edges.
-                list(map(lambda c : getRoots(c), job._children +
-                    job._followOns))
-        getRoots(self)
+                for other in itertools.chain(job._children, job._followOns):
+                    # Ensure we explore all successor edges.
+                    todo.append(other)
+        
         return roots
 
     def checkJobGraphConnected(self):

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1045,8 +1045,8 @@ class Job(BaseJob):
             job = todo[-1]
             todo.pop()
             if job not in visited:
-                visited.add(self)
-                for successor in itertools.chain(self._children, self._followOns):
+                visited.add(job)
+                for successor in itertools.chain(job._children, job._followOns):
                     todo.append(successor)
 
     def _checkJobGraphAcylicDFS(self, stack, visited, extraEdges):


### PR DESCRIPTION
It looks like if we create really long sticks of jobs, Toil can run out of stack when traversing connected components.

This makes it use an on-heap stack instead.