### PR TITLE
Re-enable running WDL GATK Tutorial Tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,9 +83,10 @@ py37_wdl:
   stage: main_tests
   script:
     - pwd
-    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata jq python3.7 python3.7-dev default-jre
     - virtualenv -p python3.7 venv && . venv/bin/activate && make prepare && make develop extras=[all]
-    - make test tests=src/toil/test/wdl/toilwdlTest.py
+    - which java &> /dev/null || { echo >&2 "Java is not installed.  Install java to run these tests."; exit 1; }
+    - make test tests=src/toil/test/wdl/toilwdlTest.py  # needs java (default-jre) to run "GATK.jar"
     - make test tests=src/toil/test/wdl/builtinTest.py
 
 py37_jobstore_and_provisioning:

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -399,6 +399,15 @@ def needs_lsf(test_item):
         return unittest.skip("Install LSF to include this test.")(test_item)
 
 
+def needs_java(test_item):
+    """Use as a test decorator to run only if java is installed."""
+    test_item = _mark_test('java', test_item)
+    if which('java'):
+        return test_item
+    else:
+        return unittest.skip("Install java to include this test.")(test_item)
+
+
 def needs_docker(test_item):
     """
     Use as a decorator before test classes or methods to only run them if

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -41,7 +41,6 @@ class ToilWdlIntegrationTest(ToilTest):
     @classmethod
     def setUpClass(cls):
         """Runs once for all tests."""
-        cls.pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
         cls.program = os.path.abspath("src/toil/wdl/toilwdl.py")
 
         cls.test_directory = os.path.abspath("src/toil/test/wdl/")

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -375,7 +375,7 @@ class ToilWdlIntegrationTest(ToilTest):
             u'helloHaplotypeCaller.haplotypeCaller.sampleName': u'"WDL_tut1_output"',
             u'helloHaplotypeCaller.haplotypeCaller.inputBAM': u'"src/toil/test/wdl/GATK_data/inputs/NA12878_wgs_20.bam"',
             u'helloHaplotypeCaller.haplotypeCaller.bamIndex': u'"src/toil/test/wdl/GATK_data/inputs/NA12878_wgs_20.bai"',
-            u'helloHaplotypeCaller.haplotypeCaller.GATK': u'"src/toil/test/wdl/GATK_data/GenomeAnalysisTK.jar"',
+            u'helloHaplotypeCaller.haplotypeCaller.GATK': u'"src/toil/test/wdl/GATK_data/gatk-package-4.1.9.0-local.jar"',
             u'helloHaplotypeCaller.haplotypeCaller.RefDict': u'"src/toil/test/wdl/GATK_data/ref/human_g1k_b37_20.dict"',
             u'helloHaplotypeCaller.haplotypeCaller.RefFasta': u'"src/toil/test/wdl/GATK_data/ref/human_g1k_b37_20.fasta"'}
 

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -23,7 +23,7 @@ from toil.wdl.wdl_functions import defined
 from toil.wdl.wdl_functions import read_tsv
 from toil.wdl.wdl_functions import read_csv
 from toil.wdl.wdl_functions import basename
-from toil.test import ToilTest, slow, needs_docker
+from toil.test import ToilTest, slow, needs_docker, needs_java
 from toil import urlretrieve
 import zipfile
 import shutil
@@ -264,6 +264,7 @@ class ToilWdlIntegrationTest(ToilTest):
 
     # estimated run time 27 sec
     @slow
+    @needs_java
     def testTut01(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's
         GATK tutorial #1.'''
@@ -277,6 +278,7 @@ class ToilWdlIntegrationTest(ToilTest):
 
     # estimated run time 28 sec
     @slow
+    @needs_java
     def testTut02(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's
         GATK tutorial #2.'''
@@ -290,6 +292,7 @@ class ToilWdlIntegrationTest(ToilTest):
 
     # estimated run time 60 sec
     @slow
+    @needs_java
     def testTut03(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's
         GATK tutorial #3.'''
@@ -303,6 +306,7 @@ class ToilWdlIntegrationTest(ToilTest):
 
     # estimated run time 175 sec
     @slow
+    @needs_java
     @unittest.skip('broken; see: https://github.com/DataBiosphere/toil/issues/3339')
     def testTut04(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -41,6 +41,7 @@ class ToilWdlIntegrationTest(ToilTest):
     @classmethod
     def setUpClass(cls):
         """Runs once for all tests."""
+        cls.pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
         cls.program = os.path.abspath("src/toil/wdl/toilwdl.py")
 
         cls.test_directory = os.path.abspath("src/toil/test/wdl/")
@@ -54,17 +55,6 @@ class ToilWdlIntegrationTest(ToilTest):
         cls.gatk_data = os.path.join(cls.test_directory, "GATK_data.zip")
         cls.gatk_data_dir = os.path.join(cls.test_directory, "GATK_data")
 
-        # GATK tests will not run on jenkins b/c GATK.jar needs Java 7
-        # and jenkins only has Java 6 (12-16-2017).
-        # Set this to true to run the GATK integration tests locally.
-        cls.manual_integration_tests = False
-
-        # Delete the test datasets after running the tests.
-        # Jenkins requires this to not error on "untracked files".
-        # Set to true if running tests locally and you don't want to
-        # redownload the data each time you run the test.
-        cls.jenkins = True
-
         cls.fetch_and_unzip_from_s3(filename='ENCODE_data.zip',
                                     data=cls.encode_data,
                                     data_dir=cls.encode_data_dir)
@@ -73,42 +63,53 @@ class ToilWdlIntegrationTest(ToilTest):
                                     data=cls.wdl_data,
                                     data_dir=cls.wdl_data_dir)
 
-        # these tests require Java 7 (GATK.jar); jenkins has Java 6 and so must
-        # be run manually as integration tests (12.16.2017)
-        if cls.manual_integration_tests:
-            cls.fetch_and_unzip_from_s3(filename='GATK_data.zip',
-                                        data=cls.gatk_data,
-                                        data_dir=cls.gatk_data_dir)
+        cls.fetch_and_unzip_from_s3(filename='GATK_data.zip',
+                                    data=cls.gatk_data,
+                                    data_dir=cls.gatk_data_dir)
 
     def tearDown(self):
-        """Clean up outputs."""
-        remove_outputs(self.output_dir)
-
-        jobstores = ['./toilWorkflowRun', '/mnt/ephemeral/workspace/toil-pull-requests/toilWorkflowRun']
-        for jobstore in jobstores:
-            if os.path.exists(jobstore):
-                shutil.rmtree(jobstore)
-
-        unittest.TestCase.tearDown(self)
+        if os.path.exists(self.output_dir):
+            shutil.rmtree(self.output_dir)
 
     @classmethod
     def tearDownClass(cls):
-        """Clean up (shared) inputs."""
-        if cls.jenkins:
-            if os.path.exists(cls.gatk_data):
-                os.remove(cls.gatk_data)
-            if os.path.exists(cls.gatk_data_dir):
-                shutil.rmtree(cls.gatk_data_dir)
-
-            if os.path.exists(cls.wdl_data):
-                os.remove(cls.wdl_data)
-            if os.path.exists(cls.wdl_data_dir):
-                shutil.rmtree(cls.wdl_data_dir)
-
-            if os.path.exists(cls.encode_data):
-                os.remove(cls.encode_data)
-            if os.path.exists(cls.encode_data_dir):
-                shutil.rmtree(cls.encode_data_dir)
+        """We generate a lot of cruft."""
+        jobstores = ['./toilWorkflowRun', '/mnt/ephemeral/workspace/toil-pull-requests/toilWorkflowRun']
+        data_dirs = [cls.gatk_data_dir, cls.wdl_data_dir, cls.encode_data_dir]
+        data_zips = [cls.gatk_data, cls.wdl_data, cls.encode_data]
+        encode_outputs = ['ENCFF000VOL_chr21.fq.gz',
+                          'ENCFF000VOL_chr21.raw.srt.bam',
+                          'ENCFF000VOL_chr21.raw.srt.bam.flagstat.qc',
+                          'ENCFF000VOL_chr21.raw.srt.dup.qc',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.bam',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.bam.bai',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.filt.nodup.sample.15.SE.tagAlign.gz',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.filt.nodup.sample.15.SE.tagAlign.gz.cc.plot.pdf',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.filt.nodup.sample.15.SE.tagAlign.gz.cc.qc',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.flagstat.qc',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.pbc.qc',
+                          'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.SE.tagAlign.gz',
+                          'ENCFF000VOL_chr21.sai',
+                          'test.txt',
+                          'filter_qc.json',
+                          'filter_qc.log',
+                          'GRCh38_chr21_bwa.tar.gz',
+                          'mapping.json',
+                          'mapping.log',
+                          'post_mapping.json',
+                          'post_mapping.log',
+                          'wdl-stats.log',
+                          'xcor.json',
+                          'xcor.log',
+                          'toilwdl_compiled.pyc',
+                          'toilwdl_compiled.py',
+                          'post_processing.log',
+                          'md5.log']
+        for cleanup in jobstores + data_dirs + data_zips + encode_outputs:
+            if os.path.isdir(cleanup):
+                shutil.rmtree(cleanup)
+            elif os.path.exists(cleanup):
+                os.remove(cleanup)
 
     @needs_docker
     def testMD5sum(self):
@@ -267,56 +268,53 @@ class ToilWdlIntegrationTest(ToilTest):
     def testTut01(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's
         GATK tutorial #1.'''
-        if self.manual_integration_tests:
-            wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/helloHaplotypeCaller.wdl")
-            json = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/helloHaplotypeCaller_inputs.json")
-            ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/output/")
+        wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/helloHaplotypeCaller.wdl")
+        json = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/helloHaplotypeCaller_inputs.json")
+        ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/output/")
 
-            subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
+        subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
 
-            compare_runs(self.output_dir, ref_dir)
+        compare_runs(self.output_dir, ref_dir)
 
     # estimated run time 28 sec
     @slow
     def testTut02(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's
         GATK tutorial #2.'''
-        if self.manual_integration_tests:
-            wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/simpleVariantSelection.wdl")
-            json = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/simpleVariantSelection_inputs.json")
-            ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/output/")
+        wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/simpleVariantSelection.wdl")
+        json = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/simpleVariantSelection_inputs.json")
+        ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/output/")
 
-            subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
+        subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
 
-            compare_runs(self.output_dir, ref_dir)
+        compare_runs(self.output_dir, ref_dir)
 
     # estimated run time 60 sec
     @slow
     def testTut03(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's
         GATK tutorial #3.'''
-        if self.manual_integration_tests:
-            wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/simpleVariantDiscovery.wdl")
-            json = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/simpleVariantDiscovery_inputs.json")
-            ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/output/")
+        wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/simpleVariantDiscovery.wdl")
+        json = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/simpleVariantDiscovery_inputs.json")
+        ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/output/")
 
-            subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
+        subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
 
-            compare_runs(self.output_dir, ref_dir)
+        compare_runs(self.output_dir, ref_dir)
 
     # estimated run time 175 sec
     @slow
+    @unittest.skip('broken; see: https://github.com/DataBiosphere/toil/issues/3339')
     def testTut04(self):
         '''Test if toilwdl produces the same outputs as known good outputs for WDL's
         GATK tutorial #4.'''
-        if self.manual_integration_tests:
-            wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/jointCallingGenotypes.wdl")
-            json = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/jointCallingGenotypes_inputs.json")
-            ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/output/")
+        wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/jointCallingGenotypes.wdl")
+        json = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/jointCallingGenotypes_inputs.json")
+        ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/output/")
 
-            subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
+        subprocess.check_call([exactPython, self.program, wdl, json, '-o', self.output_dir])
 
-            compare_runs(self.output_dir, ref_dir)
+        compare_runs(self.output_dir, ref_dir)
 
     # estimated run time 80 sec
     @slow
@@ -397,49 +395,6 @@ class ToilWdlIntegrationTest(ToilTest):
                 zip_ref.extractall(cls.test_directory)
 
 
-def remove_outputs(output_dir):
-    '''Remove the outputs generated by various unittests.
-
-    These are created in the current working directory, which on jenkins is the
-    main toil folder.  They must be removed so that jenkins does not think we
-    have untracked files in our github repo.'''
-    encode_outputs = ['ENCFF000VOL_chr21.fq.gz',
-                      'ENCFF000VOL_chr21.raw.srt.bam',
-                      'ENCFF000VOL_chr21.raw.srt.bam.flagstat.qc',
-                      'ENCFF000VOL_chr21.raw.srt.dup.qc',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.bam',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.bam.bai',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.filt.nodup.sample.15.SE.tagAlign.gz',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.filt.nodup.sample.15.SE.tagAlign.gz.cc.plot.pdf',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.filt.nodup.sample.15.SE.tagAlign.gz.cc.qc',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.flagstat.qc',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.pbc.qc',
-                      'ENCFF000VOL_chr21.raw.srt.filt.nodup.srt.final.SE.tagAlign.gz',
-                      'ENCFF000VOL_chr21.sai',
-                      'test.txt',
-                      'filter_qc.json',
-                      'filter_qc.log',
-                      'GRCh38_chr21_bwa.tar.gz',
-                      'mapping.json',
-                      'mapping.log',
-                      'post_mapping.json',
-                      'post_mapping.log',
-                      'wdl-stats.log',
-                      'xcor.json',
-                      'xcor.log',
-                      'toilwdl_compiled.pyc',
-                      'toilwdl_compiled.py']
-    other_log_outputs = ['post_processing.log',
-                         'md5.log']
-    outputs = encode_outputs + other_log_outputs
-    for output in outputs:
-        output = os.path.abspath(output)
-        if os.path.exists(output):
-            os.remove(output)
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
-
-
 def compare_runs(output_dir, ref_dir):
     """
     Takes two directories and compares all of the files between those two
@@ -457,7 +412,7 @@ def compare_runs(output_dir, ref_dir):
     """
     reference_output_files = os.listdir(ref_dir)
     for file in reference_output_files:
-        if file != 'outputs.txt':
+        if file not in ('outputs.txt', '__pycache__'):
             test_output_files = os.listdir(output_dir)
             filepath = os.path.join(ref_dir, file)
             with open(filepath, 'r') as default_file:
@@ -523,7 +478,14 @@ def compare_vcf_files(filepath1, filepath2):
                 # Quality score may vary (<1%) between systems because of
                 # (assumed) rounding differences.  Same for the "info" sect.
                 if j < 5:
-                    assert test_data[i][j] == good_data[i][j], "File does not match: %r" % filepath1
+                    if j == 4:
+                        if test_data[i][j].startswith('*,'):
+                            test_data[i][j] = test_data[i][j][2:]
+                        if good_data[i][j].startswith('*,'):
+                            good_data[i][j] = good_data[i][j][2:]
+                    assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
+                                                               f" - {test_data[i][j]} != {good_data[i][j]}\n" \
+                                                               f" - Line: {i} Column: {j}"
 
 
 if __name__ == "__main__":

--- a/src/toil/wdl/wdl_functions.py
+++ b/src/toil/wdl/wdl_functions.py
@@ -351,12 +351,20 @@ def process_single_outfile(f, fileStore, workDir, outDir):
         output_f_path = os.path.join('execution', f)
     elif os.path.exists(os.path.join(workDir, f)):
         output_f_path = os.path.join(workDir, f)
+    elif os.path.exists(os.path.join(outDir, f)):
+        output_f_path = os.path.join(outDir, f)
     else:
         tmp = subprocess.check_output(['ls', '-lha', workDir]).decode('utf-8')
         exe = subprocess.check_output(['ls', '-lha', os.path.join(workDir, 'execution')]).decode('utf-8')
-        raise RuntimeError('OUTPUT FILE: {} was not found!\n'
+        for std_file in ('stdout', 'stderr'):
+            std_file = os.path.join(workDir, 'execution', std_file)
+            if os.path.exists(std_file):
+                with open(std_file, 'rb') as f:
+                    wdllogger.info(f.read())
+
+        raise RuntimeError('OUTPUT FILE: {} was not found in {}!\n'
                            '{}\n\n'
-                           '{}\n'.format(f, tmp, exe))
+                           '{}\n'.format(f, os.getcwd(), tmp, exe))
     output_file = fileStore.writeGlobalFile(output_f_path)
     preserveThisFilename = os.path.basename(output_f_path)
     fileStore.exportFile(output_file, "file://" + os.path.join(os.path.abspath(outDir), preserveThisFilename))


### PR DESCRIPTION
Making these non-manual now.  GATK has changed quite a bit and it looks like the WDL tutorials contain commands that don't exist in GATK anymore (they don't exist in version 4 and the version 3 in our bucket seems to have imports that break it): https://support.terra.bio/hc/en-us/sections/360007347652-WDL-Tutorials

The scripts and data have been updated and uploaded back into the s3 test data bucket and the tests have been re-enabled to help prevent future breakage.  Tutorials 1-3 seem to still work.  Tutorial 4 is breaking though and the test is skipped until the issue can be addressed: https://github.com/DataBiosphere/toil/issues/3339

Not sure how java is setup on gitlab currently, so the test environment may need further tweaking.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Re-enabled running WDL GATK Tutorial Tests 1-3.
