### PR TITLE
Create dirs that do not exist when bind-mounting to docker.

### DIFF
--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -162,7 +162,7 @@ def apiDockerCall(job,
 
     for volume in volumes:
         if not os.path.exists(volume):
-            os.makedirs(volume)
+            os.makedirs(volume, exist_ok=True)
 
     if parameters is None:
         parameters = []

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -160,6 +160,10 @@ def apiDockerCall(job,
     if volumes is None:
         volumes = {working_dir: {'bind': '/data', 'mode': 'rw'}}
 
+    for volume in volumes:
+        if not os.path.exists(volume):
+            os.makedirs(volume)
+
     if parameters is None:
         parameters = []
 


### PR DESCRIPTION
Created to test a solution proposed by Adam for https://github.com/DataBiosphere/toil/issues/3116 .

I don't have a Mac, so I can't test this.