### PR TITLE
Add WDL builtin test 'round'.

### DIFF
--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -41,6 +41,9 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
     def test_floor(self):
         self.check_function('floor', expected_result='11')
 
+    def test_round(self):
+        self.check_function('round', expected_result='11')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -3,9 +3,30 @@ import os
 import subprocess
 import shutil
 import uuid
+from toil.wdl.wdl_functions import ceil
+from toil.wdl.wdl_functions import floor
 
 from toil.version import exactPython
 from toil.test import ToilTest
+
+
+class WdlStandardLibraryFunctionsTest(ToilTest):
+    """ A set of test cases for toil's wdl functions."""
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    def testFn_Ceil(self):
+        """Test the wdl built-in functional equivalent of 'ceil()', which converts
+        a Float value into an Int by rounding up to the next higher integer"""
+        assert ceil(1.999) == 2
+        assert ceil(-1.5) == -1
+
+    def testFn_Floor(self):
+        """Test the wdl built-in functional equivalent of 'floor()', which converts
+        a Float value into an Int by rounding down to the next lower integer"""
+        assert floor(1.999) == 1
+        assert floor(-1.5) == -2
 
 
 class WdlStandardLibraryWorkflowsTest(ToilTest):

--- a/src/toil/test/wdl/standard_library/round.json
+++ b/src/toil/test/wdl/standard_library/round.json
@@ -1,0 +1,3 @@
+{
+  "roundWorkflow.num": 11.2345
+}

--- a/src/toil/test/wdl/standard_library/round_as_command.wdl
+++ b/src/toil/test/wdl/standard_library/round_as_command.wdl
@@ -1,0 +1,16 @@
+workflow roundWorkflow {
+  Float num
+  call get_round { input: num=num }
+}
+
+task get_round {
+  Float num
+
+  command {
+    echo ${round(num)} > output.txt
+  }
+
+ output {
+    File the_rounding = 'output.txt'
+ }
+}

--- a/src/toil/test/wdl/standard_library/round_as_input.wdl
+++ b/src/toil/test/wdl/standard_library/round_as_input.wdl
@@ -1,0 +1,16 @@
+workflow roundWorkflow {
+  Float num
+  call get_round { input: num=round(num) }
+}
+
+task get_round {
+  Float num
+
+  command {
+    echo ${num} > output.txt
+  }
+
+ output {
+    File the_rounding = 'output.txt'
+ }
+}

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -27,8 +27,6 @@ from toil.wdl.wdl_functions import defined
 from toil.wdl.wdl_functions import read_tsv
 from toil.wdl.wdl_functions import read_csv
 from toil.wdl.wdl_functions import basename
-from toil.wdl.wdl_functions import floor
-from toil.wdl.wdl_functions import ceil
 from toil.test import ToilTest, slow, needs_docker
 from toil import urlretrieve
 import zipfile
@@ -222,18 +220,6 @@ class ToilWdlIntegrationTest(ToilTest):
         assert parse_disk('local-disk 10 SSD') == 10000000000, str(parse_disk('local-disk 10 SSD'))
         assert parse_disk('/mnt/ 10 HDD') == 10000000000, str(parse_disk('/mnt/ 10 HDD'))
         assert parse_disk('/mnt/ 1000 HDD') == 1000000000000, str(parse_disk('/mnt/ 1000 HDD'))
-
-    def testFn_Floor(self):
-        """Test the wdl built-in functional equivalent of 'floor()', which converts
-        a Float value into an Int by rounding down to the next lower integer"""
-        assert floor(1.999) == 1
-        assert floor(-1.5) == -2
-
-    def testFn_Ceil(self):
-        """Test the wdl built-in functional equivalent of 'ceil()', which converts
-        a Float value into an Int by rounding up to the next higher integer"""
-        assert ceil(1.999) == 2
-        assert ceil(-1.5) == -1
 
     # estimated run time <1 sec
     def testPrimitives(self):


### PR DESCRIPTION
Address #3152.

`round()` is not added to https://github.com/DataBiosphere/toil/blob/master/src/toil/wdl/wdl_functions.py because we are using the Python built-in function. 

Note that `src/toil/test/wdl/toilwdlTest.py` still contains tests for WDL functions. In the future these tests will be moved to `WdlStandardLibraryFunctionsTest` as we add in the corresponding workflow tests. I'm not moving them all at once because there are tests that depend on the test files in `toilwdlTest.py` and I don't want to mess with those in this PR. 