### PR TITLE
Catch other kubernetes imports.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
 install:
   - make prepare
-  - make develop extras=[aws,google,kubernetes] # adding extras to avoid import errors
+  - make develop extras=[aws,google] # adding extras to avoid import errors
 script:
   - TOIL_TEST_QUICK=True make test_offline
 env:


### PR DESCRIPTION
Since `kubernetes` is a Toil "extra", we can't import it unless the module is present.  This follows up on https://github.com/DataBiosphere/toil/pull/3259 to catch additional `kubernetes` modules that may error if the `kubernetes` extra is not installed.