### PR TITLE
Replace makepublicdir with builtin.

### DIFF
--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -27,7 +27,6 @@ from contextlib import contextmanager
 from toil.common import cacheDirName, getDirSizeRecursively, getFileSystemSize
 from toil.fileStores import FileID
 from toil.fileStores.abstractFileStore import AbstractFileStore
-from toil.lib.bioio import makePublicDir
 from toil.lib.humanize import bytes2human
 from toil.lib.misc import atomic_copy, atomic_copyobj, robust_rmtree
 from toil.lib.retry import ErrorCondition, retry
@@ -975,7 +974,7 @@ class CachingFileStore(AbstractFileStore):
         # Create a working directory for the job
         startingDir = os.getcwd()
         # Move self.localTempDir from the worker directory set up in __init__ to a per-job directory.
-        self.localTempDir = makePublicDir(os.path.join(self.localTempDir, str(uuid.uuid4())))
+        self.localTempDir = os.makedirs(os.path.join(self.localTempDir, str(uuid.uuid4())), exist_ok=True)
         # Check the status of all jobs on this node. If there are jobs that started and died before
         # cleaning up their presence from the database, clean them up ourselves.
         self._removeDeadJobs(self.workDir, self.con)

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -27,7 +27,6 @@ import dill
 from toil.common import getDirSizeRecursively, getFileSystemSize
 from toil.fileStores import FileID
 from toil.fileStores.abstractFileStore import AbstractFileStore
-from toil.lib.bioio import makePublicDir
 from toil.lib.humanize import bytes2human
 from toil.lib.misc import robust_rmtree
 from toil.lib.threading import get_process_name, process_name_exists
@@ -50,7 +49,7 @@ class NonCachingFileStore(AbstractFileStore):
     def open(self, job):
         jobReqs = job.disk
         startingDir = os.getcwd()
-        self.localTempDir = makePublicDir(os.path.join(self.localTempDir, str(uuid.uuid4())))
+        self.localTempDir = os.makedirs(os.path.join(self.localTempDir, str(uuid.uuid4())), exist_ok=True)
         self._removeDeadJobs(self.workDir)
         self.jobStateFile = self._createJobStateFile()
         freeSpace, diskSize = getFileSystemSize(self.localTempDir)

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -287,14 +287,6 @@ def getRandomAlphaNumericString(length=10):
     """
     return "".join([ random.choice('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz') for i in range(0, length) ])
 
-def makePublicDir(dirName):
-    """Makes a given subdirectory if it doesn't already exist, making sure it is public.
-    """
-    if not os.path.exists(dirName):
-        os.mkdir(dirName)
-        os.chmod(dirName, 0o777)
-    return dirName
-
 def getTempFile(suffix="", rootDir=None):
     """Returns a string representing a temporary file, that must be manually deleted
     """


### PR DESCRIPTION
`os.makedirs` defaults to `mode=0o777`.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Replace makepublicdir with builtin.

