### PR TITLE
Add a retry logic for BucketNotEmpty error.

### DIFF
--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -33,6 +33,7 @@ from boto.exception import (SDBResponseError,
                             S3CreateError,
                             S3CopyError)
 import boto3
+from botocore.exceptions import ClientError
 
 log = logging.getLogger(__name__)
 
@@ -379,7 +380,8 @@ def retryable_s3_errors(e):
             or (isinstance(e, BotoServerError) and e.status == 500)
             # Throttling response sometimes received on bucket creation
             or (isinstance(e, BotoServerError) and e.status == 503 and e.code == 'SlowDown')
-            or (isinstance(e, S3CopyError) and 'try again' in e.message))
+            or (isinstance(e, S3CopyError) and 'try again' in e.message)
+            or (isinstance(e, ClientError) and 'BucketNotEmpty' in str(e)))
 
 
 def retry_s3(delays=default_delays, timeout=default_timeout, predicate=retryable_s3_errors):


### PR DESCRIPTION
Fixes #3263 

While ideally this should only be added to `_delete_bucket`, this exception is very specific and isn't expected to happen elsewhere, so didn't seem like it was worth the extra complexity, but lemme know if you feel strongly about only having it there!