### PR TITLE
Define a changelog process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Changelog Entry
+To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:
+
+ * Whatsits now frobnicated
+

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -416,7 +416,7 @@ These are the steps to take to publish a Toil release:
   should be incremented, and **Y** and **Z** should be zero. If non-breaking
   changes are made but new functionality is added, **X** should remain the same
   as the last release, **Y** should be incremented, and **Z** should be zero.
-  If only bugfixes are released, **X** and **Y** should be the same as the last
+  If only patches are released, **X** and **Y** should be the same as the last
   release and **Z** should be incremented.
 
   .. _semantic versioning: https://semver.org/

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -364,6 +364,13 @@ Pull Requests
 * Modified pull requests must be re-reviewed before merging. **Note that Github
   does not enforce this!**
 
+* When merging a pull request, make sure to update the `Draft Changelog`_ on
+  the Github wiki, which we will use to produce the changelog for the next
+  release. The PR template tells you to do this, so don't forget. New entries
+  should go at the bottom.
+
+  .. _Draft Changelog: https://github.com/DataBiosphere/toil/wiki/Draft-Changelog
+
 * Pull requests will not be merged unless Travis and Gitlab CI tests pass.
   Gitlab tests are only run on code in the main Toil repository on some branch,
   so it is the responsibility of the approving reviewer to make sure that pull

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -404,6 +404,66 @@ Pull Requests
   .. _Co-authored-by: https://github.blog/2018-01-29-commit-together-with-co-authors/
   .. _Issue #2816: https://github.com/DataBiosphere/toil/issues/2816
   .. _toil.lib.retry: https://github.com/DataBiosphere/toil/blob/master/src/toil/lib/retry.py
+  
+
+Publishing a Release
+~~~~~~~~~~~~~~~~~~~~
+
+These are the steps to take to publish a Toil release:
+
+* Determine the release version **X.Y.Z**. This should follow
+  `semantic versioning`_; if user-workflow-breaking changes are made, **X**
+  should be incremented, and **Y** and **Z** should be zero. If non-breaking
+  changes are made but new functionality is added, **X** should remain the same
+  as the last release, **Y** should be incremented, and **Z** should be zero.
+  If only bugfixes are released, **X** and **Y** should be the same as the last
+  release and **Z** should be incremented.
+
+  .. _semantic versioning: https://semver.org/
+
+* If it does not exist already, create a release branch in the Toil repo
+  named ``X.Y.x``, where **x** is a literal lower-case "x". For patch releases,
+  find the existing branch and make sure it is up to date with the patch
+  commits that are to be released. They may be `cherry-picked over`_ from
+  master.
+
+  .. _cherry-picked over: https://trunkbaseddevelopment.com/branch-for-release/
+
+* On the release branch, edit ``version_template.py`` in the root of the
+  repository. Find the line that looks like this (slightly different for patch
+  releases):
+
+  .. code-block:: python
+
+      baseVersion = 'X.Y.0a1'
+
+  Make it look like this instead:
+
+  .. code-block:: python
+
+      baseVersion = 'X.Y.Z'
+
+  Commit your change to the branch.
+
+* Tag the current state of the release branch as ``releases/X.Y.Z``.
+
+* Make the Github release here_, referencing that tag. For a non-patch
+  release, fill in the description with the changelog from `the wiki page`_,
+  which you should clear. For a patch release, just describe the patch.
+
+  .. _here: https://github.com/DataBiosphere/toil/releases/new
+  .. _the wiki page: https://github.com/DataBiosphere/toil/wiki/Draft-Changelog
+
+* For a non-patch release, set up the main branch so that development
+  builds will declare themselves to be alpha versions of what the next release
+  will probably be. Edit  ``version_template.py`` in the root of the repository
+  on the main branch to set ``baseVersion`` like this:
+
+  .. code-block:: python
+
+      baseVersion = 'X.Y+1.0a1'
+
+  Make sure to replace ``X`` and ``Y+1`` with actual numbers.
 
 Adding Retries to a Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This adds a PR template that prompts you for a changelog entry, notes that the merger should add it to a wiki page, and has a step in the release process to pull the list of changes from the wiki page.

It also documents at least part of a release checklist, so that there's a place to put the note about pulling the changelog from the wiki. @DailyDreaming we probably will need the steps for doing the PyPI release on there too eventually.

This should fix #3315 .