### PR TITLE
CWL Test #213: Evaluate loadContents if True for StepValueFrom objects.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,40 +19,40 @@ after_script:
   - stopdocker || true
 
 stages:
-  - basic_tests
+#  - basic_tests
   - main_tests
-  - integration
-
-
-# Python3.6
-py36_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest --duration=0 -s -r s src/toil/test/src
-    - python -m pytest --duration=0 -s -r s src/toil/test/utils
-
-py36_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-
-# Python3.7
-py37_batch_systems:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python -m pytest --duration=0 -s -r s src/toil/test/batchSystems/batchSystemTest.py
-    - python -m pytest --duration=0 -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
+#  - integration
+#
+#
+## Python3.6
+#py36_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest --duration=0 -s -r s src/toil/test/src
+#    - python -m pytest --duration=0 -s -r s src/toil/test/utils
+#
+#py36_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+#
+## Python3.7
+#py37_batch_systems:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - python -m pytest --duration=0 -s -r s src/toil/test/batchSystems/batchSystemTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
   stage: main_tests
@@ -79,127 +79,127 @@ py37_cwl_v1.2:
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - python -m pytest --duration=0 -s -r s src/toil/test/cwl/cwlTest.py::CWLv12Test
 
-py37_wdl:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/toilwdlTest.py
-    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/builtinTest.py
-
-py37_jobstore_and_provisioning:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
-    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-
-py37_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest --duration=0 -s -r s src/toil/test/src
-    - python -m pytest --duration=0 -s -r s src/toil/test/utils
-
-py37_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-py37_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - export TOIL_TEST_INTEGRATIVE=True
-    - export TOIL_AWS_KEYNAME=id_rsa
-    - export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - chmod 400 /root/.ssh/id_rsa
-    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
-
-py37_provisioner_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-    - export LIBPROCESS_IP=127.0.0.1
-    - python setup_gitlab_docker.py
-    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - make push_docker
-    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
-    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
-    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
-
-# Python3.8
-py38_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - python -m pytest --duration=0 -s -r s src/toil/test/src
-    - python -m pytest --duration=0 -s -r s src/toil/test/utils
-
-py38_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-# Cactus-on-Kubernetes integration (as a script and not a pytest test)
-py37_cactus_integration:
-  stage: integration
-  script:
-    - set -e
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-    - virtualenv --system-site-packages --python python3.7 venv
-    - . venv/bin/activate
-    - pip install .[aws,kubernetes]
-    - export TOIL_KUBERNETES_OWNER=toiltest
-    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
-    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
-    - export TOIL_WORKDIR=/var/lib/toil
-    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-    - mkdir -p ${TOIL_WORKDIR}
-    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
-    - cd
-    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
-    - cd cactus
-    - git fetch origin
-    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
-    - git submodule update --init --recursive
-    - pip install --upgrade setuptools pip
-    - pip install --upgrade .
-    - toil clean aws:us-west-2:${BUCKET_NAME}
-    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
+#py37_wdl:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+#    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/toilwdlTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/builtinTest.py
+#
+#py37_jobstore_and_provisioning:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
+##    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+## https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
+## guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
+#
+#py37_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest --duration=0 -s -r s src/toil/test/src
+#    - python -m pytest --duration=0 -s -r s src/toil/test/utils
+#
+#py37_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+#py37_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - export TOIL_TEST_INTEGRATIVE=True
+#    - export TOIL_AWS_KEYNAME=id_rsa
+#    - export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+#    - python setup_gitlab_ssh.py
+#    - chmod 400 /root/.ssh/id_rsa
+#    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
+#
+#py37_provisioner_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
+#    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
+#    - export LIBPROCESS_IP=127.0.0.1
+#    - python setup_gitlab_docker.py
+#    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+#    - python setup_gitlab_ssh.py
+#    - make push_docker
+#    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
+#    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+#    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
+#
+## Python3.8
+#py38_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - python -m pytest --duration=0 -s -r s src/toil/test/src
+#    - python -m pytest --duration=0 -s -r s src/toil/test/utils
+#
+#py38_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+## Cactus-on-Kubernetes integration (as a script and not a pytest test)
+#py37_cactus_integration:
+#  stage: integration
+#  script:
+#    - set -e
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+#    - virtualenv --system-site-packages --python python3.7 venv
+#    - . venv/bin/activate
+#    - pip install .[aws,kubernetes]
+#    - export TOIL_KUBERNETES_OWNER=toiltest
+#    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+#    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+#    - export TOIL_WORKDIR=/var/lib/toil
+#    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+#    - mkdir -p ${TOIL_WORKDIR}
+#    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
+#    - cd
+#    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
+#    - cd cactus
+#    - git fetch origin
+#    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
+#    - git submodule update --init --recursive
+#    - pip install --upgrade setuptools pip
+#    - pip install --upgrade .
+#    - toil clean aws:us-west-2:${BUCKET_NAME}
+#    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,40 +19,40 @@ after_script:
   - stopdocker || true
 
 stages:
-#  - basic_tests
+  - basic_tests
   - main_tests
-#  - integration
-#
-#
-## Python3.6
-#py36_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest --duration=0 -s -r s src/toil/test/src
-#    - python -m pytest --duration=0 -s -r s src/toil/test/utils
-#
-#py36_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-#
-## Python3.7
-#py37_batch_systems:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - python -m pytest --duration=0 -s -r s src/toil/test/batchSystems/batchSystemTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
+  - integration
+
+
+# Python3.6
+py36_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest --duration=0 -s -r s src/toil/test/src
+    - python -m pytest --duration=0 -s -r s src/toil/test/utils
+
+py36_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+
+# Python3.7
+py37_batch_systems:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - python -m pytest --duration=0 -s -r s src/toil/test/batchSystems/batchSystemTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
   stage: main_tests
@@ -79,127 +79,125 @@ py37_cwl_v1.2:
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - python -m pytest --duration=0 -s -r s src/toil/test/cwl/cwlTest.py::CWLv12Test
 
-#py37_wdl:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-#    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/toilwdlTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/builtinTest.py
-#
-#py37_jobstore_and_provisioning:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
-##    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-## https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-## guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-#
-#py37_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest --duration=0 -s -r s src/toil/test/src
-#    - python -m pytest --duration=0 -s -r s src/toil/test/utils
-#
-#py37_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-#py37_integration:
-#  stage: integration
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - export TOIL_TEST_INTEGRATIVE=True
-#    - export TOIL_AWS_KEYNAME=id_rsa
-#    - export TOIL_AWS_ZONE=us-west-2a
-#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-#    - python setup_gitlab_ssh.py
-#    - chmod 400 /root/.ssh/id_rsa
-#    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
-#
-#py37_provisioner_integration:
-#  stage: integration
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-#    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-#    - export LIBPROCESS_IP=127.0.0.1
-#    - python setup_gitlab_docker.py
-#    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-#    - python setup_gitlab_ssh.py
-#    - make push_docker
-#    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
-#    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-#    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
-#
-## Python3.8
-#py38_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - python -m pytest --duration=0 -s -r s src/toil/test/src
-#    - python -m pytest --duration=0 -s -r s src/toil/test/utils
-#
-#py38_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
-#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-## Cactus-on-Kubernetes integration (as a script and not a pytest test)
-#py37_cactus_integration:
-#  stage: integration
-#  script:
-#    - set -e
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-#    - virtualenv --system-site-packages --python python3.7 venv
-#    - . venv/bin/activate
-#    - pip install .[aws,kubernetes]
-#    - export TOIL_KUBERNETES_OWNER=toiltest
-#    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
-#    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
-#    - export TOIL_WORKDIR=/var/lib/toil
-#    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-#    - mkdir -p ${TOIL_WORKDIR}
-#    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
-#    - cd
-#    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
-#    - cd cactus
-#    - git fetch origin
-#    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
-#    - git submodule update --init --recursive
-#    - pip install --upgrade setuptools pip
-#    - pip install --upgrade .
-#    - toil clean aws:us-west-2:${BUCKET_NAME}
-#    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
+py37_wdl:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/toilwdlTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/wdl/builtinTest.py
 
+py37_jobstore_and_provisioning:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
+# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
 
+py37_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest --duration=0 -s -r s src/toil/test/src
+    - python -m pytest --duration=0 -s -r s src/toil/test/utils
+
+py37_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+py37_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - export TOIL_TEST_INTEGRATIVE=True
+    - export TOIL_AWS_KEYNAME=id_rsa
+    - export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - chmod 400 /root/.ssh/id_rsa
+    - python -m pytest --duration=0 -s -r s src/toil/test/jobStores/jobStoreTest.py
+
+py37_provisioner_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
+    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
+    - export LIBPROCESS_IP=127.0.0.1
+    - python setup_gitlab_docker.py
+    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - make push_docker
+    - python -m pytest --duration=0 -s -r s src/toil/test/sort/sortTest.py
+    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/clusterScalerTest.py
+    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
+    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
+
+# Python3.8
+py38_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - python -m pytest --duration=0 -s -r s src/toil/test/src
+    - python -m pytest --duration=0 -s -r s src/toil/test/utils
+
+py38_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+# Cactus-on-Kubernetes integration (as a script and not a pytest test)
+py37_cactus_integration:
+  stage: integration
+  script:
+    - set -e
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+    - virtualenv --system-site-packages --python python3.7 venv
+    - . venv/bin/activate
+    - pip install .[aws,kubernetes]
+    - export TOIL_KUBERNETES_OWNER=toiltest
+    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+    - export TOIL_WORKDIR=/var/lib/toil
+    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+    - mkdir -p ${TOIL_WORKDIR}
+    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
+    - cd
+    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
+    - cd cactus
+    - git fetch origin
+    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
+    - git submodule update --init --recursive
+    - pip install --upgrade setuptools pip
+    - pip install --upgrade .
+    - toil clean aws:us-west-2:${BUCKET_NAME}
+    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -725,6 +725,7 @@ def uploadFile(uploadfunc: Any,
 
 def writeGlobalFileWrapper(file_store: AbstractFileStore, fileuri: str) -> str:
     """Wrap writeGlobalFile to accept file:// URIs"""
+    fileuri = fileuri if ':/' in fileuri else f'file://{fileuri}'
     return file_store.writeGlobalFile(
         schema_salad.ref_resolver.uri_file_path(fileuri))
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -367,7 +367,8 @@ class StepValueFrom:
     def eval_prep(self, step_inputs, file_store):
         for k, v in step_inputs.items():
             val = cast(CWLObjectType, v)
-            if isinstance(val, dict) and isinstance(self.source.input, dict):
+            source_input = getattr(self.source, 'input', {})
+            if isinstance(val, dict) and isinstance(source_input, dict):
                 if val.get("contents") is None and self.source.input.get('loadContents') is True:
                     fs_access = functools.partial(ToilFsAccess, file_store=file_store)
                     with fs_access('').open(cast(str, val["location"]), "rb") as f:

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -364,7 +364,14 @@ class StepValueFrom:
         self.context = None
         self.req = req
 
-    def eval_prep(self, step_inputs, file_store):
+    def eval_prep(self, step_inputs: dict, file_store: AbstractFileStore):
+        """
+        If loadContents is specified, this will resolve the contents of any file in
+        a set of inputs associated with the StepValueFrom object's self.source.
+
+        :param step_inputs: Workflow step inputs.
+        :param file_store: A toil file store, needed to resolve toil fs:// paths.
+        """
         for k, v in step_inputs.items():
             val = cast(CWLObjectType, v)
             source_input = getattr(self.source, 'input', {})
@@ -433,7 +440,7 @@ class JustAValue:
         return self.val
 
 
-def resolve_dict_w_promises(dict_w_promises: dict, file_store=None) -> dict:
+def resolve_dict_w_promises(dict_w_promises: dict, file_store: AbstractFileStore = None) -> dict:
     """
     Resolve the contents of an unresolved dictionary (containing promises) and
     evaluate expressions to produce the dictionary of actual values.

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -447,8 +447,8 @@ def resolve_dict_w_promises(dict_w_promises: dict, file_store=None) -> dict:
     result = {}
     for k, v in dict_w_promises.items():
         if isinstance(v, StepValueFrom):
-            # if file_store:
-            #     v.eval_prep(first_pass_results, file_store)
+            if file_store:
+                v.eval_prep(first_pass_results, file_store)
             result[k] = v.do_eval(inputs=first_pass_results)
         else:
             result[k] = first_pass_results[k]

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -369,7 +369,7 @@ class StepValueFrom:
             val = cast(CWLObjectType, v)
             source_input = getattr(self.source, 'input', {})
             if isinstance(val, dict) and isinstance(source_input, dict):
-                if val.get("contents") is None and self.source.input.get('loadContents') is True:
+                if val.get("contents") is None and source_input.get('loadContents') is True:
                     fs_access = functools.partial(ToilFsAccess, file_store=file_store)
                     with fs_access('').open(cast(str, val["location"]), "rb") as f:
                         val["contents"] = content_limit_respected_read(f)

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -447,8 +447,8 @@ def resolve_dict_w_promises(dict_w_promises: dict, file_store=None) -> dict:
     result = {}
     for k, v in dict_w_promises.items():
         if isinstance(v, StepValueFrom):
-            if file_store:
-                v.eval_prep(first_pass_results, file_store)
+            # if file_store:
+            #     v.eval_prep(first_pass_results, file_store)
             result[k] = v.do_eval(inputs=first_pass_results)
         else:
             result[k] = first_pass_results[k]
@@ -725,7 +725,7 @@ def uploadFile(uploadfunc: Any,
 
 def writeGlobalFileWrapper(file_store: AbstractFileStore, fileuri: str) -> str:
     """Wrap writeGlobalFile to accept file:// URIs"""
-    fileuri = fileuri if ':/' in fileuri else f'file://{fileuri}'
+    # fileuri = fileuri if ':/' in fileuri else f'file://{fileuri}'
     return file_store.writeGlobalFile(
         schema_salad.ref_resolver.uri_file_path(fileuri))
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -725,7 +725,7 @@ def uploadFile(uploadfunc: Any,
 
 def writeGlobalFileWrapper(file_store: AbstractFileStore, fileuri: str) -> str:
     """Wrap writeGlobalFile to accept file:// URIs"""
-    # fileuri = fileuri if ':/' in fileuri else f'file://{fileuri}'
+    fileuri = fileuri if ':/' in fileuri else f'file://{fileuri}'
     return file_store.writeGlobalFile(
         schema_salad.ref_resolver.uri_file_path(fileuri))
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -367,7 +367,7 @@ class StepValueFrom:
     def eval_prep(self, step_inputs, file_store):
         for k, v in step_inputs.items():
             val = cast(CWLObjectType, v)
-            if val.get("contents") is None:
+            if val.get("contents") is None and self.source.input['loadContents'] is True:
                 fs_access = functools.partial(ToilFsAccess, file_store=file_store)
                 with fs_access('').open(cast(str, val["location"]), "rb") as f:
                     val["contents"] = content_limit_respected_read(f)

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -367,10 +367,11 @@ class StepValueFrom:
     def eval_prep(self, step_inputs, file_store):
         for k, v in step_inputs.items():
             val = cast(CWLObjectType, v)
-            if val.get("contents") is None and self.source.input['loadContents'] is True:
-                fs_access = functools.partial(ToilFsAccess, file_store=file_store)
-                with fs_access('').open(cast(str, val["location"]), "rb") as f:
-                    val["contents"] = content_limit_respected_read(f)
+            if isinstance(val, dict) and isinstance(self.source.input, dict):
+                if val.get("contents") is None and self.source.input.get('loadContents') is True:
+                    fs_access = functools.partial(ToilFsAccess, file_store=file_store)
+                    with fs_access('').open(cast(str, val["location"]), "rb") as f:
+                        val["contents"] = content_limit_respected_read(f)
 
     def resolve(self) -> Any:
         """

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -349,8 +349,8 @@ class CWLv11Test(ToilTest):
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 213, 236
-            selected_tests = '1-212,214-235,237-253'
+            # TODO: we do not currently pass test: 236
+            selected_tests = '1-235,237-253'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',
@@ -411,8 +411,8 @@ class CWLv12Test(ToilTest):
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
         try:
-            # TODO: we do not currently pass tests: 214, 237 (offset from other versions), 307, 309, 310, 311, 330, 331, 332
-            selected_tests = '1-213,215-236,238-306,308,312-329,333-336'
+            # TODO: we do not currently pass tests: 237 (offset from other versions), 307, 309, 310, 311, 330, 331, 332
+            selected_tests = '1-236,238-306,308,312-329,333-336'
             cmd = [f'cwltest',
                    f'--tool=toil-cwl-runner',
                    f'--test={self.test_yaml}',


### PR DESCRIPTION
This PR adds support for CWL1.1 and allows us to pass conformance test 213.

Input files evaluated in `StepValueFrom` weren't resolving the toil specific uris we use, so were returning `None` for toil paths, which were seen as files that don't exist.

Adds the check if `loadContents == True`, as well as the `loadContents` content size limit.

In cwltool, this is done here: https://github.com/common-workflow-language/cwltool/blob/876e5bd384843bae41c98dcd36641bc71b2bf729/cwltool/workflow_job.py#L647

Closes #3257 .