### PR TITLE
Change command output processing (resolves #3132)

### DIFF
--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -101,9 +101,9 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
                     '-S', '1970-01-01'] # override start time limit
 
             stdout = call_command(args)
-            for line in stdout:
+            for line in stdout.split('\n'):
                 logger.debug("%s output %s", args[0], line)
-                values = line.decode('utf-8').strip().split('|')
+                values = line.strip().split('|')
                 if len(values) < 2:
                     continue
                 state, exitcode = values


### PR DESCRIPTION
Possible fix for https://github.com/DataBiosphere/toil/issues/3132

When running CWL workflows with `--batchsystem Slurm` option the execution was failing due to an error:

```
$ toil-cwl-runner --batchSystem Slurm --workDir=(...) --jobStore=./jstore wf1.cwl task1.yaml 
...
(...)/toil/lib/python3.7/site-packages/toil/batchSystems/slurm.py", line 106, in _getJobDetailsFromSacct
    values = line.decode('utf-8').strip().split('|')
AttributeError: 'str' object has no attribute 'decode'
```

This is the referenced fragment (lines 103-104 from `batchSystems/slurm.py`):
```
stdout = call_command(args)
            for line in stdout:
```
Function `call_command()` from `lib/misc.py` (lines 304-329) returns a string so calling `decode()` causes an error.

First issue is that `for line in stdout` loops over a string meaning that it iterates over characters rather than lines. To fix this I added `split('\n')` (line 104).
Removing `decode('utf-8')` was necessary to be able to split the lines with `|` deliminator (line 106).

After these changes I was able to succesfully execute the workflow through Slurm job submission.
I am not sure if this is the best way to handle this, I will appreciate any help.