### PR TITLE
Resolve #3383 and avoids overloading --doubleMem parameter

### DIFF
--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -243,6 +243,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
               mem: number of bytes of memory needed
               jobID: ID number of the job
             """
+            bsubMem = []
             if mem:
                 if per_core_reservation():
                     mem = float(mem)/1024**3/math.ceil(cpu)
@@ -253,11 +254,11 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     mem_resource = parse_memory_resource(mem)
                     mem_limit = parse_memory_limit(mem)
 
-                bsubMem = ['-R', 'select[mem > {m}] '
-                           'rusage[mem={m}]'.format(m=mem_resource),
-                           '-M', str(mem_limit)]
-            else:
-                bsubMem = []
+                if mem > 0:
+                    bsubMem = ['-R', 'select[mem > {m}] '
+                               'rusage[mem={m}]'.format(m=mem_resource),
+                               '-M', str(mem_limit)]
+                
             bsubCpu = [] if cpu is None else ['-n', str(math.ceil(cpu))]
             bsubline = ["bsub", "-cwd", ".", "-J", "toil_job_{}".format(jobID)]
             bsubline.extend(bsubMem)

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -742,7 +742,7 @@ class JobDescription(Requirer):
             self.memory = self.memory * 2
             logger.warning("We have doubled the memory of the failed job %s to %s bytes due to doubleMem flag",
                            self, self.memory)
-        if self.memory < self._config.defaultMemory:
+        elif self.memory < self._config.defaultMemory:
             self.memory = self._config.defaultMemory
             logger.warning("We have increased the default memory of the failed job %s to %s bytes",
                            self, self.memory)


### PR DESCRIPTION
This commit attempts to solve the problem of making LSF to  "-R
 select[mem > 0] rusage[mem=0]" as well as the problem of overloading the behaviour of the --doubleMem parameters

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Whatsits now frobnicated

