### PR TITLE
Added doubleMem functionality for lsf jobs that die due to reaching imposed memory limit

### DIFF
--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -224,6 +224,11 @@ the logging module:
   --retryCount RETRYCOUNT
                         Number of times to retry a failing job before giving
                         up and labeling job failed. default=1
+  --doubleMem           If set, batch jobs which die due to reaching memory
+                        limit on batch schedulers will have their memory
+			doubled and they will be retried. The remaining
+			retry count will be reduced by 1. Currently only
+			supported by LSF. default=False
   --maxJobDuration MAXJOBDURATION
                         Maximum runtime of a job (in seconds) before we kill
                         it (this is a lower bound, and the actual time before

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -54,7 +54,7 @@ class BatchJobExitReason(enum.Enum):
     LOST = 3  # Preemptable failure (job's executing host went away).
     KILLED = 4  # Job killed before finishing.
     ERROR = 5  # Internal error.
-
+    MEMLIMIT = 6 # Job hit batch system imposed memory limit
 
 # Value to use as exitStatus in UpdatedBatchJobInfo.exitStatus when status is not available.
 EXIT_STATUS_UNAVAILABLE_VALUE = 255

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -104,7 +104,7 @@ class AbstractGridEngineBatchSystem(BatchSystemCleanupSupport):
 
             Implementation-specific; called by AbstractGridEngineWorker.run()
 
-            :param string newJob: Toil job ID
+            :param: string newJob: Toil job ID
             """
             activity = False
             # Load new job id if present:
@@ -277,17 +277,21 @@ class AbstractGridEngineBatchSystem(BatchSystemCleanupSupport):
             Kill specific job with the Toil job ID. Implementation-specific; called
             by AbstractGridEngineWorker.killJobs()
 
-            :param string jobID: Toil job ID
+            :param: string jobID: Toil job ID
             """
             raise NotImplementedError()
 
         @abstractmethod
         def getJobExitCode(self, batchJobID):
             """
-            Returns job exit code. Implementation-specific; called by
-            AbstractGridEngineWorker.checkOnJobs()
+            Returns job exit code or an instance of abstractBatchSystem.BatchJobExitReason
+            if something else happened other than the job exiting.
+            Implementation-specific; called by AbstractGridEngineWorker.checkOnJobs()
 
-            :param string batchjobID: batch system job ID
+            :param: string batchjobID: batch system job ID
+
+            :rtype: int|toil.batchSystems.abstractBatchSystem.BatchJobExitReason: exit code int
+                    or BatchJobExitReason if something else happened other than job exiting.
             """
             raise NotImplementedError()
 

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -156,6 +156,8 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                                 exit_info += "\nexit reason: {}".format(exit_reason)
                             logger.error(
                                 "bjobs detected job failed with: {}\nfor job: {}".format(exit_info, job))
+                            if "TERM_MEMLIMIT" in exit_reason:
+                                return 1117 #random exit code for TERM_MEMLIMIT specific failures, would not be present on other systems
                             return exit_code
                         if process_status == 'RUN':
                             logger.debug(

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -35,6 +35,7 @@ from dateutil.tz import tzlocal
 from datetime import datetime
 
 from toil.batchSystems import MemoryString
+from toil.batchSystems.abstractBatchSystem import BatchJobExitReason
 from toil.batchSystems.abstractGridEngineBatchSystem import \
         AbstractGridEngineBatchSystem
 from toil.batchSystems.lsfHelper import (parse_memory_resource,
@@ -157,7 +158,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                             logger.error(
                                 "bjobs detected job failed with: {}\nfor job: {}".format(exit_info, job))
                             if "TERM_MEMLIMIT" in exit_reason:
-                                return 1117 #random exit code for TERM_MEMLIMIT specific failures, would not be present on other systems
+                                return BatchJobExitReason.MEMLIMIT
                             return exit_code
                         if process_status == 'RUN':
                             logger.debug(

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -107,6 +107,7 @@ class Config(object):
         # Retrying/rescuing jobs
         self.retryCount = 1
         self.enableUnlimitedPreemptableRetries = False
+        self.doubleMem = False
         self.maxJobDuration = sys.maxsize
         self.rescueJobsFrequency = 3600
 
@@ -272,6 +273,7 @@ class Config(object):
         # Retrying/rescuing jobs
         setOption("retryCount", int, iC(1))
         setOption("enableUnlimitedPreemptableRetries")
+        setOption("doubleMem")
         setOption("maxJobDuration", int, iC(1))
         setOption("rescueJobsFrequency", int, iC(1))
 
@@ -554,6 +556,10 @@ def _addOptions(addGroupFn, config):
                 help=("If set, preemptable failures (or any failure due to an instance getting "
                       "unexpectedly terminated) would not count towards job failures and "
                       "--retryCount."))
+    addOptionFn("--doubleMem", dest="doubleMem", action='store_true', default=False,
+                help=("If set, batch jobs which die to reaching memory limit on batch schedulers "
+                      "will have their memory doubled and they will be retried. The remaining "
+                      "retry count will be reduced by 1. Currently supported by LSF."))
     addOptionFn("--maxJobDuration", dest="maxJobDuration", default=None,
                 help=("Maximum runtime of a job (in seconds) before we kill it "
                       "(this is a lower bound, and the actual time before killing "

--- a/src/toil/jobGraph.py
+++ b/src/toil/jobGraph.py
@@ -152,7 +152,7 @@ class JobGraph(JobNode):
             self._memory = self.memory * 2
             logger.warning("We have doubled the memory of the failed job %s to %s bytes due to doubleMem flag",
                            str(self), str(self.memory))
-        if self.memory < config.defaultMemory:
+        if self.memory < config.defaultMemory and not config.doubleMem:
             self._memory = config.defaultMemory
             logger.warning("We have increased the default memory of the failed job %s to %s bytes",
                            self, self.memory)

--- a/src/toil/jobGraph.py
+++ b/src/toil/jobGraph.py
@@ -148,6 +148,10 @@ class JobGraph(JobNode):
         # Set the default memory to be at least as large as the default, in
         # case this was a malloc failure (we do this because of the combined
         # batch system)
+        if exitReason == BatchJobExitReason.MEMLIMIT and config.doubleMem:
+            self._memory = self.memory * 2
+            logger.warning("We have doubled the memory of the failed job %s to %s bytes due to doubleMem flag",
+                           str(self), str(self.memory))
         if self.memory < config.defaultMemory:
             self._memory = config.defaultMemory
             logger.warning("We have increased the default memory of the failed job %s to %s bytes",

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -511,6 +511,8 @@ class Leader(object):
             updatedJobTuple.jobID, updatedJobTuple.exitStatus, updatedJobTuple.exitReason,
             updatedJobTuple.wallTime)
         # easy, track different state
+        if exitStatus == 1117:
+            exitReason = BatchJobExitReason.MEMLIMIT
         try:
             updatedJob = self.jobBatchSystemIDToIssuedJob[jobID]
         except KeyError:

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -511,15 +511,13 @@ class Leader(object):
             updatedJobTuple.jobID, updatedJobTuple.exitStatus, updatedJobTuple.exitReason,
             updatedJobTuple.wallTime)
         # easy, track different state
-        if exitStatus == 1117:
-            exitReason = BatchJobExitReason.MEMLIMIT
         try:
             updatedJob = self.jobBatchSystemIDToIssuedJob[jobID]
         except KeyError:
             logger.warning("A result seems to already have been processed "
                         "for job %s", jobID)
         else:
-            if exitStatus == 0:
+            if exitStatus == 0 and exitReason == None:
                 cur_logger = (logger.debug if str(updatedJob.jobName).startswith(CWL_INTERNAL_JOBS)
                               else logger.info)
                 cur_logger('Job ended: %s', updatedJob)


### PR DESCRIPTION
Often in genomics pipelines, especially for post-processing, memory limits of programs are not well-defined and can be dependent on data. This PR will add a memory doubling functionality if the flag `--doubleMem` is included on the command line for the LSF scheduler which will double the memory of and resubmit jobs that die due to reaching the LSF imposed memory limit. This functionality is incredibly useful for on-prem clusters. This addresses the issue opened by me: #3269 