### PR TITLE
Add 500 status to the list of retriable SDB BotoServerErrors.

### DIFF
--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -346,7 +346,7 @@ def connection_reset(e):
 
 
 def sdb_unavailable(e):
-    return isinstance(e, BotoServerError) and e.status == 503
+    return isinstance(e, BotoServerError) and e.status in (500, 503)
 
 
 def no_such_sdb_domain(e):


### PR DESCRIPTION
Fixes #3328 