### PR TITLE
Add support for TOIL_CUSTOM_INIT_COMMAND.

### DIFF
--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -136,5 +136,11 @@ There are several environment variables that affect the way Toil runs.
 |                                  | ``pip install awscli && eval $(aws ecr get-login   |
 |                                  | --no-include-email --region us-east-1)``.          |
 +----------------------------------+----------------------------------------------------+
+| TOIL_CUSTOM_INIT_COMMAND         | Any custom bash command to run prior to starting   |
+|                                  | the Toil appliance. Can be used for any custom     |
+|                                  | initialization in the worker and/or primary nodes  |
+|                                  | such as private docker authentication for the Toil |
+|                                  | appliance itself (i.e. from TOIL_APPLIANCE_SELF).  |
++----------------------------------+----------------------------------------------------+
 
 .. _standard temporary directory: https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 import errno
 import logging
 import os
+import re
 import requests
 import socket
 import sys
@@ -220,14 +221,16 @@ def customDockerInitCmd():
     Returns the custom command (if any) provided through the ``TOIL_CUSTOM_DOCKER_INIT_COMMAND``
     environment variable to run prior to running the workers and/or the primary node's services.
     This can be useful for doing any custom initialization on instances (e.g. authenticating to
-    private docker registries). An empty string is returned if the environment variable is not
-    set.
+    private docker registries). Any single quotes are escaped and the command cannot contain a
+    set of blacklisted chars (newline or tab). An empty string is returned if the environment
+    variable is not set.
 
     :rtype: str
     """
     command = lookupEnvVar(name='user-defined custom docker init command',
                            envName='TOIL_CUSTOM_DOCKER_INIT_COMMAND',
                            defaultValue='')
+    _check_custom_bash_cmd(command)
     return command.replace("'", "'\\''")  # Ensure any single quotes are escaped.
 
 
@@ -237,14 +240,22 @@ def customInitCmd():
     environment variable to run prior to running Toil appliance itself in workers and/or the
     primary node (i.e. this is run one stage before ``TOIL_CUSTOM_DOCKER_INIT_COMMAND``).
     This can be useful for doing any custom initialization on instances (e.g. authenticating to
-    private docker registries). An empty string is returned if the environment variable is not
-    set.
+    private docker registries). Any single quotes are escaped and the command cannot contain a
+    set of blacklisted chars (newline or tab). An empty string is returned if the environment
+    variable is not set.
+
     :rtype: str
     """
     command = lookupEnvVar(name='user-defined custom init command',
                            envName='TOIL_CUSTOM_INIT_COMMAND',
                            defaultValue='')
+    _check_custom_bash_cmd(command)
     return command.replace("'", "'\\''")  # Ensure any single quotes are escaped.
+
+
+def _check_custom_bash_cmd(cmd_str):
+    """Ensures that the bash command doesn't contain blacklisted characters."""
+    assert not re.search(r'[\n\r\t]', cmd_str), f'"{cmd_str}" contains invalid characters (newline and/or tab).'
 
 
 def lookupEnvVar(name, envName, defaultValue):

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -231,6 +231,22 @@ def customDockerInitCmd():
     return command.replace("'", "'\\''")  # Ensure any single quotes are escaped.
 
 
+def customInitCmd():
+    """
+    Returns the custom command (if any) provided through the ``TOIL_CUSTOM_INIT_COMMAND``
+    environment variable to run prior to running Toil appliance itself in workers and/or the
+    primary node (i.e. this is run one stage before ``TOIL_CUSTOM_DOCKER_INIT_COMMAND``).
+    This can be useful for doing any custom initialization on instances (e.g. authenticating to
+    private docker registries). An empty string is returned if the environment variable is not
+    set.
+    :rtype: str
+    """
+    command = lookupEnvVar(name='user-defined custom init command',
+                           envName='TOIL_CUSTOM_INIT_COMMAND',
+                           defaultValue='')
+    return command.replace("'", "'\\''")  # Ensure any single quotes are escaped.
+
+
 def lookupEnvVar(name, envName, defaultValue):
     """
     Use this for looking up environment variables that control Toil and are important enough to

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -19,7 +19,7 @@ import logging
 import os.path
 
 import subprocess
-from toil import applianceSelf, customDockerInitCmd
+from toil import applianceSelf, customDockerInitCmd, customInitCmd
 from toil.lib.retry import never
 
 a_short_time = 5
@@ -337,6 +337,7 @@ coreos:
         Restart=on-failure
         RestartSec=2
         ExecStartPre=-/usr/bin/docker rm toil_{role}
+        ExecStartPre=-/usr/bin/bash -c '{customInitCommand}'
         ExecStart=/usr/bin/docker run \
             --entrypoint={entrypoint} \
             --net=host \
@@ -418,6 +419,7 @@ coreos:
                             dockerImage=applianceSelf(),
                             entrypoint=entryPoint,
                             sshKey=masterPublicKey,   # ignored if None
-                            mesosArgs=mesosArgs)
+                            mesosArgs=mesosArgs,
+                            customInitCommand=customInitCmd())
         userData = template.format(**templateArgs)
         return userData


### PR DESCRIPTION
Similar to #2561 except that it provides a way to run custom commands before running the appliance itself (e.g. we use this to authenticate to a private docker registry to pull the Toil appliance itself). May be useful for other use cases now that there seems to be more restrictions on doing a lot of pulls from public registries.

Resolves #3182 