### PR TITLE
Remove unused --defaultPreemptable option.

### DIFF
--- a/docs/running/cloud/amazon.rst
+++ b/docs/running/cloud/amazon.rst
@@ -326,9 +326,8 @@ somewhere else.
 A node type can be specified as preemptable by adding a `spot bid`_ to its entry in the list of node types provided with
 the ``--nodeTypes`` flag. If spot instance prices rise above your bid, the preemptable node whill be shut down.
 
-While individual jobs can each explicitly specify whether or not they should be run on preemptable nodes
-via the boolean ``preemptable`` resource requirement, the ``--defaultPreemptable`` flag will allow jobs without a
-``preemptable`` requirement to run on preemptable machines.
+Individual jobs can each explicitly specify whether or not they should be run on preemptable nodes
+via the boolean ``preemptable`` resource requirement.
 
 .. admonition:: Specify Preemptability Carefully
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -100,7 +100,6 @@ class Config:
         self.defaultCores = 1
         self.defaultDisk = 2147483648
         self.readGlobalFileMutableByDefault = False
-        self.defaultPreemptable = False
         self.maxCores = sys.maxsize
         self.maxMemory = sys.maxsize
         self.maxDisk = sys.maxsize
@@ -253,7 +252,6 @@ class Config:
         setOption("maxCores", int, iC(1))
         setOption("maxMemory", h2b, iC(1))
         setOption("maxDisk", h2b, iC(1))
-        setOption("defaultPreemptable")
 
         # Retrying/rescuing jobs
         setOption("retryCount", int, iC(1))
@@ -538,8 +536,6 @@ def addOptions(parser: ArgumentParser, config: Config = Config()):
                      'that do not specify an explicit value for this requirement. Standard '
                      'suffixes like K, Ki, M, Mi, G or Gi are supported. Default is %s' %
                      bytes2human(config.defaultDisk, symbols='iec'))
-    assert not config.defaultPreemptable, 'User would be unable to reset config.defaultPreemptable'
-    addOptionFn('--defaultPreemptable', dest='defaultPreemptable', action='store_true')
     addOptionFn('--maxCores', dest='maxCores', default=None, metavar='INT',
                 help='The maximum number of CPU cores to request from the batch system at any one '
                      'time. Standard suffixes like K, Ki, M, Mi, G or Gi are supported. Default '

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -147,8 +147,6 @@ class AbstractAWSAutoscaleTest(ToilTest):
 
         toilOptions.extend(['--nodeTypes=' + ",".join(self.instanceTypes),
                             '--maxNodes=' + ",".join(self.numWorkers)])
-        if preemptableJobs:
-            toilOptions.extend(['--defaultPreemptable'])
 
         self._runScript(toilOptions)
 

--- a/src/toil/test/provisioners/gceProvisionerTest.py
+++ b/src/toil/test/provisioners/gceProvisionerTest.py
@@ -154,8 +154,6 @@ class AbstractGCEAutoscaleTest(ToilTest):
 
         toilOptions.extend(['--nodeTypes=' + ",".join(self.instanceTypes),
                             '--maxNodes=%s' % ",".join(self.numWorkers)])
-        if preemptableJobs:
-            toilOptions.extend(['--defaultPreemptable'])
 
         self._runScript(toilOptions)
 


### PR DESCRIPTION
This option had no `help` message and went I went to look at what it did, it seemed completely unused.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Remove unused --defaultPreemptable option.

