### PR TITLE
Fix broken stdout/stderr in  torque job (#3254)

### DIFF
--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -201,8 +201,8 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
             A very simple script generator that just wraps the command given; for
             now this goes to default tempdir
             """
-            stdoutfile = self.boss.formatStdOutErrPath(jobID, 'torque', '$PBS_JOBID', 'std_output')
-            stderrfile = self.boss.formatStdOutErrPath(jobID, 'torque', '$PBS_JOBID', 'std_error')
+            stdoutfile = self.boss.formatStdOutErrPath(jobID, 'torque', r'${PBS_JOBID}', 'std_output')
+            stderrfile = self.boss.formatStdOutErrPath(jobID, 'torque', r'${PBS_JOBID}', 'std_error')
 
             _, tmpFile = tempfile.mkstemp(suffix='.sh', prefix='torque_wrapper')
             fh = open(tmpFile , 'w')


### PR DESCRIPTION
This pull request attempts to fix #3254 .

@mr-c @adamnovak 

The problem is caused by `generateTorqueWrapper()` within `src\toil\batchSystems\torque.py`：

```python
        def generateTorqueWrapper(self, command, jobID):
            """
            A very simple script generator that just wraps the command given; for
            now this goes to default tempdir
            """
            stdoutfile = self.boss.formatStdOutErrPath(jobID, 'torque', '$PBS_JOBID', 'std_output')
            stderrfile = self.boss.formatStdOutErrPath(jobID, 'torque', '$PBS_JOBID', 'std_error')

            _, tmpFile = tempfile.mkstemp(suffix='.sh', prefix='torque_wrapper')
            fh = open(tmpFile , 'w')
            fh.write("#!/bin/sh\n")
            fh.write("#PBS -o {}\n".format(stdoutfile))
            fh.write("#PBS -e {}\n".format(stderrfile))
            fh.write("cd $PBS_O_WORKDIR\n\n")
            fh.write(command + "\n")

            fh.close

            return tmpFile
```

The function above wraps the toil job into a shell script, and then uses `qsub` to submit the script to the torque batch system.

Two lines of code in this function will generate two paths：

```python
            fh.write("#PBS -o {}\n".format(stdoutfile))
            fh.write("#PBS -e {}\n".format(stderrfile))
```

```
/tmp/toil_workflow_57b6a086-6d74-4578-8941-0ce2401e1c48_job_1_batch_torque_$PBS_JOBID_std_output.log
/tmp/toil_workflow_57b6a086-6d74-4578-8941-0ce2401e1c48_job_1_batch_torque_$PBS_JOBID_std_error.log
```

The problem is caused by **the variable reference format** of bash. The underscore is a legal variable name, so the reference to the `PBS_JOBID` variable above actually becomes `PBS_JOBID_std_output` and `PBS_JOBID_std_error`.

Let's test the variable reference format in bash:

```shell
PBS_JOBID="175958.admin"
echo /tmp/toil_workflow_57b6a086-6d74-4578-8941-0ce2401e1c48_job_1_batch_torque_$PBS_JOBID_std_output.log
echo /tmp/toil_workflow_57b6a086-6d74-4578-8941-0ce2401e1c48_job_1_batch_torque_$PBS_JOBID_std_error.log
```

The two `echo` statements above will produce the same path:

```shell
/tmp/toil_workflow_57b6a086-6d74-4578-8941-0ce2401e1c48_job_1_batch_torque_.log
```

The bash script generated by `generateTorqueWrapper()` fails for the reasons mentioned above, and the exit_status is -9. The meaning of this status code in torque is "Could not create/open stdout stderr files". Please see: [jobExitStatus](http://docs.adaptivecomputing.com/torque/4-2-7/Content/topics/2-jobs/jobExitStatus.htm)。

The obvious fix is to use curly brackets to refer to bash variable names：

```python
            stdoutfile = self.boss.formatStdOutErrPath(jobID, 'torque', r'${PBS_JOBID}', 'std_output')
            stderrfile = self.boss.formatStdOutErrPath(jobID, 'torque', r'${PBS_JOBID}', 'std_error')
```

With this patch, the problem mentioned in #3254 is fixed and I can see stdout/stderr properly. Now I can successfully run through the process without using the `--noStdOutErr` option.

```shell
export TOIL_TORQUE_ARGS="-N test-toil -q batch"
export TOIL_TORQUE_REQS="walltime=48:00:00"
export CWL_SINGULARITY_CACHE="$HOME/src/rhapsody-wta/dockerImages"
export TMPDIR="$PWD/tmp/toil"
toil-cwl-runner \
  --batchSystem torque \
  --singularity \
  --defaultDisk 120G \
  --jobStore file:results/rhapsody-wta-job-store \
  --outdir results \
  --writeLogs logs \
  --logFile logs/cwltoil_$(date +%Y%m%d_%H%M%S).log \
  --workDir tmp/toil \
  --disableCaching \
  --logLevel INFO \
  --retryCount 2 \
  --maxLogFileSize 20000000000 \
  --stats \
  workflow/rhapsody_wta_1.8/main.cwl data/human_sample.yml
```