### PR TITLE
Deduplicate updated jobs

### DIFF
--- a/src/toil/jobGraph.py
+++ b/src/toil/jobGraph.py
@@ -103,6 +103,34 @@ class JobGraph(JobNode):
 
     def __hash__(self):
         return hash(self.jobStoreID)
+        
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and self.remainingRetryCount == other.remainingRetryCount
+            and self.jobStoreID == other.jobStoreID
+            and self.filesToDelete == other.filesToDelete
+            and self.stack == other.stack
+            and self.predecessorNumber == other.predecessorNumber
+            and self.predecessorsFinished == other.predecessorsFinished
+            and self.logJobStoreFileID == other.logJobStoreFileID)
+            
+    def __repr__(self):
+        return "JobGraph({})".format(", ".join((repr(x) for x in [command, memory, cores, disk, unitName, jobName, preemptable,
+            jobStoreID,
+            remainingRetryCount,
+            predecessorNumber,
+            filesToDelete,
+            predecessorsFinished,
+            stack,
+            services,
+            startJobStoreID,
+            terminateJobStoreID,
+            errorJobStoreID,
+            logJobStoreFileID,
+            checkpoint,
+            checkpointFilesToDelete,
+            chainedJobs])))
 
     def setupJobAfterFailure(self, config, exitReason=None):
         """
@@ -204,13 +232,4 @@ class JobGraph(JobNode):
                    unitName=jobNode.unitName, jobName=jobNode.jobName,
                    **jobNode._requirements)
 
-    def __eq__(self, other):
-        return (
-            isinstance(other, self.__class__)
-            and self.remainingRetryCount == other.remainingRetryCount
-            and self.jobStoreID == other.jobStoreID
-            and self.filesToDelete == other.filesToDelete
-            and self.stack == other.stack
-            and self.predecessorNumber == other.predecessorNumber
-            and self.predecessorsFinished == other.predecessorsFinished
-            and self.logJobStoreFileID == other.logJobStoreFileID)
+   

--- a/src/toil/toilState.py
+++ b/src/toil/toilState.py
@@ -47,8 +47,11 @@ class ToilState(object):
         # Hash of jobStoreIDs mapping to services issued for the job
         self.servicesIssued = {}
         
-        # Jobs that are ready to be processed
-        self.updatedJobs = set()
+        # Jobs that are ready to be processed.
+        # Stored as a dict from job store ID to a pair of (job, result status),
+        # where a status other than 0 indicates that an error occurred when
+        # running the job.
+        self.updatedJobs = {} 
         
         # The set of totally failed jobs - this needs to be filtered at the
         # end to remove jobs that were removed by checkpoints
@@ -96,7 +99,7 @@ class ToilState(object):
                          'with  services: %s, with stack: %s', jobGraph.jobStoreID,
                          jobGraph.command is not None, jobGraph.checkpoint is not None,
                          len(jobGraph.services) > 0, len(jobGraph.stack) == 0)
-            self.updatedJobs.add((jobGraph, 0))
+            self.updatedJobs[jobGraph.jobStoreID] = (jobGraph, 0)
 
             if jobGraph.checkpoint is not None:
                 jobGraph.command = jobGraph.checkpoint


### PR DESCRIPTION
As is, multiple JobGraphs for the same job ID can be updated in the same tick.
I don't think multiple job graphs for the same job ID are supposed to exist at
all.

I'm now deduplicating everything by job ID. The first update with the first
status will win.

Really we should change the whole system to pass around just the IDs of updated
things, and store a single source of truth for the job graph's state, so it is
impossible to have conflicting updates in flight.

This is a workaround for some test failures caused by #3106 in #3088.