### PR TITLE
Update docker module version to 4.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def runSetup():
     six = 'six>=1.10.0'
     future = 'future'
     requests = 'requests>=2, <3'
-    docker = 'docker>=2.7.0, <3'
+    docker = 'docker==4.3.1'
     dateutil = 'python-dateutil'
     addict = 'addict>=2.2.1, <2.3'
     enlighten = 'enlighten>=1.5.2, <2'


### PR DESCRIPTION
Address #3218. 

Our docker dependency version is currently at `2.7.0` and the latest stable release is `4.3.1`. 

This is to support the hidden "content" attribute in the docker iterator and multiplexed streams, which are part of docker-py's  3.2.0 and 3.7.0 release, respectively. (https://github.com/DataBiosphere/toil/issues/3184#issuecomment-689048387)

This is a big upgrade but our docker wrapper doesn't seem to be affected by the breaking changes described in the [docker change log](https://docker-py.readthedocs.io/en/stable/change-log.html). 