### PR TITLE
Fix failed job accounting.

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -313,7 +313,6 @@ class Job(BaseJob):
         self._fileStore = None
         self._defer = None
         self._tempDir = None
-        self._succeeded = True
 
     def run(self, fileStore):
         """

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -517,11 +517,11 @@ class Leader(object):
                 cur_logger = (logger.debug if str(updatedJob.jobName).startswith(CWL_INTERNAL_JOBS)
                               else logger.info)
                 cur_logger('Job ended: %s', updatedJob)
-                if self.toilMetrics:
-                    self.toilMetrics.logCompletedJob(updatedJob)
             else:
                 logger.warning('Job failed with exit value %i: %s',
                                exitStatus, updatedJob)
+            if self.toilMetrics:
+                self.toilMetrics.logCompletedJob(updatedJob)
             self.processFinishedJob(jobID, exitStatus, wallTime=wallTime, exitReason=exitReason)
 
     def _processLostJobs(self):

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -478,10 +478,7 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
     
     if AbstractFileStore._terminateEvent.isSet():
         jobGraph = jobStore.load(jobStoreID)
-        jobGraph.setupJobAfterFailure(config)
         jobAttemptFailed = True
-        if job and jobGraph.remainingRetryCount == 0:
-            job._succeeded = False
 
     ##########################################
     #Cleanup


### PR DESCRIPTION
Fixes #3102 by:
* Not calling `setupJobAfterFailure` in the worker as it'll be done in the leader now that we return non-zero exit status (fixes double counting failures).
* Always calling `logCompletedJob` when the job finishes regardless of whether it succeeded. This is consistent with both the previous logic (i.e. when we used to return `0` even for failed jobs) and also fixes accounting for failures of other reasons (e.g. `LOST` jobs) as we always re-issue jobs if there are any retry attempts left.
* Remove `_succeeded` flag altogether as it was added back in https://github.com/DataBiosphere/toil/commit/9656354816542648b63b30fb6b047766857e0e30 , but is no longer needed/used.