### PR TITLE
LSF: handle unicode configuration files

### DIFF
--- a/src/toil/batchSystems/lsfHelper.py
+++ b/src/toil/batchSystems/lsfHelper.py
@@ -65,7 +65,7 @@ def apply_conf_file(fn, conf_filename):
     for env in LSF_CONF_ENV:
         conf_file = get_conf_file(conf_filename, env)
         if conf_file:
-            with open(conf_file) as conf_handle:
+            with open(conf_file, encoding='utf-8') as conf_handle:
                 value = fn(conf_handle)
             if value:
                 return value


### PR DESCRIPTION
Fixes #3353 

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * LSF configuration files are now assumed to be unicode



