### PR TITLE
CWL v1.2 conformance tests 330 and 331.

### DIFF
--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -22,6 +22,7 @@ import shutil
 import zipfile
 import pytest
 import uuid
+import subprocess
 from urllib.request import urlretrieve
 from io import StringIO
 
@@ -29,13 +30,43 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 logger = logging.getLogger(__name__)
-import subprocess
 from toil.test import (ToilTest, needs_cwl, slow, needs_docker, needs_lsf,
                        needs_mesos, needs_parasol, needs_gridengine, needs_slurm,
                        needs_torque)
 
 
 CONFORMANCE_TEST_TIMEOUT = 3600
+
+
+def run_conformance_tests(workDir, yml, caching=False, batchSystem=None, selected_tests=None):
+    try:
+        cmd = ['cwltest',
+               '--tool=toil-cwl-runner',
+               f'--test={yml}',
+               '--timeout=2400',
+               f'--basedir={workDir}']
+        if selected_tests:
+            cmd.append(f'-n={selected_tests}')
+        if batchSystem:
+            cmd.extend(["--batchSystem", batchSystem])
+        cmd.extend(['--', f'--disableCaching={not caching}'])
+        logger.info("Running: '%s'", "' '".join(cmd))
+        subprocess.check_output(cmd, cwd=workDir, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        only_unsupported = False
+        # check output -- if we failed but only have unsupported features, we're okay
+        p = re.compile(r"(?P<failures>\d+) failures, (?P<unsupported>\d+) unsupported features")
+
+        error_log = e.output.decode('utf-8')
+        for line in error_log.split('\n'):
+            m = p.search(line)
+            if m:
+                if int(m.group("failures")) == 0 and int(m.group("unsupported")) > 0:
+                    only_unsupported = True
+                    break
+        if not only_unsupported:
+            print(error_log)
+            raise e
 
 
 @needs_cwl
@@ -194,29 +225,10 @@ class CWLv10Test(ToilTest):
     @slow
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
-        try:
-            cmd = ['cwltest', '--tool', 'toil-cwl-runner', '--test=conformance_test_v1.0.yaml',
-                   '--timeout=2400', '--basedir=' + self.workDir]
-            if batchSystem:
-                cmd.extend(["--batchSystem", batchSystem])
-            cmd.extend(['--', '--disableCaching={}'.format(not caching)])
-            logger.info("Running: '%s'", "' '".join(cmd))
-            subprocess.check_output(cmd, cwd=self.workDir, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            only_unsupported = False
-            # check output -- if we failed but only have unsupported features, we're okay
-            p = re.compile(r"(?P<failures>\d+) failures, (?P<unsupported>\d+) unsupported features")
-
-            error_log = e.output.decode('utf-8')
-            for line in error_log.split('\n'):
-                m = p.search(line)
-                if m:
-                    if int(m.group("failures")) == 0 and int(m.group("unsupported")) > 0:
-                        only_unsupported = True
-                        break
-            if not only_unsupported:
-                print(error_log)
-                raise e
+        run_conformance_tests(workDir=self.workDir,
+                              yml='conformance_test_v1.0.yaml',
+                              caching=caching,
+                              batchSystem=batchSystem)
 
     @slow
     @needs_lsf
@@ -354,43 +366,18 @@ class CWLv11Test(ToilTest):
 
     @slow
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_run_conformance_with_caching(self):
         self.test_run_conformance(caching=True)
 
     @slow
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
-        try:
-            # TODO: we do not currently pass test: 236
-            selected_tests = '1-235,237-253'
-            cmd = [f'cwltest',
-                   f'--tool=toil-cwl-runner',
-                   f'--test={self.test_yaml}',
-                   f'--timeout=2400',
-                   f'--basedir={self.cwlSpec}',
-                   f'-n={selected_tests}']
-            if batchSystem:
-                cmd.extend(["--batchSystem", batchSystem])
-            cmd.extend(['--', '--disableCaching={}'.format(not caching)])
-            logger.info("Running: '%s'", "' '".join(cmd))
-            subprocess.check_output(cmd, cwd=self.cwlSpec, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            only_unsupported = False
-            # check output -- if we failed but only have unsupported features, we're okay
-            p = re.compile(r"(?P<failures>\d+) failures, (?P<unsupported>\d+) unsupported features")
-
-            error_log = e.output.decode('utf-8')
-            for line in error_log.split('\n'):
-                m = p.search(line)
-                if m:
-                    if int(m.group("failures")) == 0 and int(m.group("unsupported")) > 0:
-                        only_unsupported = True
-                        break
-            if not only_unsupported:
-                print(error_log)
-                raise e
+        run_conformance_tests(workDir=self.cwlSpec,
+                              yml=self.test_yaml,
+                              caching=caching,
+                              batchSystem=batchSystem,
+                              # TODO: we do not currently pass test: 236
+                              selected_tests='1-235,237-253')
 
 @needs_cwl
 class CWLv12Test(ToilTest):
@@ -414,46 +401,27 @@ class CWLv12Test(ToilTest):
             shutil.rmtree(self.outDir)
         unittest.TestCase.tearDown(self)
 
+    def refresh_deleted_fixtures(self):
+        # TODO: Prevent Toil from deleting these?
+        for fixture in ['tests/testdir/a', 'tests/testdir/b', 'tests/testdir/c/d']:
+            if not os.path.exists(os.path.join(self.cwlSpec, os.path.dirname(fixture))):
+                os.makedirs(os.path.join(self.cwlSpec, os.path.dirname(fixture)), exist_ok=True)
+                with open(os.path.join(self.cwlSpec, os.path.dirname(fixture)), 'w') as f:
+                    f.write()
+
     @slow
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
-    # Cannot work until we fix https://github.com/DataBiosphere/toil/issues/2801
-    @pytest.mark.xfail
     def test_run_conformance_with_caching(self):
         self.test_run_conformance(caching=True)
 
     @slow
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
-        try:
-            # TODO: we do not currently pass tests: 237 (offset from other versions), 307, 309, 310, 311, 330, 331, 332
-            selected_tests = '1-236,238-306,308,312-329,333-336'
-            cmd = [f'cwltest',
-                   f'--tool=toil-cwl-runner',
-                   f'--test={self.test_yaml}',
-                   f'--timeout=2400',
-                   f'--basedir={self.cwlSpec}',
-                   f'-n={selected_tests}']
-            if batchSystem:
-                cmd.extend(["--batchSystem", batchSystem])
-
-            args_passed_directly_to_toil = ['--enable-dev']
-            args_passed_directly_to_toil.extend(['--disableCaching={}'.format(not caching)])
-            cmd.extend(['--'] + args_passed_directly_to_toil)
-            
-            logger.info("Running: '%s'", "' '".join(cmd))
-            subprocess.check_output(cmd, cwd=self.cwlSpec, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            only_unsupported = False
-            # check output -- if we failed but only have unsupported features, we're okay
-            p = re.compile(r"(?P<failures>\d+) failures, (?P<unsupported>\d+) unsupported features")
-
-            error_log = e.output.decode('utf-8')
-            for line in error_log.split('\n'):
-                m = p.search(line)
-                if m:
-                    if int(m.group("failures")) == 0 and int(m.group("unsupported")) > 0:
-                        only_unsupported = True
-                        break
-            if not only_unsupported:
-                print(error_log)
-                raise e
+        # TODO: we do not currently pass tests: 237 (offset from other versions), 307, 309, 310, 311, 332
+        for selected_tests in ['1-236,238-306,308,312-329,333-336', '330', '331']:
+            run_conformance_tests(workDir=self.cwlSpec,
+                                  yml=self.test_yaml,
+                                  caching=caching,
+                                  batchSystem=batchSystem,
+                                  selected_tests=selected_tests)
+            self.refresh_deleted_fixtures()

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -402,7 +402,7 @@ class CWLv12Test(ToilTest):
         unittest.TestCase.tearDown(self)
 
     def refresh_deleted_fixtures(self):
-        # TODO: Prevent Toil from deleting these?
+        # TODO: Prevent Toil from deleting these?  See: https://github.com/DataBiosphere/toil/issues/3318
         for fixture in ['tests/testdir/a', 'tests/testdir/b', 'tests/testdir/c/d']:
             if not os.path.exists(os.path.join(self.cwlSpec, os.path.dirname(fixture))):
                 os.makedirs(os.path.join(self.cwlSpec, os.path.dirname(fixture)), exist_ok=True)
@@ -419,6 +419,9 @@ class CWLv12Test(ToilTest):
     def test_run_conformance(self, batchSystem=None, caching=False):
         # TODO: we do not currently pass tests: 237 (offset from other versions), 307, 309, 310, 311, 332
         for selected_tests in ['1-236,238-306,308,312-329,333-336', '330', '331']:
+            # 330 and #331 are run separately in order to ensure that the potentially deleted
+            # test fixtures: ['tests/testdir/a', 'tests/testdir/b', 'tests/testdir/c/d'] exist prior
+            # to running.  See: https://github.com/DataBiosphere/toil/issues/3318
             run_conformance_tests(workDir=self.cwlSpec,
                                   yml=self.test_yaml,
                                   caching=caching,


### PR DESCRIPTION
Tests 330 and 331 were failing because some CWL v1.2 test fixtures were deleted by prior tests.  Restoring the CWL v1.2 fixtures prior to running allows them to pass.

Adds a slight refactor and also removes some of the `xfail` decorators that allow CWL caching tests to fail.