### PR TITLE
Fixes the problem with folders and files in the workdir permissions

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -769,12 +769,12 @@ def toilStageFiles(file_store: AbstractFileStore,
                 file_store.exportFile(FileID.unpack(local_file_path), destUrl)
             else:
                 if not os.path.exists(p.target) and p.type == "Directory":
-                    os.makedirs(p.target, 0o0755)
+                    os.makedirs(p.target)
                 if not os.path.exists(p.target) and p.type == "File":
-                    os.makedirs(os.path.dirname(p.target), 0o0755, exist_ok=True)
+                    os.makedirs(os.path.dirname(p.target), exist_ok=True)
                     file_store.exportFile(FileID.unpack(p.resolved[7:]), "file://" + p.target)
                 if not os.path.exists(p.target) and p.type == "CreateFile":
-                    os.makedirs(os.path.dirname(p.target), 0o0755, exist_ok=True)
+                    os.makedirs(os.path.dirname(p.target), exist_ok=True)
                     with open(p.target, "wb") as n:
                         n.write(p.resolved.encode("utf-8"))
 

--- a/src/toil/deferred.py
+++ b/src/toil/deferred.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 class DeferredFunction(namedtuple('DeferredFunction', 'function args kwargs name module')):
     """
+    >>> from collections import defaultdict
     >>> df = DeferredFunction.create(defaultdict, None, {'x':1}, y=2)
     >>> df
     DeferredFunction(defaultdict, ...)

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -567,7 +567,7 @@ class FileJobStore(AbstractJobStore):
     def writeStatsAndLogging(self, statsAndLoggingString):
         # Temporary files are placed in the stats directory tree
         tempStatsFileName = "stats" + str(uuid.uuid4().hex) + ".new"
-        tempStatsFile = os.path.join(self._getArbitraryStatsDir, tempStatsFileName)
+        tempStatsFile = os.path.join(self._getArbitraryStatsDir(), tempStatsFileName)
         writeFormat = 'w' if isinstance(statsAndLoggingString, str) else 'wb'
         with open(tempStatsFile, writeFormat) as f:
             f.write(statsAndLoggingString)


### PR DESCRIPTION
Instead of using python tempfile to create files and dirs in the
work dir use regular files with uniq names. This allows those files
and folders to honor the system permissions and umask.

This will fix #2355