### PR TITLE
Only rm a statefile that exists.

### DIFF
--- a/src/toil/deferred.py
+++ b/src/toil/deferred.py
@@ -153,7 +153,8 @@ class DeferredFunctionManager(object):
         logger.debug("Deleting %s" % self.stateFileName)
 
         # Hide the state from other processes
-        os.unlink(self.stateFileName)
+        if os.path.exists(self.stateFileName):
+            os.unlink(self.stateFileName)
 
         # Unlock it
         fcntl.lockf(self.stateFD, fcntl.LOCK_UN)


### PR DESCRIPTION
Many deferred jobs all seem to be attempting to delete the same state file at the end of the logs for: https://ucsc-ci.com/databiosphere/toil/-/jobs/67478/raw

The error seems to be ignored but it spams the screen until it finishes.  This should resolve the issue.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Only rm a statefile that exists.

