### PR TITLE
More CWL v1.2 conformance tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,40 +19,40 @@ after_script:
   - stopdocker || true
 
 stages:
-#  - basic_tests
+  - basic_tests
   - main_tests
-#  - integration
+  - integration
 
 
-## Python3.6
-#py36_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/src
-#    - make test tests=src/toil/test/utils
-#
-#py36_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
-#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-#
-## Python3.7
-#py37_batch_systems:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
-#    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
+# Python3.6
+py36_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/src
+    - make test tests=src/toil/test/utils
+
+py36_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+
+# Python3.7
+py37_batch_systems:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
+    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
   stage: main_tests
@@ -61,7 +61,7 @@ py37_cwl_v1.0:
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
-    - python setup_gitlab_docker.py  # login to attempt to increase the docker.io rate limit
+    - python setup_gitlab_docker.py  # login to increase the docker.io rate limit
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test
 
 py37_cwl_v1.1:
@@ -70,7 +70,7 @@ py37_cwl_v1.1:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
-    - python setup_gitlab_docker.py  # login to attempt to increase the docker.io rate limit
+    - python setup_gitlab_docker.py  # login to increase the docker.io rate limit
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv11Test
 
 py37_cwl_v1.2:
@@ -79,128 +79,128 @@ py37_cwl_v1.2:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
-    - python setup_gitlab_docker.py  # login to attempt to increase the docker.io rate limit
+    - python setup_gitlab_docker.py  # login to increase the docker.io rate limit
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv12Test
 
-#py37_wdl:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-#    - make test tests=src/toil/test/wdl/toilwdlTest.py
-#    - make test tests=src/toil/test/wdl/builtinTest.py
-#
-#py37_jobstore_and_provisioning:
-#  stage: main_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-#    - make test tests=src/toil/test/sort/sortTest.py
-#    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-##    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-## https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-## guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-#
-#py37_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/src
-#    - make test tests=src/toil/test/utils
-#
-#py37_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-#py37_integration:
-#  stage: integration
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - export TOIL_TEST_INTEGRATIVE=True
-#    - export TOIL_AWS_KEYNAME=id_rsa
-#    - export TOIL_AWS_ZONE=us-west-2a
-#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-#    - python setup_gitlab_ssh.py
-#    - chmod 400 /root/.ssh/id_rsa
-#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-#
-#py37_provisioner_integration:
-#  stage: integration
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-#    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-#    - export LIBPROCESS_IP=127.0.0.1
-#    - python setup_gitlab_docker.py
-#    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-#    - python setup_gitlab_ssh.py
-#    - make push_docker
-#    - make test tests=src/toil/test/sort/sortTest.py
-#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-#    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-#    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-#    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
-#
-## Python3.8
-#py38_main:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-#    - make test tests=src/toil/test/src
-#    - make test tests=src/toil/test/utils
-#
-#py38_appliance_build:
-#  stage: basic_tests
-#  script:
-#    - pwd
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-#    - python setup_gitlab_docker.py
-#    - make push_docker
-#
-## Cactus-on-Kubernetes integration (as a script and not a pytest test)
-#py37_cactus_integration:
-#  stage: integration
-#  script:
-#    - set -e
-#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-#    - virtualenv --system-site-packages --python python3.7 venv
-#    - . venv/bin/activate
-#    - pip install .[aws,kubernetes]
-#    - export TOIL_KUBERNETES_OWNER=toiltest
-#    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
-#    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
-#    - export TOIL_WORKDIR=/var/lib/toil
-#    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-#    - mkdir -p ${TOIL_WORKDIR}
-#    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
-#    - cd
-#    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
-#    - cd cactus
-#    - git fetch origin
-#    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
-#    - git submodule update --init --recursive
-#    - pip install --upgrade setuptools pip
-#    - pip install --upgrade .
-#    - toil clean aws:us-west-2:${BUCKET_NAME}
-#    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
+py37_wdl:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+    - make test tests=src/toil/test/wdl/toilwdlTest.py
+    - make test tests=src/toil/test/wdl/builtinTest.py
+
+py37_jobstore_and_provisioning:
+  stage: main_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+    - make test tests=src/toil/test/sort/sortTest.py
+    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
+    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
+# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
+
+py37_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/src
+    - make test tests=src/toil/test/utils
+
+py37_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+py37_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - export TOIL_TEST_INTEGRATIVE=True
+    - export TOIL_AWS_KEYNAME=id_rsa
+    - export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - chmod 400 /root/.ssh/id_rsa
+    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+
+py37_provisioner_integration:
+  stage: integration
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
+    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
+    - export LIBPROCESS_IP=127.0.0.1
+    - python setup_gitlab_docker.py
+    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
+    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+    - python setup_gitlab_ssh.py
+    - make push_docker
+    - make test tests=src/toil/test/sort/sortTest.py
+    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
+    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
+
+# Python3.8
+py38_main:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make test tests=src/toil/test/src
+    - make test tests=src/toil/test/utils
+
+py38_appliance_build:
+  stage: basic_tests
+  script:
+    - pwd
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+    - python setup_gitlab_docker.py
+    - make push_docker
+
+# Cactus-on-Kubernetes integration (as a script and not a pytest test)
+py37_cactus_integration:
+  stage: integration
+  script:
+    - set -e
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+    - virtualenv --system-site-packages --python python3.7 venv
+    - . venv/bin/activate
+    - pip install .[aws,kubernetes]
+    - export TOIL_KUBERNETES_OWNER=toiltest
+    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+    - export TOIL_WORKDIR=/var/lib/toil
+    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+    - mkdir -p ${TOIL_WORKDIR}
+    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
+    - cd
+    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
+    - cd cactus
+    - git fetch origin
+    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
+    - git submodule update --init --recursive
+    - pip install --upgrade setuptools pip
+    - pip install --upgrade .
+    - toil clean aws:us-west-2:${BUCKET_NAME}
+    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,7 @@ py37_cwl_v1.0:
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - mypy --ignore-missing-imports --no-strict-optional $(pwd)/src/toil/cwl/cwltoil.py  # make this a separate linting stage
+    - python setup_gitlab_docker.py  # login to attempt to increase the docker.io rate limit
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv10Test
 
 py37_cwl_v1.1:
@@ -69,6 +70,7 @@ py37_cwl_v1.1:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
+    - python setup_gitlab_docker.py  # login to attempt to increase the docker.io rate limit
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv11Test
 
 py37_cwl_v1.2:
@@ -77,6 +79,7 @@ py37_cwl_v1.2:
     - pwd
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
+    - python setup_gitlab_docker.py  # login to attempt to increase the docker.io rate limit
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv12Test
 
 #py37_wdl:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,40 +19,40 @@ after_script:
   - stopdocker || true
 
 stages:
-  - basic_tests
+#  - basic_tests
   - main_tests
-  - integration
+#  - integration
 
 
-# Python3.6
-py36_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/src
-    - make test tests=src/toil/test/utils
-
-py36_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-
-# Python3.7
-py37_batch_systems:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
-    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
+## Python3.6
+#py36_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/src
+#    - make test tests=src/toil/test/utils
+#
+#py36_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq
+#    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+#
+## Python3.7
+#py37_batch_systems:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - make test tests=src/toil/test/batchSystems/batchSystemTest.py
+#    - make test tests=src/toil/test/mesos/MesosDataStructuresTest.py
 
 py37_cwl_v1.0:
   stage: main_tests
@@ -79,125 +79,125 @@ py37_cwl_v1.2:
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[cwl,aws]
     - make test tests=src/toil/test/cwl/cwlTest.py::CWLv12Test
 
-py37_wdl:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - make test tests=src/toil/test/wdl/toilwdlTest.py
-    - make test tests=src/toil/test/wdl/builtinTest.py
-
-py37_jobstore_and_provisioning:
-  stage: main_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-    - make test tests=src/toil/test/sort/sortTest.py
-    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
-    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-#    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
-# https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
-# guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
-
-py37_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/src
-    - make test tests=src/toil/test/utils
-
-py37_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-py37_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - export TOIL_TEST_INTEGRATIVE=True
-    - export TOIL_AWS_KEYNAME=id_rsa
-    - export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - chmod 400 /root/.ssh/id_rsa
-    - make test tests=src/toil/test/jobStores/jobStoreTest.py
-
-py37_provisioner_integration:
-  stage: integration
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
-    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
-    - export LIBPROCESS_IP=127.0.0.1
-    - python setup_gitlab_docker.py
-    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
-    # This reads GITLAB_SECRET_FILE_SSH_KEYS
-    - python setup_gitlab_ssh.py
-    - make push_docker
-    - make test tests=src/toil/test/sort/sortTest.py
-    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
-    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
-    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
-    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
-
-# Python3.8
-py38_main:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make test tests=src/toil/test/src
-    - make test tests=src/toil/test/utils
-
-py38_appliance_build:
-  stage: basic_tests
-  script:
-    - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
-    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
-    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
-    - python setup_gitlab_docker.py
-    - make push_docker
-
-# Cactus-on-Kubernetes integration (as a script and not a pytest test)
-py37_cactus_integration:
-  stage: integration
-  script:
-    - set -e
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
-    - virtualenv --system-site-packages --python python3.7 venv
-    - . venv/bin/activate
-    - pip install .[aws,kubernetes]
-    - export TOIL_KUBERNETES_OWNER=toiltest
-    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
-    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
-    - export TOIL_WORKDIR=/var/lib/toil
-    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
-    - mkdir -p ${TOIL_WORKDIR}
-    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
-    - cd
-    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
-    - cd cactus
-    - git fetch origin
-    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
-    - git submodule update --init --recursive
-    - pip install --upgrade setuptools pip
-    - pip install --upgrade .
-    - toil clean aws:us-west-2:${BUCKET_NAME}
-    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false
+#py37_wdl:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
+#    - make test tests=src/toil/test/wdl/toilwdlTest.py
+#    - make test tests=src/toil/test/wdl/builtinTest.py
+#
+#py37_jobstore_and_provisioning:
+#  stage: main_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+#    - make test tests=src/toil/test/sort/sortTest.py
+#    - make test tests=src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+##    - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/gceProvisionerTest.py
+## https://ucsc-ci.com/databiosphere/toil/-/jobs/38672
+## guessing decorators are masking class as function?  ^  also, abstract class is run as normal test?  should hide.
+#
+#py37_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/src
+#    - make test tests=src/toil/test/utils
+#
+#py37_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+#py37_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - export TOIL_TEST_INTEGRATIVE=True
+#    - export TOIL_AWS_KEYNAME=id_rsa
+#    - export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+#    - python setup_gitlab_ssh.py
+#    - chmod 400 /root/.ssh/id_rsa
+#    - make test tests=src/toil/test/jobStores/jobStoreTest.py
+#
+#py37_provisioner_integration:
+#  stage: integration
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+#    - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    - python setup_gitlab_ssh.py && chmod 400 /root/.ssh/id_rsa
+#    - echo $'Host *\n    AddressFamily inet' > /root/.ssh/config
+#    - export LIBPROCESS_IP=127.0.0.1
+#    - python setup_gitlab_docker.py
+#    - export TOIL_TEST_INTEGRATIVE=True; export TOIL_AWS_KEYNAME=id_rsa; export TOIL_AWS_ZONE=us-west-2a
+#    # This reads GITLAB_SECRET_FILE_SSH_KEYS
+#    - python setup_gitlab_ssh.py
+#    - make push_docker
+#    - make test tests=src/toil/test/sort/sortTest.py
+#    - make test tests=src/toil/test/provisioners/clusterScalerTest.py
+#    # - python -m pytest --duration=0 -s -r s src/toil/test/provisioners/aws/awsProvisionerTest.py::AWSRestartTest::testAutoScaledCluster
+#    # - python -m pytest -s src/toil/test/provisioners/aws/awsProvisionerTest.py
+#    # - python -m pytest -s src/toil/test/provisioners/gceProvisionerTest.py  # needs env vars set to run
+#
+## Python3.8
+#py38_main:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+#    - make test tests=src/toil/test/src
+#    - make test tests=src/toil/test/utils
+#
+#py38_appliance_build:
+#  stage: basic_tests
+#  script:
+#    - pwd
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.8 python3.8-dev
+#    - virtualenv -p python3.8 venv && . venv/bin/activate && make prepare && pip install pycparser && make develop extras=[all] && pip install htcondor awscli==1.16.272
+#    # This reads GITLAB_SECRET_FILE_QUAY_CREDENTIALS
+#    - python setup_gitlab_docker.py
+#    - make push_docker
+#
+## Cactus-on-Kubernetes integration (as a script and not a pytest test)
+#py37_cactus_integration:
+#  stage: integration
+#  script:
+#    - set -e
+#    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata awscli jq python3.7 python3.7-dev
+#    - virtualenv --system-site-packages --python python3.7 venv
+#    - . venv/bin/activate
+#    - pip install .[aws,kubernetes]
+#    - export TOIL_KUBERNETES_OWNER=toiltest
+#    - export TOIL_AWS_SECRET_NAME=shared-s3-credentials
+#    - export TOIL_KUBERNETES_HOST_PATH=/data/scratch
+#    - export TOIL_WORKDIR=/var/lib/toil
+#    - export SINGULARITY_CACHEDIR=/var/lib/toil/singularity-cache
+#    - mkdir -p ${TOIL_WORKDIR}
+#    - BUCKET_NAME=toil-test-$RANDOM-$RANDOM-$RANDOM
+#    - cd
+#    - git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
+#    - cd cactus
+#    - git fetch origin
+#    - git checkout 12de39de78e784bff1cff5bc022c16e95ded692b
+#    - git submodule update --init --recursive
+#    - pip install --upgrade setuptools pip
+#    - pip install --upgrade .
+#    - toil clean aws:us-west-2:${BUCKET_NAME}
+#    - time cactus --batchSystem kubernetes --binariesMode singularity --clean always aws:us-west-2:${BUCKET_NAME} examples/evolverMammals.txt examples/evolverMammals.hal --root mr --defaultDisk "8G" --logDebug --disableCaching false

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -414,9 +414,9 @@ class CWLv12Test(ToilTest):
     @slow
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
-        # TODO: we do not currently pass tests: 307, 309, 310, 311, 330, 331, 332
+        # TODO: we do not currently pass tests: 307, 330, 331, 332
         run_conformance_tests(workDir=self.cwlSpec,
                               yml=self.test_yaml,
                               caching=caching,
                               batchSystem=batchSystem,
-                              selected_tests='1-306,308,312-329,333-336')
+                              selected_tests='1-306,308-329,333-336')

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -414,9 +414,9 @@ class CWLv12Test(ToilTest):
     @slow
     @pytest.mark.timeout(CONFORMANCE_TEST_TIMEOUT)
     def test_run_conformance(self, batchSystem=None, caching=False):
-        # TODO: we do not currently pass tests: 307, 330, 331, 332
+        # TODO: we do not currently pass tests: 307, 332
         run_conformance_tests(workDir=self.cwlSpec,
                               yml=self.test_yaml,
                               caching=caching,
                               batchSystem=batchSystem,
-                              selected_tests='1-306,308-329,333-336')
+                              selected_tests='1-306,308-331,333-336')

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -269,15 +269,14 @@ class DockerTest(ToilTest):
         silently missed.  This tests to make sure that the piping API for
         dockerCall() throws an exception if non-last commands in the chain fail.
         """
-        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir,
-                                                            'jobstore'))
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
         options.logLevel = self.dockerTestLogLevel
         options.workDir = self.tempDir
         options.clean = 'always'
         options.caching = disableCaching
         A = Job.wrapJobFn(_testDockerPipeChainErrorFn)
         rv = Job.Runner.startToil(A, options)
-        assert rv == True
+        assert rv is True
 
     def testNonCachingDockerChain(self):
         self.testDockerPipeChain(disableCaching=False)
@@ -365,7 +364,7 @@ def _testDockerPipeChainFn(job):
     """Return the result of a simple pipe chain.  Should be 2."""
     parameters = [['printf', 'x\n y\n'], ['wc', '-l']]
     return apiDockerCall(job,
-                         image='ubuntu:latest',
+                         image='quay.io/ucsc_cgl/ubuntu:20.04',
                          parameters=parameters,
                          privileged=True)
 
@@ -406,7 +405,7 @@ def _testDockerLogsFn(job,
         file.write(bash_script)
 
     out = apiDockerCall(job,
-                        image='ubuntu:latest',
+                        image='quay.io/ucsc_cgl/ubuntu:20.04',
                         working_dir=working_dir,
                         parameters=[script_file],
                         volumes={working_dir: {'bind': working_dir, 'mode': 'rw'}},


### PR DESCRIPTION
Tests seem to be failing on anything that pulls `docker.io`.  From `docker.io` itself:

```
The rate limits of 100 container image requests per six hours for anonymous usage, and 200 container image requests per six hours for free Docker accounts are now in effect.
```

Will wait and rerun these later today, which should put us outside of the 6 hour window.  Running locally with caching, the CWL v1.2 conformance tests seem to pass (with the exception of 307 and 332 of course).

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Removed a cwltoil double import, which avoids missing secondaryFile imports defined by only a pattern before they've resolved.  Specifically, this now allows us to now support CWL v1.2 conformance tests: 309,310,311,330,331.
