### PR TITLE
slurm.py error, undefeind stdout - stdout should be stderr in code

### DIFF
--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -169,7 +169,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
             if mem is not None:
                 # memory passed in is in bytes, but slurm expects megabytes
-                sbatch_line.append(f'--mem={int(mem / 2 ** 20)}')
+                sbatch_line.append(f'--mem={math.ceil(mem / 2 ** 20)}')
             if cpu is not None:
                 sbatch_line.append(f'--cpus-per-task={int(math.ceil(cpu))}')
 

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -11,21 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import absolute_import
-from __future__ import division
-from builtins import str
-from past.utils import old_div
 import logging
 import os
 from pipes import quote
-import time
 import math
 from toil.lib.misc import call_command, CalledProcessErrorStderr
-
-# Python 3 compatibility imports
-from six.moves.queue import Empty, Queue
-from six import iteritems
 
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractGridEngineBatchSystem import AbstractGridEngineBatchSystem
@@ -124,7 +114,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
                     'job',
                     str(slurmJobID)]
 
-            stderr = call_command(args)
+            stdout = call_command(args)
             job = dict()
             for line in stdout:
                 logger.debug("%s output %s", args[0], line)
@@ -179,9 +169,9 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
             if mem is not None:
                 # memory passed in is in bytes, but slurm expects megabytes
-                sbatch_line.append('--mem={}'.format(old_div(int(mem), 2 ** 20)))
+                sbatch_line.append(f'--mem={int(mem / 2 ** 20)}')
             if cpu is not None:
-                sbatch_line.append('--cpus-per-task={}'.format(int(math.ceil(cpu))))
+                sbatch_line.append(f'--cpus-per-task={int(math.ceil(cpu))}')
 
             stdoutfile = self.boss.formatStdOutErrPath(jobID, 'slurm', '%j', 'std_output')
             stderrfile = self.boss.formatStdOutErrPath(jobID, 'slurm', '%j', 'std_error')

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -104,9 +104,9 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
                     # A non-zero signal may indicate e.g. an out-of-memory killed job
                     status = 128 + signal
                 logger.debug("sacct exit code is %s, returning status %d", exitcode, status)
-                return (state, status)
+                return state, status
             logger.debug("Did not find exit code for job in sacct output")
-            return (None, None)
+            return None, None
 
         def _getJobDetailsFromScontrol(self, slurmJobID):
             args = ['scontrol',
@@ -118,12 +118,12 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
             job = dict()
             for line in stdout:
                 logger.debug("%s output %s", args[0], line)
-                values = line.decode('utf-8').strip().split()
+                values = line.strip().split()
 
                 # If job information is not available an error is issued:
                 # slurm_load_jobs error: Invalid job id specified
                 # There is no job information, so exit.
-                if len(values)>0 and values[0] == 'slurm_load_jobs':
+                if len(values) > 0 and values[0] == 'slurm_load_jobs':
                     return (None, None)
 
                 # Output is in the form of many key=value pairs, multiple pairs on each line
@@ -148,7 +148,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
             except KeyError:
                 rc = None
 
-            return (state, rc)
+            return state, rc
 
         """
         Implementation-specific helper methods
@@ -171,7 +171,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
                 # memory passed in is in bytes, but slurm expects megabytes
                 sbatch_line.append(f'--mem={math.ceil(mem / 2 ** 20)}')
             if cpu is not None:
-                sbatch_line.append(f'--cpus-per-task={int(math.ceil(cpu))}')
+                sbatch_line.append(f'--cpus-per-task={math.ceil(cpu)}')
 
             stdoutfile = self.boss.formatStdOutErrPath(jobID, 'slurm', '%j', 'std_output')
             stderrfile = self.boss.formatStdOutErrPath(jobID, 'slurm', '%j', 'std_error')


### PR DESCRIPTION
This should fix #3192 and also remove some of the old python2 imports.