### PR TITLE
fix maxMEM comparision

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -18,7 +18,7 @@ import shutil
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from contextlib import contextmanager
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from toil.batchSystems.registry import (BATCH_SYSTEM_FACTORY_REGISTRY,
                                         DEFAULT_BATCH_SYSTEM)
@@ -408,7 +408,7 @@ class BatchSystemLocalSupport(BatchSystemSupport):
         self.localBatch = BATCH_SYSTEM_FACTORY_REGISTRY[DEFAULT_BATCH_SYSTEM]()(
                 config, config.maxLocalJobs, maxMemory, maxDisk)
 
-    def handleLocalJob(self, jobDesc):  # type: (JobDescription) -> Optional[int]
+    def handleLocalJob(self, jobDesc):  # type: (Any) -> Optional[int]
         """
         To be called by issueBatchJobs.
 

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -22,6 +22,7 @@ import logging
 import math
 import os
 import re
+import subprocess
 from datetime import datetime
 from random import randint
 
@@ -288,7 +289,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     logger.error("Could not parse bjobs output: {}".format(bjobs_output_str))
                 if 'RECORDS' in bjobs_dict:
                     bjobs_records = bjobs_dict['RECORDS']
-            if bjobs_records == None:
+            if bjobs_records is None:
                 logger.error("Could not find bjobs output json in: {}".format(bjobs_output_str))
 
             return bjobs_records
@@ -358,7 +359,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                 MemoryString(items[mem_index]) > maxMEM):
                 maxMEM = MemoryString(items[mem_index])
 
-        if maxCPU == 0 or maxMEM == 0:
+        if maxCPU == 0 or maxMEM == MemoryString("0"):
                 raise RuntimeError("lshosts returns null ncpus or maxmem info")
         logger.debug("Got the maxMEM: {}".format(maxMEM))
         logger.debug("Got the maxCPU: {}".format(maxCPU))

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -526,7 +526,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
             if jobID in self.runningJobs:
                 info = self.runningJobs[jobID]
                 info.killIntended = True
-                if info.popen != None:
+                if info.popen is not None:
                     log.debug('Send kill to PID %s', info.popen.pid)
                     info.popen.kill()
                     log.debug('Sent kill to PID %s', info.popen.pid)

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -128,7 +128,7 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
             job = dict()
             for item in values:
-                logger.debug("%s output %s", args[0], line)
+                logger.debug("%s output %s", args[0], item)
 
                 # Output is in the form of many key=value pairs, multiple pairs on each line
                 # and multiple lines in the output. Each pair is pulled out of each line and


### PR DESCRIPTION
Fixes #3368 

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Fixed LSF batch system `AttributeError: 'int' object has no attribute 'bytes'`

@caballero  can you test this?