### PR TITLE
Add a better error message for insufficient disk.

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -144,7 +144,7 @@ def resolveEntryPoint(entryPoint):
 
 
 @memoize
-def physicalMemory():
+def physicalMemory() -> int:
     """
     >>> n = physicalMemory()
     >>> n > 0
@@ -158,11 +158,8 @@ def physicalMemory():
         return int(subprocess.check_output(['sysctl', '-n', 'hw.memsize']).decode('utf-8').strip())
 
 
-def physicalDisk(config, toilWorkflowDir=None):
-    if toilWorkflowDir is None:
-        from toil.common import Toil
-        toilWorkflowDir = Toil.getLocalWorkflowDir(config.workflowID, config.workDir)
-    diskStats = os.statvfs(toilWorkflowDir)
+def physicalDisk(directory: str) -> int:
+    diskStats = os.statvfs(directory)
     return diskStats.f_frsize * diskStats.f_bavail
 
 

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -309,19 +309,17 @@ class BatchSystemSupport(AbstractBatchSystem):
             if requested > available:
                 unit = 'bytes of ' if resource in ('disk', 'memory') else ''
                 context = f' of free space on {self.config.workDir}' if resource == 'disk' else ''
-                if job_name:
-                    if resource == 'disk':
-                        msg = (f'The job {job_name} is requesting {requested} {unit}{resource} for temporary space, '
-                               f'more than the maximum of {available} {unit}{resource}{context} that {batch_system} '
-                               f'was configured with.  Try setting/changing the toil option "--workDir" or changing '
-                               f'the base temporary directory by setting TMPDIR.')
-                    else:
-                        msg = (f'The job {job_name} is requesting {requested} {unit}{resource}, more than the '
-                               f'maximum of {available} {unit}{resource} that {batch_system} was configured with.')
+                R = f'The job {job_name} is r' if job_name else 'R'
+                if resource == 'disk':
+                    msg = (f'{R}equesting {requested} {unit}{resource} for temporary space, '
+                           f'more than the maximum of {available} {unit}{resource}{context} that {batch_system} '
+                           f'was configured with, or enforced by --max{resource.capitalize()}.  Try '
+                           f'setting/changing the toil option "--workDir" or changing the base temporary '
+                           f'directory by setting TMPDIR.')
                 else:
-                    msg = (f'Requesting more {unit}{resource}{context} than either physically available to '
-                           f'{batch_system}, or enforced by --max{resource.capitalize()}. '
-                           f'Requested: {requested}, Available: {available}')
+                    msg = (f'{R}equesting {requested} {unit}{resource}, more than the maximum of '
+                           f'{available} {unit}{resource} that {batch_system} was configured with, '
+                           f'or enforced by --max{resource.capitalize()}.')
                 if detail:
                     msg += detail
 

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -308,14 +308,13 @@ class BatchSystemSupport(AbstractBatchSystem):
             assert requested is not None
             if requested > available:
                 unit = 'bytes of ' if resource in ('disk', 'memory') else ''
-                context = f' of free space on {self.config.workDir}' if resource == 'disk' else ''
                 R = f'The job {job_name} is r' if job_name else 'R'
                 if resource == 'disk':
                     msg = (f'{R}equesting {requested} {unit}{resource} for temporary space, '
-                           f'more than the maximum of {available} {unit}{resource}{context} that {batch_system} '
-                           f'was configured with, or enforced by --max{resource.capitalize()}.  Try '
-                           f'setting/changing the toil option "--workDir" or changing the base temporary '
-                           f'directory by setting TMPDIR.')
+                           f'more than the maximum of {available} {unit}{resource} of free space on '
+                           f'{self.config.workDir} that {batch_system} was configured with, or enforced '
+                           f'by --max{resource.capitalize()}.  Try setting/changing the toil option '
+                           f'"--workDir" or changing the base temporary directory by setting TMPDIR.')
                 else:
                     msg = (f'{R}equesting {requested} {unit}{resource}, more than the maximum of '
                            f'{available} {unit}{resource} that {batch_system} was configured with, '

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -88,7 +88,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
             maxMemory = self.physicalMemory
 
         workdir = Toil.getLocalWorkflowDir(config.workflowID, config.workDir)  # config.workDir may be None; this sets a real directory
-        self.physicalDisk = toil.physicalDisk(workDir)
+        self.physicalDisk = toil.physicalDisk(workdir)
         if maxDisk > self.physicalDisk:
             if maxDisk != sys.maxsize:
                 # We have an actually specified limit and not the default

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -87,7 +87,8 @@ class SingleMachineBatchSystem(BatchSystemSupport):
                 log.warning('Not enough memory! User limited to %i bytes but we only have %i bytes.', maxMemory, self.physicalMemory)
             maxMemory = self.physicalMemory
 
-        self.physicalDisk = toil.physicalDisk(config.workDir)
+        workdir = Toil.getLocalWorkflowDir(config.workflowID, config.workDir)  # config.workDir may be None; this sets a real directory
+        self.physicalDisk = toil.physicalDisk(workDir)
         if maxDisk > self.physicalDisk:
             if maxDisk != sys.maxsize:
                 # We have an actually specified limit and not the default

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -87,8 +87,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
                 log.warning('Not enough memory! User limited to %i bytes but we only have %i bytes.', maxMemory, self.physicalMemory)
             maxMemory = self.physicalMemory
 
-        workdir = Toil.getLocalWorkflowDir(config.workflowID, config.workDir)
-        self.physicalDisk = toil.physicalDisk(workdir)  # can just config.workDir be used here?
+        self.physicalDisk = toil.physicalDisk(config.workDir)
         if maxDisk > self.physicalDisk:
             if maxDisk != sys.maxsize:
                 # We have an actually specified limit and not the default
@@ -497,7 +496,6 @@ class SingleMachineBatchSystem(BatchSystemSupport):
         # The abstract batch system can handle it.
         self.checkResourceRequest(jobDesc.memory, cores, jobDesc.disk, job_name=jobDesc.jobName,
                                   detail=f'Scale is set to {self.scale}.')
-
         log.debug(f"Issuing the command: {jobDesc.command} with "
                   f"memory: {jobDesc.memory}, cores: {cores}, disk: {jobDesc.disk}")
         with self.jobIndexLock:

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -783,7 +783,7 @@ class SingleMachineBatchSystemJobTest(hidden.AbstractBatchSystemJobTest):
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.workDir = tempDir
         from toil import physicalDisk
-        availableDisk = physicalDisk('', toilWorkflowDir=options.workDir)
+        availableDisk = physicalDisk(options.workDir)
         options.batchSystem = self.batchSystemName
 
         counterPath = os.path.join(tempDir, 'counter')

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -209,13 +209,13 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
         for e in environment["PYTHONPATH"].split(':'):
             if e != '':
                 sys.path.append(e)
-                
+
     toilWorkflowDir = Toil.getLocalWorkflowDir(config.workflowID, config.workDir)
 
     ##########################################
     #Setup the temporary directories.
     ##########################################
-        
+
     # Dir to put all this worker's temp files in.
     localWorkerTempDir = tempfile.mkdtemp(dir=toilWorkflowDir)
     os.chmod(localWorkerTempDir, 0o755)


### PR DESCRIPTION
Resolves #3359 .  Also refactored a little, somewhat due to making it easier to pass the `dir` name needed for the error message.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Better error message for insufficient disk.
