### PR TITLE
Replace abssympath w/ builtin.

### DIFF
--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 Regents of the University of California
+# Copyright (C) 2015-2020 Regents of the University of California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# standard library
 import errno
 import logging
 import os
@@ -26,7 +24,6 @@ import time
 import uuid
 from contextlib import contextmanager
 
-# toil dependencies
 from toil.fileStores import FileID
 from toil.job import TemporaryID
 from toil.jobStores.abstractJobStore import (AbstractJobStore,
@@ -34,11 +31,10 @@ from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              NoSuchFileException,
                                              NoSuchJobException,
                                              NoSuchJobStoreException)
-from toil.lib.bioio import absSymPath
 from toil.lib.misc import (AtomicFileCreate, atomic_copy, atomic_copyobj,
                            robust_rmtree)
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 class FileJobStore(AbstractJobStore):
@@ -70,7 +66,7 @@ class FileJobStore(AbstractJobStore):
                            subdirectories
         """
         super(FileJobStore, self).__init__()
-        self.jobStoreDir = absSymPath(path)
+        self.jobStoreDir = os.path.abspath(path)
         logger.debug("Path to job store directory is '%s'.", self.jobStoreDir)
 
         # Directory where actual job files go, and their job-associated temp files

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -189,12 +189,6 @@ def getTotalMemoryUsage():
     """
     return getTotalCpuTimeAndMemoryUsage()[1]
 
-def absSymPath(path):
-    """like os.path.abspath except it doesn't dereference symlinks
-    """
-    curr_path = os.getcwd()
-    return os.path.normpath(os.path.join(curr_path, path))
-
 #########################################################
 #########################################################
 #########################################################

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -1121,6 +1121,23 @@ class FileJobStoreTest(AbstractJobStoreTest.Test):
         finally:
             os.unlink(path)
 
+    def test_jobstore_init_preserves_symlink_path(self):
+        """Test that if we provide a fileJobStore with a symlink to a directory, it doesn't de-reference it."""
+        dir_symlinked_to_original_filestore = None
+        original_filestore = None
+        try:
+            original_filestore = self._createExternalStore()
+            dir_symlinked_to_original_filestore = f'{original_filestore}-am-i-real'
+            os.symlink(original_filestore, dir_symlinked_to_original_filestore)
+            filejobstore_using_symlink = FileJobStore(dir_symlinked_to_original_filestore, fanOut=2)
+            self.assertEqual(dir_symlinked_to_original_filestore, filejobstore_using_symlink.jobStoreDir)
+        finally:
+            if dir_symlinked_to_original_filestore and os.path.exists(dir_symlinked_to_original_filestore):
+                os.unlink(dir_symlinked_to_original_filestore)
+            if original_filestore and os.path.exists(original_filestore):
+                shutil.rmtree(original_filestore)
+
+
 @needs_google
 class GoogleJobStoreTest(AbstractJobStoreTest.Test):
     projectID = os.getenv('TOIL_GOOGLE_PROJECTID')


### PR DESCRIPTION
Attempting to reduce the amount of needless complexity.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Replace abssympath w/ builtin.

