### PR TITLE
Add --nodeStorageOverrides option.

### DIFF
--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -189,6 +189,11 @@ the logging module:
                         when they are launched in gigabytes. You may want to
                         set this if your jobs require a lot of disk space. The
                         default value is 50.
+  --nodeStorageOverrides NODESTORAGEOVERRIDES
+                        (optional) Comma-separated list of nodeType:nodeStorage that
+                        are used to override the default value from --nodeStorage for
+                        the specified nodeType(s). This is useful for heterogeneous jobs
+                        where some tasks require much more disk than others.
   --metrics             Enable the prometheus/grafana dashboard for monitoring
                         CPU/RAM usage, queue size, and issued jobs.
   --defaultMemory INT   The default amount of memory to request for a job.

--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -190,9 +190,9 @@ the logging module:
                         set this if your jobs require a lot of disk space. The
                         default value is 50.
   --nodeStorageOverrides NODESTORAGEOVERRIDES
-                        (optional) Comma-separated list of nodeType:nodeStorage that
-                        are used to override the default value from --nodeStorage for
-                        the specified nodeType(s). This is useful for heterogeneous jobs
+                        Comma-separated list of nodeType:nodeStorage that are used
+                        to override the default value from --nodeStorage for the
+                        specified nodeType(s). This is useful for heterogeneous jobs
                         where some tasks require much more disk than others.
   --metrics             Enable the prometheus/grafana dashboard for monitoring
                         CPU/RAM usage, queue size, and issued jobs.

--- a/docs/running/cloud/clusterUtils.rst
+++ b/docs/running/cloud/clusterUtils.rst
@@ -222,9 +222,9 @@ exist yet, Toil will create it for you.
                         any worker instances created when using the -w flag.
                         This is an EBS volume.
   --nodeStorageOverrides NODESTORAGEOVERRIDES
-                        (optional) Comma-separated list of nodeType:nodeStorage that
-                        are used to override the default value from --nodeStorage for
-                        the specified nodeType(s). This is useful for heterogeneous jobs
+                        Comma-separated list of nodeType:nodeStorage that are used
+                        to override the default value from --nodeStorage for the
+                        specified nodeType(s). This is useful for heterogeneous jobs
                         where some tasks require much more disk than others.
 
 **Logging Options**

--- a/docs/running/cloud/clusterUtils.rst
+++ b/docs/running/cloud/clusterUtils.rst
@@ -221,6 +221,11 @@ exist yet, Toil will create it for you.
                         Specify the size (in gigabytes) of the root volume for
                         any worker instances created when using the -w flag.
                         This is an EBS volume.
+  --nodeStorageOverrides NODESTORAGEOVERRIDES
+                        (optional) Comma-separated list of nodeType:nodeStorage that
+                        are used to override the default value from --nodeStorage for
+                        the specified nodeType(s). This is useful for heterogeneous jobs
+                        where some tasks require much more disk than others.
 
 **Logging Options**
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -94,6 +94,7 @@ class Config(object):
         self.scaleInterval = 60
         self.preemptableCompensation = 0.0
         self.nodeStorage = 50
+        self.nodeStorageOverrides = []
         self.metrics = False
 
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
@@ -249,6 +250,7 @@ class Config(object):
             raise RuntimeError('preemptableCompensation (%f) must be between 0.0 and 1.0!'
                                '' % self.preemptableCompensation)
         setOption("nodeStorage", int)
+        setOption("nodeStorageOverrides", parseStrList)
 
         # Parameters to limit service jobs / detect deadlocks
         setOption("maxServiceJobs", int)
@@ -458,6 +460,11 @@ def _addOptions(addGroupFn, config):
                 help=("Specify the size of the root volume of worker nodes when they are launched "
                       "in gigabytes. You may want to set this if your jobs require a lot of disk "
                       "space. The default value is 50."))
+    addOptionFn('--nodeStorageOverrides', default=None,
+                help="(optional) Comma-separated list of nodeType:nodeStorage that are used to "
+                     "override the default value from --nodeStorage for the specified nodeType(s). "
+                     "This is useful for heterogeneous jobs where some tasks require much more "
+                     "disk than others.")
     addOptionFn("--metrics", dest="metrics",
                 default=False, action="store_true",
                 help=(
@@ -870,6 +877,7 @@ class Toil(object):
                                                clusterName=None,
                                                zone=None, # read from instance meta-data
                                                nodeStorage=self.config.nodeStorage,
+                                               nodeStorageOverrides=self.config.nodeStorageOverrides,
                                                sseKey=self.config.sseKey)
             self._provisioner.setAutoscaledNodeTypes(self.config.nodeTypes)
 

--- a/src/toil/provisioners/__init__.py
+++ b/src/toil/provisioners/__init__.py
@@ -17,7 +17,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def clusterFactory(provisioner, clusterName=None, zone=None, nodeStorage=50, sseKey=None):
+def clusterFactory(provisioner, clusterName=None, zone=None, nodeStorage=50, nodeStorageOverrides=None, sseKey=None):
     """
     :param clusterName: The name of the cluster.
     :param provisioner: The cloud type of the cluster.
@@ -30,14 +30,14 @@ def clusterFactory(provisioner, clusterName=None, zone=None, nodeStorage=50, sse
         except ImportError:
             logger.error('The aws extra must be installed to use this provisioner')
             raise
-        return AWSProvisioner(clusterName, zone, nodeStorage, sseKey)
+        return AWSProvisioner(clusterName, zone, nodeStorage, nodeStorageOverrides, sseKey)
     elif provisioner == 'gce':
         try:
             from toil.provisioners.gceProvisioner import GCEProvisioner
         except ImportError:
             logger.error('The google extra must be installed to use this provisioner')
             raise
-        return GCEProvisioner(clusterName, zone, nodeStorage, sseKey)
+        return GCEProvisioner(clusterName, zone, nodeStorage, nodeStorageOverrides, sseKey)
     else:
         raise RuntimeError("Invalid provisioner '%s'" % provisioner)
 

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -107,7 +107,7 @@ class AbstractProvisioner(with_metaclass(ABCMeta, object)):
     """
     LEADER_HOME_DIR = '/root/'  # home directory in the Toil appliance on an instance
 
-    def __init__(self, clusterName=None, zone=None, nodeStorage=50):
+    def __init__(self, clusterName=None, zone=None, nodeStorage=50, nodeStorageOverrides=None):
         """
         Initialize provisioner.
 
@@ -118,6 +118,10 @@ class AbstractProvisioner(with_metaclass(ABCMeta, object)):
         self.clusterName = clusterName
         self._zone = zone
         self._nodeStorage = nodeStorage
+        self._nodeStorageOverrides = {}
+        for override in nodeStorageOverrides or []:
+            nodeShape, storageOverride = override.split(':')
+            self._nodeStorageOverrides[nodeShape] = int(storageOverride)
         self._leaderPrivateIP = None
 
     def readClusterSettings(self):

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -105,8 +105,8 @@ class AWSProvisioner(AbstractProvisioner):
     Implements an AWS provisioner using the boto libraries.
     """
 
-    def __init__(self, clusterName, zone, nodeStorage, sseKey):
-        super(AWSProvisioner, self).__init__(clusterName, zone, nodeStorage)
+    def __init__(self, clusterName, zone, nodeStorage, nodeStorageOverrides, sseKey):
+        super(AWSProvisioner, self).__init__(clusterName, zone, nodeStorage, nodeStorageOverrides)
         self.cloud = 'aws'
         self._sseKey = sseKey
         if not zone:
@@ -201,7 +201,7 @@ class AWSProvisioner(AbstractProvisioner):
             # This is an EBS-backed instance. We will use the root
             # volume, so add the amount of EBS storage requested for
             # the root volume
-            disk = self._nodeStorage * 2 ** 30
+            disk = self._nodeStorageOverrides.get(nodeType, self._nodeStorage) * 2 ** 30
 
         #Underestimate memory by 100M to prevent autoscaler from disagreeing with
         #mesos about whether a job can run on a particular node type
@@ -290,7 +290,7 @@ class AWSProvisioner(AbstractProvisioner):
             else:
                 raise RuntimeError("No spot bid given for a preemptable node request.")
         instanceType = E2Instances[nodeType]
-        bdm = self._getBlockDeviceMapping(instanceType, rootVolSize=self._nodeStorage)
+        bdm = self._getBlockDeviceMapping(instanceType, rootVolSize=self._nodeStorageOverrides.get(nodeType, self._nodeStorage))
 
         keyPath = self._sseKey if self._sseKey else None
         userData = self._getCloudConfigUserData('worker', self._masterPublicKey, keyPath, preemptable)

--- a/src/toil/provisioners/gceProvisioner.py
+++ b/src/toil/provisioners/gceProvisioner.py
@@ -41,8 +41,8 @@ class GCEProvisioner(AbstractProvisioner):
     NODE_BOTO_PATH = "/root/.boto" # boto file path on instances
     SOURCE_IMAGE = (b'projects/flatcar-cloud/global/images/family/flatcar-stable')
 
-    def __init__(self, clusterName, zone, nodeStorage, sseKey):
-        super(GCEProvisioner, self).__init__(clusterName, zone, nodeStorage)
+    def __init__(self, clusterName, zone, nodeStorage, nodeStorageOverrides, sseKey):
+        super(GCEProvisioner, self).__init__(clusterName, zone, nodeStorage, nodeStorageOverrides)
         self.cloud = 'gce'
         self._sseKey = sseKey
 
@@ -181,7 +181,7 @@ class GCEProvisioner(AbstractProvisioner):
         if disk == 0:
             # This is an EBS-backed instance. We will use the root
             # volume, so add the amount of EBS storage requested forhe root volume
-            disk = self._nodeStorage * 2 ** 30
+            disk = self._nodeStorageOverrides.get(nodeType, self._nodeStorage) * 2 ** 30
 
         # Ram is in M.
         #Underestimate memory by 100M to prevent autoscaler from disagreeing with
@@ -248,7 +248,7 @@ class GCEProvisioner(AbstractProvisioner):
         disk = {}
         disk['initializeParams'] = {
             'sourceImage': self.SOURCE_IMAGE,
-            'diskSizeGb' : self._nodeStorage }
+            'diskSizeGb' : self._nodeStorageOverrides.get(nodeType, self._nodeStorage) }
         disk.update({'boot': True,
              'autoDelete': True })
 

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -39,7 +39,7 @@ class AWSProvisionerBenchTest(ToilTest):
     
     def testAMIFinding(self):
         for zone in ['us-west-2a', 'eu-central-1a', 'sa-east-1b']:
-            provisioner = AWSProvisioner('fakename', zone, 10000, None)
+            provisioner = AWSProvisioner('fakename', zone, 10000, None, None)
             ami = provisioner._discoverAMI()
             # Make sure we got an AMI and it looks plausible
             assert(ami.startswith('ami-'))


### PR DESCRIPTION
Adds an option to override `nodeStorage` for specific `nodeTypes`. Useful for heterogeneous jobs where some tasks need much more disk than others.
Example use case:
`--nodeTypes c5.2xlarge,c5.9xlarge,m4.10xlarge --nodeStorage 100 --nodeStorageOverrides c5.9xlarge:2000`

Fixes #3084 