### PR TITLE
Add WDL builtin test 'range'.

### DIFF
--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -321,6 +321,9 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
         self.check_function('write_map', cases=['as_command'],
                             expected_result='key1\tvalue1\nkey2\tvalue2')
 
+    def test_range(self):
+        self.check_function('range', cases=['as_input'], expected_result='0\n1\n2\n3\n4\n5\n6\n7')
+
     def test_transpose(self):
         # this workflow writes a transposed 2-dimensional array as a TSV file.
         self.check_function('transpose', cases=['as_input'], expected_result='0\t3\n1\t4\n2\t5')

--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import shutil
 import uuid
+from typing import Optional, List
+
 from toil.wdl.wdl_functions import sub
 from toil.wdl.wdl_functions import ceil
 from toil.wdl.wdl_functions import floor
@@ -242,18 +244,49 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
     def setUpClass(cls):
         cls.program = os.path.abspath("src/toil/wdl/toilwdl.py")
 
-    def check_function(self, function_name, cases, expected_result, json_file_name=None):
-        wdl_files = [os.path.abspath(f'src/toil/test/wdl/standard_library/{function_name}_{case}.wdl') for case in cases]
+    def check_function(self,
+                       function_name: str,
+                       cases: List[str],
+                       json_file_name: Optional[str] = None,
+                       expected_result: Optional[str] = None,
+                       expected_exception: Optional[str] = None):
+        """
+        Run the given WDL workflow and check its output. The WDL workflow
+        should store its output inside a 'output.txt' file that can be
+        compared to `expected_result`.
+
+        If `expected_exception` is set, this test passes only when both the
+        workflow fails and that the given `expected_exception` string is
+        present in standard error.
+        """
+        wdl_files = [os.path.abspath(f'src/toil/test/wdl/standard_library/{function_name}_{case}.wdl')
+                     for case in cases]
         json_file = os.path.abspath(f'src/toil/test/wdl/standard_library/{json_file_name or function_name}.json')
         for wdl_file in wdl_files:
             with self.subTest(f'Testing: {wdl_file} {json_file}'):
                 output_dir = f'/tmp/toil-wdl-test-{uuid.uuid4()}'
                 os.makedirs(output_dir)
-                subprocess.check_call([exactPython, self.program, wdl_file, json_file, '-o', output_dir])
-                output = os.path.join(output_dir, 'output.txt')
-                with open(output, 'r') as f:
-                    result = f.read().strip()
-                self.assertEqual(result, expected_result)
+
+                if expected_exception is not None:
+                    with self.assertRaises(subprocess.CalledProcessError) as context:
+                        # use check_output() here so that the output is read before return.
+                        subprocess.check_output([exactPython, self.program, wdl_file, json_file, '-o', output_dir],
+                                                stderr=subprocess.PIPE)
+
+                    stderr = context.exception.stderr
+                    self.assertIsInstance(stderr, bytes)
+                    self.assertIn(expected_exception, stderr.decode('utf-8'))
+
+                elif expected_result is not None:
+                    subprocess.check_call([exactPython, self.program, wdl_file, json_file, '-o', output_dir])
+                    output = os.path.join(output_dir, 'output.txt')
+                    with open(output, 'r') as f:
+                        result = f.read().strip()
+                    self.assertEqual(result, expected_result)
+
+                else:
+                    self.fail("Invalid test. Either `expected_result` or `expected_exception` must be set.")
+
                 shutil.rmtree(output_dir)
 
     def test_sub(self):
@@ -325,8 +358,16 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
 
     def test_range(self):
         # NOTE: this test depends on write_lines().
-        self.check_function('range', cases=['as_input'], expected_result='0\n1\n2\n3\n4\n5\n6\n7')
-        self.check_function('range', cases=['as_input'], json_file_name='range_0', expected_result='')
+        self.check_function('range', cases=['as_input'],
+                            expected_result='0\n1\n2\n3\n4\n5\n6\n7')
+
+        self.check_function('range', cases=['as_input'],
+                            json_file_name='range_0',
+                            expected_result='')
+
+        self.check_function('range', cases=['as_input'],
+                            json_file_name='range_invalid',
+                            expected_exception='WDLRuntimeError')
 
     def test_transpose(self):
         # NOTE: this test depends on write_tsv().

--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -27,6 +27,7 @@ from toil.test import ToilTest
 
 class WdlStandardLibraryFunctionsTest(ToilTest):
     """ A set of test cases for toil's wdl functions."""
+
     def setUp(self):
         """Runs anew before each test to create farm fresh temp dirs."""
         self.output_dir = os.path.join('/tmp/', 'toil-wdl-test-' + str(uuid.uuid4()))
@@ -236,6 +237,7 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
 
     All tests should include a simple wdl and json file for toil to run that checks the output.
     """
+
     @classmethod
     def setUpClass(cls):
         cls.program = os.path.abspath("src/toil/wdl/toilwdl.py")
@@ -287,7 +289,7 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
 
     def test_read(self):
         """ Test the set of WDL read functions."""
-        # NOTE: these tests depends on stdout() and the write_*() functions.
+        # NOTE: these tests depend on stdout() and the write_*() functions.
 
         self.check_function('read_lines', cases=['as_output'],
                             expected_result='line 1\n\t\tline 2 with tabs\n line 3\n\nline 5')
@@ -322,9 +324,12 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
                             expected_result='key1\tvalue1\nkey2\tvalue2')
 
     def test_range(self):
+        # NOTE: this test depends on write_lines().
         self.check_function('range', cases=['as_input'], expected_result='0\n1\n2\n3\n4\n5\n6\n7')
 
     def test_transpose(self):
+        # NOTE: this test depends on write_tsv().
+
         # this workflow writes a transposed 2-dimensional array as a TSV file.
         self.check_function('transpose', cases=['as_input'], expected_result='0\t3\n1\t4\n2\t5')
 

--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -242,9 +242,9 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
     def setUpClass(cls):
         cls.program = os.path.abspath("src/toil/wdl/toilwdl.py")
 
-    def check_function(self, function_name, cases, expected_result):
+    def check_function(self, function_name, cases, expected_result, json_file_name=None):
         wdl_files = [os.path.abspath(f'src/toil/test/wdl/standard_library/{function_name}_{case}.wdl') for case in cases]
-        json_file = os.path.abspath(f'src/toil/test/wdl/standard_library/{function_name}.json')
+        json_file = os.path.abspath(f'src/toil/test/wdl/standard_library/{json_file_name or function_name}.json')
         for wdl_file in wdl_files:
             with self.subTest(f'Testing: {wdl_file} {json_file}'):
                 output_dir = f'/tmp/toil-wdl-test-{uuid.uuid4()}'
@@ -326,6 +326,7 @@ class WdlStandardLibraryWorkflowsTest(ToilTest):
     def test_range(self):
         # NOTE: this test depends on write_lines().
         self.check_function('range', cases=['as_input'], expected_result='0\n1\n2\n3\n4\n5\n6\n7')
+        self.check_function('range', cases=['as_input'], json_file_name='range_0', expected_result='')
 
     def test_transpose(self):
         # NOTE: this test depends on write_tsv().

--- a/src/toil/test/wdl/standard_library/range.json
+++ b/src/toil/test/wdl/standard_library/range.json
@@ -1,0 +1,3 @@
+{
+  "rangeWorkflow.num": 8
+}

--- a/src/toil/test/wdl/standard_library/range_0.json
+++ b/src/toil/test/wdl/standard_library/range_0.json
@@ -1,0 +1,3 @@
+{
+  "rangeWorkflow.num": 0
+}

--- a/src/toil/test/wdl/standard_library/range_as_input.wdl
+++ b/src/toil/test/wdl/standard_library/range_as_input.wdl
@@ -1,0 +1,16 @@
+workflow rangeWorkflow {
+  Int num
+  call copy_output {input: in_array=range(num)}
+}
+
+task copy_output {
+  Array[Int] in_array
+
+  command {
+    cp ${write_lines(in_array)} output.txt
+  }
+
+  output {
+    File the_output = 'output.txt'
+  }
+}

--- a/src/toil/test/wdl/standard_library/range_as_input.wdl
+++ b/src/toil/test/wdl/standard_library/range_as_input.wdl
@@ -1,4 +1,5 @@
 workflow rangeWorkflow {
+  # this workflow depends on write_lines()
   Int num
   call copy_output {input: in_array=range(num)}
 }

--- a/src/toil/test/wdl/standard_library/range_invalid.json
+++ b/src/toil/test/wdl/standard_library/range_invalid.json
@@ -1,0 +1,3 @@
+{
+  "rangeWorkflow.num": -1
+}

--- a/src/toil/test/wdl/standard_library/transpose_as_input.wdl
+++ b/src/toil/test/wdl/standard_library/transpose_as_input.wdl
@@ -1,4 +1,5 @@
 workflow transposeWorkflow {
+  # this workflow depends on write_tsv()
   Array[Array[Int]] in_array
 
   call copy_output {input: in_array=transpose(in_array)}

--- a/src/toil/wdl/wdl_analysis.py
+++ b/src/toil/wdl/wdl_analysis.py
@@ -899,6 +899,9 @@ class AnalyzeWDL:
                     return es + '_toil_wdl_internal__stdout_file'
                 elif name.source_string == 'stderr':
                     return es + '_toil_wdl_internal__stderr_file'
+                elif name.source_string in ('range', 'zip'):
+                    # replace python built-in functions
+                    es += f'wdl_{name.source_string}('
                 else:
                     es = es + name.source_string + '('
             else:

--- a/src/toil/wdl/wdl_functions.py
+++ b/src/toil/wdl/wdl_functions.py
@@ -34,6 +34,12 @@ from toil.fileStores.abstractFileStore import AbstractFileStore
 wdllogger = logging.getLogger(__name__)
 
 
+class WDLRuntimeError(Exception):
+    """ WDL-related run-time error."""
+    def __init__(self, message):
+        super(WDLRuntimeError, self).__init__(message)
+
+
 def glob(glob_pattern, directoryname):
     '''
     Walks through a directory and its subdirectories looking for files matching
@@ -846,8 +852,8 @@ def wdl_range(num: int) -> List[int]:
 
     WDL syntax: Array[Int] range(Int)
     """
-    assert isinstance(num, int) and num >= 0, \
-        f'range() requires an integer greater than or equal to 0 (but got {num})'
+    if not (isinstance(num, int) and num >= 0):
+        raise WDLRuntimeError(f'range() requires an integer greater than or equal to 0 (but got {num})')
 
     return list(range(num))
 

--- a/src/toil/wdl/wdl_functions.py
+++ b/src/toil/wdl/wdl_functions.py
@@ -759,7 +759,7 @@ def write_lines(in_lines: List[str],
 
     with open(path, 'w') as file:
         for line in in_lines:
-            file.write(line + '\n')
+            file.write(f'{line}\n')
 
     if file_store:
         file_store.writeGlobalFile(path, cleanup=True)
@@ -837,6 +837,19 @@ def write_map(in_map: Dict[str, str],
         file_store.writeGlobalFile(path, cleanup=True)
 
     return path
+
+
+def wdl_range(num: int) -> List[int]:
+    """
+    Given an integer argument, the range function creates an array of integers of
+    length equal to the given argument.
+
+    WDL syntax: Array[Int] range(Int)
+    """
+    assert isinstance(num, int) and num >= 0, \
+        f'range() requires an integer greater than or equal to 0 (but got {num})'
+
+    return list(range(num))
 
 
 def transpose(in_array: List[List[Any]]) -> List[List[Any]]:

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -109,6 +109,7 @@ class SynthesizeWDL:
                     from toil.wdl.wdl_functions import basename
                     from toil.wdl.wdl_functions import floor
                     from toil.wdl.wdl_functions import ceil
+                    from toil.wdl.wdl_functions import wdl_range
                     from toil.wdl.wdl_functions import transpose
                     import fnmatch
                     import textwrap


### PR DESCRIPTION
Closes #3196. 

`range()` is a Python built-in function but the return type is `range`, so I'm adding a new function to make sure the correct type is returned. 