### PR TITLE
getting job details from scontrol is now functional.

### DIFF
--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import math
 import os
 from pipes import quote
+import math
+from toil.lib.misc import call_command, CalledProcessErrorStderr
 
 from toil.batchSystems import MemoryString
-from toil.batchSystems.abstractGridEngineBatchSystem import \
-    AbstractGridEngineBatchSystem
-from toil.lib.misc import CalledProcessErrorStderr, call_command
+from toil.batchSystems.abstractGridEngineBatchSystem import AbstractGridEngineBatchSystem
 
 logger = logging.getLogger(__name__)
 
@@ -116,16 +115,20 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
                     str(slurmJobID)]
 
             stdout = call_command(args)
-            job = dict()
-            for line in stdout:
-                logger.debug("%s output %s", args[0], line)
-                values = line.strip().split()
+            if isinstance(stdout, str):
+                values = stdout.strip().split()
+            elif isinstance(stdout, bytes):
+                values = stdout.decode('utf-8').strip().split()
 
-                # If job information is not available an error is issued:
-                # slurm_load_jobs error: Invalid job id specified
-                # There is no job information, so exit.
-                if len(values) > 0 and values[0] == 'slurm_load_jobs':
-                    return (None, None)
+            # If job information is not available an error is issued:
+            # slurm_load_jobs error: Invalid job id specified
+            # There is no job information, so exit.
+            if len(values) > 0 and values[0] == 'slurm_load_jobs':
+                return (None, None)
+
+            job = dict()
+            for item in values:
+                logger.debug("%s output %s", args[0], line)
 
                 # Output is in the form of many key=value pairs, multiple pairs on each line
                 # and multiple lines in the output. Each pair is pulled out of each line and


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * getting job details from `scontrol show jobs` was non-functional. This PR enables this behavior in the case of sacct not being configured.

