### PR TITLE
CWL test script refactor.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,25 +63,6 @@ py37_cwl_v1.0:
     - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test
 
-py37_cwl_v1.0_kubernetes:
-  stage: main_tests
-  script:
-    - pwd
-    - set -e
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-    - virtualenv --system-site-packages -p python3.7 venv && . venv/bin/activate
-    - make prepare && make develop extras=[cwl,aws,kubernetes]
-    - export TOIL_KUBERNETES_OWNER=toiltest
-    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
-    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
-    - export TOIL_WORKDIR=/var/lib/toil
-    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-    - mkdir -p ${TOIL_WORKDIR}
-    - export CWL_K8_TEST_BUCKET=toil-test-$RANDOM-$RANDOM-$RANDOM
-    - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
-    - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test::test_kubernetes_cwl_conformance
-    - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test::test_kubernetes_cwl_conformance_with_caching
-
 py37_cwl_v1.1:
   stage: main_tests
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,40 +19,40 @@ after_script:
   - stopdocker || true
 
 stages:
-  - basic_tests
+#  - basic_tests
   - main_tests
-  - integration
+#  - integration
 
 
-# Python3.6
-py36_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/src
-    - make test tests=src/toil/test/utils
-
-py36_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-
-# Python3.7
-py37_batch_systems:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
-    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
+## Python3.6
+#py36_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/src
+#    - make test tests=src/toil/test/utils
+#
+#py36_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+#
+## Python3.7
+#py37_batch_systems:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
+#    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
   stage: main_tests
@@ -98,125 +98,125 @@ py37_cwl_v1.2:
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv12Test
 
-py37_wdl:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - make test tests=src/toil/test/wdl/toilwdlTest.py
-    - make test tests=src/toil/test/wdl/builtinTest.py
-
-py37_jobstore_and_provisioning:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-    - make test tests=src/toil/test/sort/sortTest.py
-    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-
-py37_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/src
-    - make test tests=src/toil/test/utils
-
-py37_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-py37_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - export TOIL_TEST_INTEGRATIVE=True
-    - export TOIL_AWS_KEYNAME=id_rsa
-    - export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - chmod 400 /root/.ssh/id_rsa
-    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-
-py37_provisioner_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-    - export LIBPROCESS_IP=127.0.0.1
-    - python setup_gitlab_docker.py
-    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - make push_docker
-    - make test tests=src/toil/test/sort/sortTest.py
-    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
-
-# Python3.8
-py38_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/src
-    - make test tests=src/toil/test/utils
-
-py38_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-# Cactus-on-Kubernetes integration (as a script and not a pytest test)
-py37_cactus_integration:
-  stage: integration
-  script:
-    - set -e
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-    - virtualenv --system-site-packages --python python3.7 venv
-    - . venv/bin/activate
-    - pip install .[aws,kubernetes]
-    - export TOIL_KUBERNETES_OWNER=toiltest
-    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
-    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
-    - export TOIL_WORKDIR=/var/lib/toil
-    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-    - mkdir -p ${TOIL_WORKDIR}
-    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
-    - cd
-    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
-    - cd cactus
-    - git fetch origin
-    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
-    - git submodule update --init --recursive
-    - pip install --upgrade setuptools pip
-    - pip install --upgrade .
-    - toil clean aws:us-west-2:${BUCKET_NAME}
-    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
+#py37_wdl:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+#    - make test tests=src/toil/test/wdl/toilwdlTest.py
+#    - make test tests=src/toil/test/wdl/builtinTest.py
+#
+#py37_jobstore_and_provisioning:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+#    - make test tests=src/toil/test/sort/sortTest.py
+#    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+##    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+## https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
+## guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
+#
+#py37_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/src
+#    - make test tests=src/toil/test/utils
+#
+#py37_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+#py37_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - export TOIL_TEST_INTEGRATIVE=True
+#    - export TOIL_AWS_KEYNAME=id_rsa
+#    - export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+#    - python setup_gitlab_ssh.py
+#    - chmod 400 /root/.ssh/id_rsa
+#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+#
+#py37_provisioner_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
+#    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
+#    - export LIBPROCESS_IP=127.0.0.1
+#    - python setup_gitlab_docker.py
+#    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+#    - python setup_gitlab_ssh.py
+#    - make push_docker
+#    - make test tests=src/toil/test/sort/sortTest.py
+#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+#    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+#    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
+#
+## Python3.8
+#py38_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/src
+#    - make test tests=src/toil/test/utils
+#
+#py38_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+## Cactus-on-Kubernetes integration (as a script and not a pytest test)
+#py37_cactus_integration:
+#  stage: integration
+#  script:
+#    - set -e
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+#    - virtualenv --system-site-packages --python python3.7 venv
+#    - . venv/bin/activate
+#    - pip install .[aws,kubernetes]
+#    - export TOIL_KUBERNETES_OWNER=toiltest
+#    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+#    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+#    - export TOIL_WORKDIR=/var/lib/toil
+#    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+#    - mkdir -p ${TOIL_WORKDIR}
+#    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
+#    - cd
+#    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
+#    - cd cactus
+#    - git fetch origin
+#    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
+#    - git submodule update --init --recursive
+#    - pip install --upgrade setuptools pip
+#    - pip install --upgrade .
+#    - toil clean aws:us-west-2:${BUCKET_NAME}
+#    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ py36_appliance_build:
   stage: basic_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
     # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
     - python setup_gitlab_docker.py
@@ -49,7 +49,7 @@ py37_batch_systems:
   stage: main_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
     - make test tests=src/toil/test/batchSystems/batchSystemTest.py
     - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
@@ -58,16 +58,35 @@ py37_cwl_v1.0:
   stage: main_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test
+
+py37_cwl_v1.0_kubernetes:
+  stage: main_tests
+  script:
+    - pwd
+    - set -e
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+    - virtualenv --system-site-packages -p python3.7 venv && . venv/bin/activate
+    - make prepare && make develop extras=[cwl,aws,kubernetes]
+    - export TOIL_KUBERNETES_OWNER=toiltest
+    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+    - export TOIL_WORKDIR=/var/lib/toil
+    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+    - mkdir -p ${TOIL_WORKDIR}
+    - export CWL_K8_TEST_BUCKET=toil-test-$RANDOM-$RANDOM-$RANDOM
+    - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
+    - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test::test_kubernetes_cwl_conformance
+    - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test::test_kubernetes_cwl_conformance_with_caching
 
 py37_cwl_v1.1:
   stage: main_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv11Test
 
@@ -75,7 +94,7 @@ py37_cwl_v1.2:
   stage: main_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv12Test
 
@@ -83,7 +102,7 @@ py37_wdl:
   stage: main_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
     - make test tests=src/toil/test/wdl/toilwdlTest.py
     - make test tests=src/toil/test/wdl/builtinTest.py
@@ -92,7 +111,7 @@ py37_jobstore_and_provisioning:
   stage: main_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
     - make test tests=src/toil/test/jobStores/jobStoreTest.py
     - make test tests=src/toil/test/sort/sortTest.py
@@ -106,7 +125,7 @@ py37_main:
   stage: basic_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
     - make test tests=src/toil/test/src
     - make test tests=src/toil/test/utils
@@ -115,7 +134,7 @@ py37_appliance_build:
   stage: basic_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
     # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
     - python setup_gitlab_docker.py
@@ -125,7 +144,7 @@ py37_integration:
   stage: integration
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
     - export TOIL_TEST_INTEGRATIVE=True
     - export TOIL_AWS_KEYNAME=id_rsa
@@ -160,7 +179,7 @@ py38_main:
   stage: basic_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
     - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
     - make test tests=src/toil/test/src
     - make test tests=src/toil/test/utils
@@ -169,7 +188,7 @@ py38_appliance_build:
   stage: basic_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && apt install -y jq python3.8 python3.8-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
     - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
     # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
     - python setup_gitlab_docker.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ py37_cwl_v1.0:
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test
 
@@ -87,7 +87,7 @@ py37_cwl_v1.1:
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv11Test
 
 py37_cwl_v1.2:
@@ -95,7 +95,7 @@ py37_cwl_v1.2:
   script:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv12Test
 
 py37_wdl:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,40 +19,40 @@ after_script:
   - stopdocker || true
 
 stages:
-#  - basic_tests
+  - basic_tests
   - main_tests
-#  - integration
+  - integration
 
 
-## Python3.6
-#py36_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/src
-#    - make test tests=src/toil/test/utils
-#
-#py36_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-#
-## Python3.7
-#py37_batch_systems:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
-#    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
+# Python3.6
+py36_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/src
+    - make test tests=src/toil/test/utils
+
+py36_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+
+# Python3.7
+py37_batch_systems:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
+    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
   stage: main_tests
@@ -98,125 +98,125 @@ py37_cwl_v1.2:
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv12Test
 
-#py37_wdl:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-#    - make test tests=src/toil/test/wdl/toilwdlTest.py
-#    - make test tests=src/toil/test/wdl/builtinTest.py
-#
-#py37_jobstore_and_provisioning:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-#    - make test tests=src/toil/test/sort/sortTest.py
-#    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-##    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-## https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-## guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-#
-#py37_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/src
-#    - make test tests=src/toil/test/utils
-#
-#py37_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-#py37_integration:
-#  stage: integration
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - export TOIL_TEST_INTEGRATIVE=True
-#    - export TOIL_AWS_KEYNAME=id_rsa
-#    - export TOIL_AWS_ZONE=us-west-2a
-#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-#    - python setup_gitlab_ssh.py
-#    - chmod 400 /root/.ssh/id_rsa
-#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-#
-#py37_provisioner_integration:
-#  stage: integration
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-#    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-#    - export LIBPROCESS_IP=127.0.0.1
-#    - python setup_gitlab_docker.py
-#    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-#    - python setup_gitlab_ssh.py
-#    - make push_docker
-#    - make test tests=src/toil/test/sort/sortTest.py
-#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-#    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-#    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
-#
-## Python3.8
-#py38_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/src
-#    - make test tests=src/toil/test/utils
-#
-#py38_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-## Cactus-on-Kubernetes integration (as a script and not a pytest test)
-#py37_cactus_integration:
-#  stage: integration
-#  script:
-#    - set -e
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-#    - virtualenv --system-site-packages --python python3.7 venv
-#    - . venv/bin/activate
-#    - pip install .[aws,kubernetes]
-#    - export TOIL_KUBERNETES_OWNER=toiltest
-#    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
-#    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
-#    - export TOIL_WORKDIR=/var/lib/toil
-#    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-#    - mkdir -p ${TOIL_WORKDIR}
-#    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
-#    - cd
-#    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
-#    - cd cactus
-#    - git fetch origin
-#    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
-#    - git submodule update --init --recursive
-#    - pip install --upgrade setuptools pip
-#    - pip install --upgrade .
-#    - toil clean aws:us-west-2:${BUCKET_NAME}
-#    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
+py37_wdl:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - make test tests=src/toil/test/wdl/toilwdlTest.py
+    - make test tests=src/toil/test/wdl/builtinTest.py
+
+py37_jobstore_and_provisioning:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+    - make test tests=src/toil/test/sort/sortTest.py
+    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
+# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
+
+py37_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/src
+    - make test tests=src/toil/test/utils
+
+py37_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+py37_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - export TOIL_TEST_INTEGRATIVE=True
+    - export TOIL_AWS_KEYNAME=id_rsa
+    - export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - chmod 400 /root/.ssh/id_rsa
+    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+
+py37_provisioner_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
+    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
+    - export LIBPROCESS_IP=127.0.0.1
+    - python setup_gitlab_docker.py
+    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - make push_docker
+    - make test tests=src/toil/test/sort/sortTest.py
+    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
+    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
+
+# Python3.8
+py38_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/src
+    - make test tests=src/toil/test/utils
+
+py38_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+# Cactus-on-Kubernetes integration (as a script and not a pytest test)
+py37_cactus_integration:
+  stage: integration
+  script:
+    - set -e
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+    - virtualenv --system-site-packages --python python3.7 venv
+    - . venv/bin/activate
+    - pip install .[aws,kubernetes]
+    - export TOIL_KUBERNETES_OWNER=toiltest
+    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+    - export TOIL_WORKDIR=/var/lib/toil
+    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+    - mkdir -p ${TOIL_WORKDIR}
+    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
+    - cd
+    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
+    - cd cactus
+    - git fetch origin
+    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
+    - git submodule update --init --recursive
+    - pip install --upgrade setuptools pip
+    - pip install --upgrade .
+    - toil clean aws:us-west-2:${BUCKET_NAME}
+    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -31,7 +31,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from toil.test import (ToilTest, needs_cwl, slow, needs_docker, needs_lsf,
                        needs_mesos, needs_parasol, needs_gridengine, needs_slurm,
-                       needs_torque, needs_kubernetes)
+                       needs_torque)
 
 
 log = logging.getLogger(__name__)
@@ -278,11 +278,6 @@ class CWLv10Test(ToilTest):
         return self.test_run_conformance(batchSystem="parasol", caching=True)
 
     @slow
-    @needs_kubernetes
-    def test_kubernetes_cwl_conformance_caching(self):
-        return self.test_run_conformance(batchSystem="kubernetes", caching=True)
-
-    @slow
     @needs_lsf
     @unittest.skip
     def test_lsf_cwl_conformance(self):
@@ -317,11 +312,6 @@ class CWLv10Test(ToilTest):
     @unittest.skip
     def test_parasol_cwl_conformance(self):
         return self.test_run_conformance(batchSystem="parasol")
-
-    @slow
-    @needs_kubernetes
-    def test_kubernetes_cwl_conformance(self):
-        return self.test_run_conformance(batchSystem="kubernetes")
 
     @staticmethod
     def _expected_seqtk_output(outDir):

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -49,15 +49,10 @@ def run_conformance_tests(workDir, yml, caching=False, batchSystem=None, selecte
             cmd.append(f'-n={selected_tests}')
 
         args_passed_directly_to_toil = [f'--disableCaching={not caching}', '--clean=always']
-
-        if yml != 'conformance_test_v1.0.yaml':
-            # only enable dev if we're on version 1.1+
-            args_passed_directly_to_toil.append('--enable-dev')
-
         if batchSystem:
             args_passed_directly_to_toil.append(f"--batchSystem={batchSystem}")
-
         cmd.extend(['--'] + args_passed_directly_to_toil)
+
         log.info("Running: '%s'", "' '".join(cmd))
         subprocess.check_output(cmd, cwd=workDir, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -29,12 +29,12 @@ from io import StringIO
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-logger = logging.getLogger(__name__)
 from toil.test import (ToilTest, needs_cwl, slow, needs_docker, needs_lsf,
                        needs_mesos, needs_parasol, needs_gridengine, needs_slurm,
                        needs_torque, needs_kubernetes)
 
 
+log = logging.getLogger(__name__)
 CONFORMANCE_TEST_TIMEOUT = 3600
 
 
@@ -50,8 +50,8 @@ def run_conformance_tests(workDir, yml, caching=False, batchSystem=None, selecte
 
         args_passed_directly_to_toil = [f'--disableCaching={not caching}', '--clean=always']
 
-        if batchSystem == 'kubernetes' and "CWL_K8_TEST_BUCKET" in os.environ:
-            args_passed_directly_to_toil.append(f'aws:us-west-2:{os.environ["CWL_K8_TEST_BUCKET"]}')
+        if batchSystem == 'kubernetes' and 'CWL_K8_TEST_BUCKET' in os.environ:
+            args_passed_directly_to_toil.append(f'--jobStore=aws:us-west-2:{os.environ["CWL_K8_TEST_BUCKET"]}')
 
         if yml != 'conformance_test_v1.0.yaml':
             # only enable dev if we're on version 1.1+
@@ -61,7 +61,7 @@ def run_conformance_tests(workDir, yml, caching=False, batchSystem=None, selecte
             args_passed_directly_to_toil.append(f"--batchSystem={batchSystem}")
 
         cmd.extend(['--'] + args_passed_directly_to_toil)
-        logger.info("Running: '%s'", "' '".join(cmd))
+        log.info("Running: '%s'", "' '".join(cmd))
         subprocess.check_output(cmd, cwd=workDir, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         only_unsupported = False
@@ -193,7 +193,7 @@ class CWLv10Test(ToilTest):
     @slow
     def test_restart(self):
         """Enable restarts with toil-cwl-runner -- run failing test, re-run correct test."""
-        logger.info('Running CWL Test Restart.  Expecting failure, then success.')
+        log.info('Running CWL Test Restart.  Expecting failure, then success.')
         from toil.cwl import cwltoil
         from toil.jobStores.abstractJobStore import NoSuchJobStoreException
         from toil.leader import FailedJobsException
@@ -245,25 +245,25 @@ class CWLv10Test(ToilTest):
     @needs_lsf
     @unittest.skip
     def test_lsf_cwl_conformance_with_caching(self):
-        return self.test_run_conformance(batchSystem="LSF", caching=True)
+        return self.test_run_conformance(batchSystem="lsf", caching=True)
 
     @slow
     @needs_slurm
     @unittest.skip
     def test_slurm_cwl_conformance_with_caching(self):
-        return self.test_run_conformance(batchSystem="Slurm", caching=True)
+        return self.test_run_conformance(batchSystem="slurm", caching=True)
 
     @slow
     @needs_torque
     @unittest.skip
     def test_torque_cwl_conformance_with_caching(self):
-        return self.test_run_conformance(batchSystem="Torque", caching=True)
+        return self.test_run_conformance(batchSystem="torque", caching=True)
 
     @slow
     @needs_gridengine
     @unittest.skip
     def test_gridengine_cwl_conformance_with_caching(self):
-        return self.test_run_conformance(batchSystem="gridEngine", caching=True)
+        return self.test_run_conformance(batchSystem="grid_engine", caching=True)
 
     @slow
     @needs_mesos
@@ -286,25 +286,25 @@ class CWLv10Test(ToilTest):
     @needs_lsf
     @unittest.skip
     def test_lsf_cwl_conformance(self):
-        return self.test_run_conformance(batchSystem="LSF")
+        return self.test_run_conformance(batchSystem="lsf")
 
     @slow
     @needs_slurm
     @unittest.skip
     def test_slurm_cwl_conformance(self):
-        return self.test_run_conformance(batchSystem="Slurm")
+        return self.test_run_conformance(batchSystem="slurm")
 
     @slow
     @needs_torque
     @unittest.skip
     def test_torque_cwl_conformance(self):
-        return self.test_run_conformance(batchSystem="Torque")
+        return self.test_run_conformance(batchSystem="torque")
 
     @slow
     @needs_gridengine
     @unittest.skip
     def test_gridengine_cwl_conformance(self):
-        return self.test_run_conformance(batchSystem="gridEngine")
+        return self.test_run_conformance(batchSystem="grid_engine")
 
     @slow
     @needs_mesos

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -50,9 +50,6 @@ def run_conformance_tests(workDir, yml, caching=False, batchSystem=None, selecte
 
         args_passed_directly_to_toil = [f'--disableCaching={not caching}', '--clean=always']
 
-        if batchSystem == 'kubernetes' and 'CWL_K8_TEST_BUCKET' in os.environ:
-            args_passed_directly_to_toil.append(f'--jobStore=aws:us-west-2:{os.environ["CWL_K8_TEST_BUCKET"]}')
-
         if yml != 'conformance_test_v1.0.yaml':
             # only enable dev if we're on version 1.1+
             args_passed_directly_to_toil.append('--enable-dev')

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -394,7 +394,7 @@ class CWLv12Test(ToilTest):
         cls.test_yaml = os.path.join(cls.cwlSpec, 'conformance_tests.yaml')
         # TODO: Use a commit zip in case someone decides to rewrite master's history?
         url = 'https://github.com/common-workflow-language/cwl-v1.2.git'
-        commit = 'b6ae88d63ff0b8dfc7ff5deed20f8f42bcb1cc9e'
+        commit = '9c6898993d13c644034535555c1da8ff98b10968'
         p = subprocess.Popen(f'git clone {url} {cls.cwlSpec} && cd {cls.cwlSpec} && git checkout {commit}', shell=True)
         p.communicate()
 

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -51,7 +51,7 @@ def run_conformance_tests(workDir, yml, caching=False, batchSystem=None, selecte
         args_passed_directly_to_toil = [f'--disableCaching={not caching}', '--clean=always']
 
         if batchSystem == 'kubernetes' and "CWL_K8_TEST_BUCKET" in os.environ:
-            args_passed_directly_to_toil.append(f'aws:us-west-2:${os.environ["CWL_K8_TEST_BUCKET"]}')
+            args_passed_directly_to_toil.append(f'aws:us-west-2:{os.environ["CWL_K8_TEST_BUCKET"]}')
 
         if yml != 'conformance_test_v1.0.yaml':
             # only enable dev if we're on version 1.1+


### PR DESCRIPTION
Takes all of the extra minor refactors out of https://github.com/DataBiosphere/toil/pull/3323 to be added separately until the CWL conformance tests in kubernetes are running.

Changes:
 - Refactored the 1/1.1/1.2 CWL conformance tests so that they share the same function.
 - Corrected batch system names (i.e. `gridEngine` -> `grid_engine`) since https://github.com/DataBiosphere/toil/pull/3225 (and placed the `--batchSystem` arg at the correct position)
 - Removed any remaining `@pytest.mark.xfail` decorators on CWL cache tests.
 - CWL tests now only install the `[cwl,aws]` extras
 - Other minor refactors/renames