### PR TITLE
[easy] Replace custom mkdir_p with the built in.

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -25,7 +25,6 @@ from datetime import datetime
 from pytz import timezone
 from docker.errors import ImageNotFound
 from toil.lib.memoize import memoize
-from toil.lib.misc import mkdir_p
 from toil.lib.retry import retry
 from toil.version import currentCommit
 
@@ -612,7 +611,7 @@ try:
                         if not os.path.exists(dir_path):
                             log.debug('Creating parent directory %s', dir_path)
                             # A race would be ok at this point
-                            mkdir_p(dir_path)
+                            os.makedirs(dir_path, exist_ok=True)
                     else:
                         raise
                 else:

--- a/src/toil/deferred.py
+++ b/src/toil/deferred.py
@@ -29,7 +29,6 @@ import os
 import shutil
 import tempfile
 
-from toil.lib.misc import mkdir_p
 from toil.realtimeLogger import RealtimeLogger
 from toil.resource import ModuleDescriptor
 
@@ -125,7 +124,7 @@ class DeferredFunctionManager(object):
 
         # Work out where state files live
         self.stateDir = os.path.join(stateDirBase, self.STATE_DIR_STEM)
-        mkdir_p(self.stateDir)
+        os.makedirs(self.stateDir, exist_ok=True)
 
         # We need to get a state file, locked by us and not somebody scanning for abandoned state files.
         # So we suffix not-yet-ready ones with our suffix

--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -36,7 +36,7 @@ import uuid
 from toil.common import cacheDirName, getDirSizeRecursively, getFileSystemSize
 from toil.lib.bioio import makePublicDir
 from toil.lib.humanize import bytes2human
-from toil.lib.misc import mkdir_p, robust_rmtree, atomic_copy, atomic_copyobj
+from toil.lib.misc import robust_rmtree, atomic_copy, atomic_copyobj
 from toil.lib.retry import retry
 from toil.lib.threading import get_process_name, process_name_exists
 from toil.fileStores.abstractFileStore import AbstractFileStore
@@ -221,7 +221,7 @@ class CachingFileStore(AbstractFileStore):
         self.workflowAttemptNumber = self.jobStore.config.workflowAttemptNumber
 
         # Make sure the cache directory exists
-        mkdir_p(self.localCacheDir)
+        os.makedirs(self.localCacheDir, exist_ok=True)
 
         # Connect to the cache database in there, or create it if not present.
         # We name it by workflow attempt number in case a previous attempt of

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -35,7 +35,7 @@ except ImportError:
 # toil dependencies
 from toil.fileStores import FileID
 from toil.lib.bioio import absSymPath
-from toil.lib.misc import mkdir_p, robust_rmtree, AtomicFileCreate, atomic_copy, atomic_copyobj
+from toil.lib.misc import robust_rmtree, AtomicFileCreate, atomic_copy, atomic_copyobj
 from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              NoSuchJobException,
                                              NoSuchFileException,
@@ -107,11 +107,11 @@ class FileJobStore(AbstractJobStore):
                 raise JobStoreExistsException(self.jobStoreDir)
             else:
                 raise
-        mkdir_p(self.jobsDir)
-        mkdir_p(self.statsDir)
-        mkdir_p(self.filesDir)
-        mkdir_p(self.jobFilesDir)
-        mkdir_p(self.sharedFilesDir)
+        os.makedirs(self.jobsDir, exist_ok=True)
+        os.makedirs(self.statsDir, exist_ok=True)
+        os.makedirs(self.filesDir, exist_ok=True)
+        os.makedirs(self.jobFilesDir, exist_ok=True)
+        os.makedirs(self.sharedFilesDir, exist_ok=True)
         self.linkImports = config.linkImports
         self.moveExports = config.moveExports
         super(FileJobStore, self).initialize(config)
@@ -764,12 +764,12 @@ class FileJobStore(AbstractJobStore):
         tempDir = root
 
         # Make sure the root exists
-        mkdir_p(tempDir)
+        os.makedirs(tempDir, exist_ok=True)
 
         while len(os.listdir(tempDir)) >= self.fanOut:
             # We need to use a layer of directories under here to avoid over-packing the directory
             tempDir = os.path.join(tempDir, random.choice(self.validDirs))
-            mkdir_p(tempDir)
+            os.makedirs(tempDir, exist_ok=True)
 
         # When we get here, we found a sufficiently empty directory
         return tempDir
@@ -899,7 +899,7 @@ class FileJobStore(AbstractJobStore):
 
             # Lazily create the parent directory.
             # We don't want our tree filled with confusingly empty directories.
-            mkdir_p(jobFilesDir)
+            os.makedirs(jobFilesDir, exist_ok=True)
 
             # Then make a temp directory inside it
             return tempfile.mkdtemp(prefix='file-', dir=jobFilesDir)

--- a/src/toil/lib/misc.py
+++ b/src/toil/lib/misc.py
@@ -1,28 +1,15 @@
 import random
 from math import sqrt
 import logging
-import errno
 import os
 import shutil
 import sys
-import time
 import uuid
-import socket
 from contextlib import contextmanager
 import subprocess
 
 logger = logging.getLogger(__name__)
 
-
-def mkdir_p(path):
-    """The equivalent of mkdir -p"""
-    try:
-        os.makedirs(path)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
 
 def robust_rmtree(path):
     """

--- a/src/toil/lib/threading.py
+++ b/src/toil/lib/threading.py
@@ -31,7 +31,7 @@ from threading import BoundedSemaphore
 
 import psutil
 
-from toil.lib.misc import mkdir_p, robust_rmtree
+from toil.lib.misc import robust_rmtree
 
 log = logging.getLogger(__name__)
 

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -42,7 +42,6 @@ from toil import toilPackageDirPath, applianceSelf, ApplianceImageNotFound
 from toil import which
 from toil.lib.iterables import concat
 from toil.lib.memoize import memoize
-from toil.lib.misc import mkdir_p
 from toil.lib.threading import ExceptionalThread, cpu_count
 from toil.provisioners.aws import runningOnEC2
 from toil.version import distVersion
@@ -80,7 +79,7 @@ class ToilTest(unittest.TestCase):
         tempBaseDir = os.environ.get('TOIL_TEST_TEMP', None)
         if tempBaseDir is not None and not os.path.isabs(tempBaseDir):
             tempBaseDir = os.path.abspath(os.path.join(cls._projectRootPath(), tempBaseDir))
-            mkdir_p(tempBaseDir)
+            os.makedirs(tempBaseDir, exist_ok=True)
         cls._tempBaseDir = tempBaseDir
 
     @classmethod

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -22,7 +22,6 @@ import docker
 from threading import Thread
 from docker.errors import ContainerError
 
-from toil.test import mkdir_p
 from toil.job import Job
 from toil.leader import FailedJobsException
 from toil.test import ToilTest, slow, needs_docker
@@ -77,8 +76,8 @@ class DockerTest(ToilTest):
         working_dir = os.path.join(self.tempDir, 'working')
         test_file = os.path.join(working_dir, 'test.txt')
 
-        mkdir_p(data_dir)
-        mkdir_p(working_dir)
+        os.makedirs(data_dir, exist_ok=True)
+        os.makedirs(working_dir, exist_ok=True)
 
         options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir,
                                                             'jobstore'))

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -22,7 +22,6 @@ from io import BytesIO
 from textwrap import dedent
 from zipfile import ZipFile
 
-from toil.test import mkdir_p
 from mock import MagicMock, patch
 
 import subprocess
@@ -84,7 +83,7 @@ class ResourceTest(ToilTest):
         try:
             for relPath in pyFiles:
                 path = os.path.join(dirPath, relPath)
-                mkdir_p(os.path.dirname(path))
+                os.makedirs(os.path.dirname(path), exist_ok=True)
                 with open(path, 'w') as f:
                     f.write('pass\n')
             sys.path.append(dirPath)


### PR DESCRIPTION
"exist_ok" was added in Python 3.2, so I think we're okay.