### PR TITLE
Turn off watch code in Kubernetes

### DIFF
--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -179,7 +179,8 @@ class KubernetesBatchSystem(BatchSystemCleanupSupport):
         self.awsSecretName = os.environ.get("TOIL_AWS_SECRET_NAME", None)
 
         # Set this to True to enable the experimental wait-for-job-update code
-        self.enableWatching = True
+        # TODO: Make this an environment variable?
+        self.enableWatching = False
 
         self.jobIds = set()
     


### PR DESCRIPTION
It may be dramatically slowing job collection. This will work around #3174 and might help with #3104.