### PR TITLE
Fix database state when file upload fails.

### DIFF
--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -367,9 +367,6 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
 
                             job._runner(jobGraph=jobGraph, jobStore=jobStore, fileStore=fileStore, defer=defer)
 
-                            # When the job succeeds, start committing files immediately.
-                            fileStore.startCommit(jobState=False)      
-
                 # Accumulate messages from this job & any subsequent chained jobs
                 statsDict.workers.logsToMaster += fileStore.loggingMessages
 


### PR DESCRIPTION
Fixes #3121 by:
* Ensuring we revert the state of files that failed to upload back to `uploadable` so that they can be retried again later.
* Removing the unnecessary extra commit thread.

Note: I didnt see anything in `_executePendingDeletions` that needed to be changed, so left it as is. 