### PR TITLE
added doubleMem functionality for LSF for lsf jobs that die due to reaching imposed memory limit

### DIFF
--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -224,6 +224,11 @@ the logging module:
   --retryCount RETRYCOUNT
                         Number of times to retry a failing job before giving
                         up and labeling job failed. default=1
+  --doubleMem           If set, batch jobs which die due to reaching memory
+                        limit on batch schedulers will have their memory
+			doubled and they will be retried. The remaining
+			retry count will be reduced by 1. Currently only
+			supported by LSF. default=False.
   --maxJobDuration MAXJOBDURATION
                         Maximum runtime of a job (in seconds) before we kill
                         it (this is a lower bound, and the actual time before

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -54,7 +54,7 @@ class BatchJobExitReason(enum.Enum):
     LOST = 3  # Preemptable failure (job's executing host went away).
     KILLED = 4  # Job killed before finishing.
     ERROR = 5  # Internal error.
-
+    MEMLIMIT = 6 # Job hit batch system imposed memory limit
 
 # Value to use as exitStatus in UpdatedBatchJobInfo.exitStatus when status is not available.
 EXIT_STATUS_UNAVAILABLE_VALUE = 255

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -28,7 +28,7 @@ from future.utils import with_metaclass
 from toil.lib.misc import CalledProcessErrorStderr
 from toil.lib.objects import abstractclassmethod
 
-from toil.batchSystems.abstractBatchSystem import BatchSystemCleanupSupport, UpdatedBatchJobInfo
+from toil.batchSystems.abstractBatchSystem import BatchSystemCleanupSupport, UpdatedBatchJobInfo, BatchJobExitReason
 
 logger = logging.getLogger(__name__)
 
@@ -192,9 +192,13 @@ class AbstractGridEngineBatchSystem(BatchSystemCleanupSupport):
             for jobID in list(self.runningJobs):
                 batchJobID = self.getBatchSystemID(jobID)
                 status = self.boss.with_retries(self.getJobExitCode, batchJobID)
-                if status is not None:
+                if status is not None and isinstance(status, int):
                     activity = True
                     self.updatedJobsQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=status, exitReason=None, wallTime=None))
+                    self.forgetJob(jobID)
+                elif status is not None and isinstance(status, BatchJobExitReason):
+                    activity = True
+                    self.updatedJobsQueue.put(UpdatedBatchJobInfo(jobID=jobID, exitStatus=1, exitReason=status, wallTime=None))
                     self.forgetJob(jobID)
             self._checkOnJobsCache = activity
             self._checkOnJobsTimestamp = datetime.now()
@@ -280,10 +284,14 @@ class AbstractGridEngineBatchSystem(BatchSystemCleanupSupport):
         @abstractmethod
         def getJobExitCode(self, batchJobID):
             """
-            Returns job exit code. Implementation-specific; called by
-            AbstractGridEngineWorker.checkOnJobs()
+            Returns job exit code or an instance of abstractBatchSystem.BatchJobExitReason.
+            if something else happened other than the job exiting.
+            Implementation-specific; called by AbstractGridEngineWorker.checkOnJobs()
 
             :param string batchjobID: batch system job ID
+
+            :rtype: int|toil.batchSystems.abstractBatchSystem.BatchJobExitReason: exit code int
+                    or BatchJobExitReason if something else happened other than job exiting.
             """
             raise NotImplementedError()
 

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -35,6 +35,7 @@ from dateutil.tz import tzlocal
 from datetime import datetime
 
 from toil.batchSystems import MemoryString
+from toil.batchSystems.abstractBatchSystem import BatchJobExitReason
 from toil.batchSystems.abstractGridEngineBatchSystem import \
         AbstractGridEngineBatchSystem
 from toil.batchSystems.lsfHelper import (parse_memory_resource,
@@ -156,6 +157,8 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                                 exit_info += "\nexit reason: {}".format(exit_reason)
                             logger.error(
                                 "bjobs detected job failed with: {}\nfor job: {}".format(exit_info, job))
+                            if "TERM_MEMLIMIT" in exit_reason:
+                                return BatchJobExitReason.MEMLIMIT
                             return exit_code
                         if process_status == 'RUN':
                             logger.debug(

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -107,6 +107,7 @@ class Config(object):
         # Retrying/rescuing jobs
         self.retryCount = 1
         self.enableUnlimitedPreemptableRetries = False
+        self.doubleMem = False
         self.maxJobDuration = sys.maxsize
         self.rescueJobsFrequency = 3600
 
@@ -272,6 +273,7 @@ class Config(object):
         # Retrying/rescuing jobs
         setOption("retryCount", int, iC(1))
         setOption("enableUnlimitedPreemptableRetries")
+        setOption("doubleMem")
         setOption("maxJobDuration", int, iC(1))
         setOption("rescueJobsFrequency", int, iC(1))
 
@@ -554,6 +556,10 @@ def _addOptions(addGroupFn, config):
                 help=("If set, preemptable failures (or any failure due to an instance getting "
                       "unexpectedly terminated) would not count towards job failures and "
                       "--retryCount."))
+    addOptionFn("--doubleMem", dest="doubleMem", action='store_true', default=False,
+                help=("If set, batch jobs which die to reaching memory limit on batch schedulers "
+                      "will have their memory doubled and they will be retried. The remaining "
+                      "retry count will be reduced by 1. Currently supported by LSF."))
     addOptionFn("--maxJobDuration", dest="maxJobDuration", default=None,
                 help=("Maximum runtime of a job (in seconds) before we kill it "
                       "(this is a lower bound, and the actual time before killing "

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -756,6 +756,10 @@ class JobDescription(Requirer):
         # Set the default memory to be at least as large as the default, in
         # case this was a malloc failure (we do this because of the combined
         # batch system)
+        if exitReason == BatchJobExitReason.MEMLIMIT and self._config.doubleMem:
+            self.memory = self.memory * 2
+            logger.warning("We have doubled the memory of the failed job %s to %s bytes due to doubleMem flag",
+                           self, self.memory)
         if self.memory < self._config.defaultMemory:
             self.memory = self._config.defaultMemory
             logger.warning("We have increased the default memory of the failed job %s to %s bytes",

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -575,7 +575,7 @@ class Leader(object):
             logger.warning("A result seems to already have been processed "
                         "for job %s", jobID)
         else:
-            if exitStatus == 0:
+            if exitStatus == 0 and exitReason == None:
                 cur_logger = (logger.debug if str(updatedJob.jobName).startswith(CWL_INTERNAL_JOBS)
                               else logger.info)
                 cur_logger('Job ended: %s', updatedJob)


### PR DESCRIPTION
Often in genomics pipelines, especially for post-processing, memory limits of programs are not well-defined and can be dependent on data. This PR will add a memory doubling functionality if the flag --doubleMem is included on the command line for the LSF scheduler which will double the memory of and resubmit jobs that die due to reaching the LSF imposed memory limit. This functionality is incredibly useful for on-prem clusters. This addresses the issue opened by me: #3269