### PR TITLE
Remove Python 2 imports in WDL

### DIFF
--- a/src/toil/wdl/toilwdl.py
+++ b/src/toil/wdl/toilwdl.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 UCSC Computational Genomics Lab
+# Copyright (C) 2018-2020 UCSC Computational Genomics Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
-
 import argparse
 import os
 import logging

--- a/src/toil/wdl/wdl_analysis.py
+++ b/src/toil/wdl/wdl_analysis.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 UCSC Computational Genomics Lab
+# Copyright (C) 2018-2020 UCSC Computational Genomics Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
-from past.builtins import basestring
-
 import json
 import os
 import logging
@@ -122,7 +117,7 @@ class AnalyzeWDL:
         with open(JSON_file) as data_file:
             data = json.load(data_file)
         for d in data:
-            if isinstance(data[d], basestring):
+            if isinstance(data[d], str):
                 self.json_dict[d] = '"' + data[d] + '"'
             else:
                 self.json_dict[d] = data[d]

--- a/src/toil/wdl/wdl_functions.py
+++ b/src/toil/wdl/wdl_functions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 UCSC Computational Genomics Lab
+# Copyright (C) 2018-2020 UCSC Computational Genomics Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
-from past.builtins import basestring
-
 import fnmatch
 import os
 import logging
@@ -26,7 +21,6 @@ import math
 import subprocess
 
 wdllogger = logging.getLogger(__name__)
-
 
 
 def glob(glob_pattern, directoryname):
@@ -190,7 +184,7 @@ def process_single_infile(f, fileStore):
     else:
         filepath = fileStore.importFile("file://" + os.path.abspath(f))
         preserveThisFilename = os.path.basename(f)
-    return (filepath, preserveThisFilename)
+    return filepath, preserveThisFilename
 
 
 def process_array_infile(af, fileStore):
@@ -218,7 +212,7 @@ def process_infile(f, fileStore):
         return f
     elif isinstance(f, list):
         return process_array_infile(f, fileStore)
-    elif isinstance(f, basestring):
+    elif isinstance(f, str):
         return process_single_infile(f, fileStore)
     else:
         raise RuntimeError('Error processing file: '.format(str(f)))
@@ -261,7 +255,7 @@ def process_single_outfile(f, fileStore, workDir, outDir):
     output_file = fileStore.writeGlobalFile(output_f_path)
     preserveThisFilename = os.path.basename(output_f_path)
     fileStore.exportFile(output_file, "file://" + os.path.join(os.path.abspath(outDir), preserveThisFilename))
-    return (output_file, preserveThisFilename)
+    return output_file, preserveThisFilename
 
 
 def process_array_outfile(af, fileStore, workDir, outDir):
@@ -274,7 +268,7 @@ def process_array_outfile(af, fileStore, workDir, outDir):
 def process_outfile(f, fileStore, workDir, outDir):
     if isinstance(f, list):
         return process_array_outfile(f, fileStore, workDir, outDir)
-    elif isinstance(f, basestring):
+    elif isinstance(f, str):
         return process_single_outfile(f, fileStore, workDir, outDir)
     else:
         raise RuntimeError('Error processing file: '.format(str(f)))
@@ -304,7 +298,7 @@ def abspath_file(f, cwd):
         return f
     if isinstance(f, list):
         return abspath_array_file(f, cwd)
-    elif isinstance(f, basestring):
+    elif isinstance(f, str):
         if f.startswith('s3://') or f.startswith('http://') or f.startswith('https://') or \
                 f.startswith('file://') or f.startswith('wasb://') or f.startswith('gs://'):
             return f
@@ -411,7 +405,7 @@ def parse_memory(memory):
     """
     memory = str(memory)
     if 'None' in memory:
-        return 2147483648 # toil's default
+        return 2147483648  # toil's default
     try:
         import re
         raw_mem_split = re.split('([a-zA-Z]+)', memory)
@@ -431,13 +425,13 @@ def parse_memory(memory):
         else:
             raise RuntimeError('Memory parsing failed: {}'.format(memory))
     except:
-        return 2147483648 # toil's default
+        return 2147483648  # toil's default
 
 
 def parse_cores(cores):
     cores = str(cores)
     if 'None' in cores:
-        return 1 # toil's default
+        return 1  # toil's default
     if cores:
         return float(cores)
     else:
@@ -447,7 +441,7 @@ def parse_cores(cores):
 def parse_disk(disk):
     disk = str(disk)
     if 'None' in disk:
-        return 2147483648 # toil's default
+        return 2147483648  # toil's default
     try:
         total_disk = 0
         disks = disk.split(',')

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 UCSC Computational Genomics Lab
+# Copyright (C) 2018-2020 UCSC Computational Genomics Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 from six import iteritems
 
 import os
@@ -366,8 +363,6 @@ class SynthesizeWDL:
                     return inputs_list, False
         return inputs_list, True
 
-
-
     def write_main_jobwrappers_call(self, task):
         main_section = '        {} = job0.addChild({}Cls('.format(task['alias'], task['task'])
         for var in task['io']:
@@ -423,7 +418,6 @@ class SynthesizeWDL:
                 fn_section += self.write_scatterfunctions_within_if(ifstatement[assignment]['body'])
         return fn_section
 
-
     def write_scatterfunction(self, job, scattername):
         '''
         Writes out a python function for each WDL "scatter" object.
@@ -444,7 +438,6 @@ class SynthesizeWDL:
         fn_section += self.write_scatterfunction_outputreturn(scatter_outputs)
 
         return fn_section
-
 
     def write_scatterfunction_header(self, scattername):
         """
@@ -504,7 +497,6 @@ class SynthesizeWDL:
             fn_section += '        {var} = []\n'.format(var=var['task'] + '_' + var['output'])
 
         return fn_section
-
 
     def write_scatterfunction_loop(self, job, scatter_outputs):
         """
@@ -780,15 +772,16 @@ class SynthesizeWDL:
         cmd_array = []
         if 'raw_commandline' in self.tasks_dictionary[job]:
             for cmd in self.tasks_dictionary[job]['raw_commandline']:
-                if not cmd.startswith("r'''"):
-                    cmd = 'str({i} if not isinstance({i}, tuple) else process_and_read_file({i}, tempDir, fileStore)).strip("{nl}")'.format(i=cmd, nl=r"\n")
-                fn_section = fn_section + heredoc_wdl('''
-                        try:
-                            # Intended to deal with "optional" inputs that may not exist
-                            # TODO: handle this better
+                if cmd.startswith("r'''"):
+                    fn_section += heredoc_wdl('''
                             command{num} = {cmd}
-                        except:
-                            command{num} = ''\n''', {'cmd': cmd, 'num': self.cmd_num}, indent='        ')
+                            ''', {'cmd': cmd, 'num': self.cmd_num}, indent='        ')
+                else:
+                    fn_section += heredoc_wdl('''
+                            command{num}_var = {cmd}
+                            command{num} = str(command{num}_var if not isinstance(command{num}_var, tuple) 
+                                           else process_and_read_file(command{num}_var, tempDir, fileStore)).strip("\\n")
+                            ''', {'cmd': cmd, 'num': self.cmd_num}, indent='        ')
                 cmd_array.append('command' + str(self.cmd_num))
                 self.cmd_num = self.cmd_num + 1
 
@@ -994,6 +987,7 @@ class SynthesizeWDL:
             f.write(pretty(i.tasks_dictionary))
             f.write('\n\n\n\n\n\n')
             f.write(pretty(i.workflows_dictionary))
+
 
 def write_AST(wdl_file, outdir=None):
     '''


### PR DESCRIPTION
Removes old Python 2 imports + PEP 8 changes.

Edit: revert part that breaks tests.