### PR TITLE
Corrected gridengine maxMEM check to use memorystring, not a plain int 0

### DIFF
--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -174,6 +174,6 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
                 maxCPU = int(items[cpu_index])
             if items[mem_index] != '-' and MemoryString(items[mem_index]) > maxMEM:
                 maxMEM = MemoryString(items[mem_index])
-        if maxCPU == 0 or maxMEM == 0:
+        if maxCPU == 0 or maxMEM == MemoryString("0"):
             raise RuntimeError('qhost returned null NCPU or MEMTOT info')
         return maxCPU, maxMEM


### PR DESCRIPTION
Using v5.1.0 with SGE kicked out an error about a missing byte subclass for the int object - so I've corrected this check to use the same MemoryString construct that maxMEM is initialised with.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * bugfix for gridengine maxMEM check 

