### PR TITLE
Use a Docker Hub mirror when pulling Docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,12 @@ variables:
   DEBIAN_FRONTEND: "noninteractive"
 
 before_script:
+  # Configure Docker to use a mirror for Docker Hub and restart the daemon
+  # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
+  - |
+    if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
+        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
+    fi
   - startdocker || true
   - docker info
   - cat /etc/hosts


### PR DESCRIPTION
This should fix #3337 by pointing CI at the local Docker Hub mirror Lon set up.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * CI now uses a caching Docker mirror

