### PR TITLE
Update dictionary structure in AnalyzeWDL.

### DIFF
--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -8,27 +8,29 @@ from typing import List, Optional
 
 from toil.test import ToilTest
 from toil.version import exactPython
-from toil.wdl.wdl_functions import (WDLPair,
-                                    WDLRuntimeError,
-                                    ceil,
-                                    cross,
-                                    floor,
-                                    length,
-                                    read_boolean,
-                                    read_float,
-                                    read_int,
-                                    read_json,
-                                    read_lines,
-                                    read_map,
-                                    read_string,
-                                    read_tsv,
-                                    sub,
-                                    transpose,
-                                    wdl_zip,
-                                    write_json,
-                                    write_lines,
-                                    write_map,
-                                    write_tsv)
+from toil.wdl.wdl_functions import (
+    WDLPair,
+    WDLRuntimeError,
+    ceil,
+    cross,
+    floor,
+    length,
+    read_boolean,
+    read_float,
+    read_int,
+    read_json,
+    read_lines,
+    read_map,
+    read_string,
+    read_tsv,
+    sub,
+    transpose,
+    wdl_zip,
+    write_json,
+    write_lines,
+    write_map,
+    write_tsv
+)
 
 
 class WdlStandardLibraryFunctionsTest(ToilTest):

--- a/src/toil/test/wdl/builtinTest.py
+++ b/src/toil/test/wdl/builtinTest.py
@@ -8,29 +8,27 @@ from typing import List, Optional
 
 from toil.test import ToilTest
 from toil.version import exactPython
-from toil.wdl.wdl_functions import (
-    WDLPair,
-    WDLRuntimeError,
-    ceil,
-    cross,
-    floor,
-    length,
-    read_boolean,
-    read_float,
-    read_int,
-    read_json,
-    read_lines,
-    read_map,
-    read_string,
-    read_tsv,
-    sub,
-    transpose,
-    wdl_zip,
-    write_json,
-    write_lines,
-    write_map,
-    write_tsv
-)
+from toil.wdl.wdl_functions import (WDLPair,
+                                    WDLRuntimeError,
+                                    ceil,
+                                    cross,
+                                    floor,
+                                    length,
+                                    read_boolean,
+                                    read_float,
+                                    read_int,
+                                    read_json,
+                                    read_lines,
+                                    read_map,
+                                    read_string,
+                                    read_tsv,
+                                    sub,
+                                    transpose,
+                                    wdl_zip,
+                                    write_json,
+                                    write_lines,
+                                    write_map,
+                                    write_tsv)
 
 
 class WdlStandardLibraryFunctionsTest(ToilTest):

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -9,23 +9,21 @@ from urllib.request import urlretrieve
 from toil.test import ToilTest, needs_docker, needs_java, slow
 from toil.version import exactPython
 from toil.wdl.utils import get_analyzer
-from toil.wdl.wdl_functions import (
-    abspath_file,
-    basename,
-    combine_dicts,
-    generate_docker_bashscript_file,
-    glob,
-    parse_cores,
-    parse_disk,
-    parse_memory,
-    process_and_read_file,
-    process_infile,
-    process_outfile,
-    read_csv,
-    read_tsv,
-    select_first,
-    size
-)
+from toil.wdl.wdl_functions import (abspath_file,
+                                    basename,
+                                    combine_dicts,
+                                    generate_docker_bashscript_file,
+                                    glob,
+                                    parse_cores,
+                                    parse_disk,
+                                    parse_memory,
+                                    process_and_read_file,
+                                    process_infile,
+                                    process_outfile,
+                                    read_csv,
+                                    read_tsv,
+                                    select_first,
+                                    size)
 
 
 class ToilWdlIntegrationTest(ToilTest):

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -8,22 +8,24 @@ from urllib.request import urlretrieve
 
 from toil.test import ToilTest, needs_docker, needs_java, slow
 from toil.version import exactPython
-from toil.wdl.wdl_functions import (abspath_file,
-                                    basename,
-                                    combine_dicts,
-                                    defined,
-                                    generate_docker_bashscript_file,
-                                    glob,
-                                    parse_cores,
-                                    parse_disk,
-                                    parse_memory,
-                                    process_and_read_file,
-                                    process_infile,
-                                    process_outfile,
-                                    read_csv,
-                                    read_tsv,
-                                    select_first,
-                                    size)
+from toil.wdl.utils import get_analyzer
+from toil.wdl.wdl_functions import (
+    abspath_file,
+    basename,
+    combine_dicts,
+    generate_docker_bashscript_file,
+    glob,
+    parse_cores,
+    parse_disk,
+    parse_memory,
+    process_and_read_file,
+    process_infile,
+    process_outfile,
+    read_csv,
+    read_tsv,
+    select_first,
+    size
+)
 
 
 class ToilWdlIntegrationTest(ToilTest):
@@ -108,8 +110,8 @@ class ToilWdlIntegrationTest(ToilTest):
 
     @needs_docker
     def testMD5sum(self):
-        '''Test if toilwdl produces the same outputs as known good outputs for WDL's
-        GATK tutorial #1.'''
+        """Test if toilwdl produces the same outputs as known good outputs for WDL's
+        GATK tutorial #1."""
         wdl = os.path.abspath('src/toil/test/wdl/md5sum/md5sum.wdl')
         inputfile = os.path.abspath('src/toil/test/wdl/md5sum/md5sum.input')
         json = os.path.abspath('src/toil/test/wdl/md5sum/md5sum.json')
@@ -216,42 +218,45 @@ class ToilWdlIntegrationTest(ToilTest):
 
     # estimated run time <1 sec
     def testPrimitives(self):
-        '''Test if toilwdl correctly interprets some basic declarations.'''
+        """Test if toilwdl correctly interprets some basic declarations."""
         wdl = os.path.abspath('src/toil/test/wdl/testfiles/vocab.wdl')
 
         # TODO: test for all version.
-        from toil.wdl.versions.draft2 import AnalyzeDraft2WDL
-        aWDL = AnalyzeDraft2WDL(wdl)
+        aWDL = get_analyzer(wdl)
         aWDL.analyze()
 
         no_declaration = ['bool1', 'int1', 'float1', 'file1', 'string1']
         collection_counter = []
-        for name, declaration in aWDL.workflows_dictionary['vocabulary']['wf_declarations'].items():
+        for key, declaration in aWDL.workflows_dictionary['vocabulary'].items():
+            if not key.startswith('declaration'):
+                continue
+
+            name, var_type, var_expr = declaration
 
             if name in no_declaration:
                 collection_counter.append(name)
-                assert not declaration['value']
+                assert not var_expr
 
             if name == 'bool2':
                 collection_counter.append(name)
-                assert declaration['value'] == 'True', declaration['value']
-                assert declaration['type'] == 'Boolean', declaration['type']
+                assert var_expr == 'True', var_expr
+                assert var_type == 'Boolean', var_type
             if name == 'int2':
                 collection_counter.append(name)
-                assert declaration['value'] == '1', declaration['value']
-                assert declaration['type'] == 'Int', declaration['type']
+                assert var_expr == '1', var_expr
+                assert var_type == 'Int', var_type
             if name == 'float2':
                 collection_counter.append(name)
-                assert declaration['value'] == '1.1', declaration['value']
-                assert declaration['type'] == 'Float', declaration['type']
+                assert var_expr == '1.1', var_expr
+                assert var_type == 'Float', var_type
             if name == 'file2':
                 collection_counter.append(name)
-                assert declaration['value'] == "'src/toil/test/wdl/test.tsv'", declaration['value']
-                assert declaration['type'] == 'File', declaration['type']
+                assert var_expr == "'src/toil/test/wdl/test.tsv'", var_expr
+                assert var_type == 'File', var_type
             if name == 'string2':
                 collection_counter.append(name)
-                assert declaration['value'] == "'x'", declaration['value']
-                assert declaration['type'] == 'String', declaration['type']
+                assert var_expr == "'x'", var_expr
+                assert var_type == 'String', var_type
         assert collection_counter == ['bool1', 'int1', 'float1', 'file1', 'string1',
                                       'bool2', 'int2', 'float2', 'file2', 'string2']
 
@@ -259,8 +264,8 @@ class ToilWdlIntegrationTest(ToilTest):
     @slow
     @needs_java
     def testTut01(self):
-        '''Test if toilwdl produces the same outputs as known good outputs for WDL's
-        GATK tutorial #1.'''
+        """Test if toilwdl produces the same outputs as known good outputs for WDL's
+        GATK tutorial #1."""
         wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/helloHaplotypeCaller.wdl")
         json = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/helloHaplotypeCaller_inputs.json")
         ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t01/output/")
@@ -273,8 +278,8 @@ class ToilWdlIntegrationTest(ToilTest):
     @slow
     @needs_java
     def testTut02(self):
-        '''Test if toilwdl produces the same outputs as known good outputs for WDL's
-        GATK tutorial #2.'''
+        """Test if toilwdl produces the same outputs as known good outputs for WDL's
+        GATK tutorial #2."""
         wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/simpleVariantSelection.wdl")
         json = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/simpleVariantSelection_inputs.json")
         ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t02/output/")
@@ -287,8 +292,8 @@ class ToilWdlIntegrationTest(ToilTest):
     @slow
     @needs_java
     def testTut03(self):
-        '''Test if toilwdl produces the same outputs as known good outputs for WDL's
-        GATK tutorial #3.'''
+        """Test if toilwdl produces the same outputs as known good outputs for WDL's
+        GATK tutorial #3."""
         wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/simpleVariantDiscovery.wdl")
         json = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/simpleVariantDiscovery_inputs.json")
         ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t03/output/")
@@ -302,8 +307,8 @@ class ToilWdlIntegrationTest(ToilTest):
     @needs_java
     @unittest.skip('broken; see: https://github.com/DataBiosphere/toil/issues/3339')
     def testTut04(self):
-        '''Test if toilwdl produces the same outputs as known good outputs for WDL's
-        GATK tutorial #4.'''
+        """Test if toilwdl produces the same outputs as known good outputs for WDL's
+        GATK tutorial #4."""
         wdl = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/jointCallingGenotypes.wdl")
         json = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/jointCallingGenotypes_inputs.json")
         ref_dir = os.path.abspath("src/toil/test/wdl/wdl_templates/t04/output/")
@@ -316,8 +321,8 @@ class ToilWdlIntegrationTest(ToilTest):
     @slow
     @needs_docker
     def testENCODE(self):
-        '''Test if toilwdl produces the same outputs as known good outputs for
-        a short ENCODE run.'''
+        """Test if toilwdl produces the same outputs as known good outputs for
+        a short ENCODE run."""
         wdl = os.path.abspath(
             "src/toil/test/wdl/wdl_templates/testENCODE/encode_mapping_workflow.wdl")
         json = os.path.abspath(
@@ -332,7 +337,7 @@ class ToilWdlIntegrationTest(ToilTest):
 
     # estimated run time 2 sec
     def testPipe(self):
-        '''Test basic bash input functionality with a pipe.'''
+        """Test basic bash input functionality with a pipe."""
         wdl = os.path.abspath(
             "src/toil/test/wdl/wdl_templates/testPipe/call.wdl")
         json = os.path.abspath(

--- a/src/toil/wdl/toilwdl.py
+++ b/src/toil/wdl/toilwdl.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 UCSC Computational Genomics Lab
+# Copyright (C) 2018-2021 UCSC Computational Genomics Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,11 @@ import os
 import subprocess
 import sys
 
-from toil.wdl.utils import dict_from_JSON
-from toil.wdl.versions.draft2 import AnalyzeDraft2WDL
+from toil.wdl.utils import (
+    get_analyzer,
+    dict_from_JSON,
+    write_mappings
+)
 from toil.wdl.wdl_synthesis import SynthesizeWDL
 
 logger = logging.getLogger(__name__)
@@ -92,8 +95,7 @@ def main():
     args.secondary_file = os.path.abspath(args.secondary_file)
     args.outdir = os.path.abspath(args.outdir)
 
-    # TODO: construct analyzer based on version.
-    aWDL = AnalyzeDraft2WDL(wdl_file=wdl_file)
+    aWDL = get_analyzer(wdl_file=wdl_file)
 
     if args.dev_mode:
         aWDL.write_AST(out_dir=args.outdir)
@@ -104,9 +106,11 @@ def main():
     else:
         raise RuntimeError('Unsupported Secondary File Type.  Use json.')
 
+    logger.info(f"Parsing WDL file with version: '{aWDL.version}'.")
     aWDL.analyze()
 
-    sWDL = SynthesizeWDL(aWDL.tasks_dictionary,
+    sWDL = SynthesizeWDL(aWDL.version,
+                         aWDL.tasks_dictionary,
                          aWDL.workflows_dictionary,
                          args.outdir,
                          json_dict,
@@ -128,7 +132,7 @@ def main():
 
     if args.dev_mode:
         logger.debug('WDL file compiled to toil script.')
-        sWDL.write_mappings(aWDL)
+        write_mappings(aWDL)
     else:
         logger.debug('WDL file compiled to toil script.  Running now.')
         exe = sys.executable if sys.executable else 'python'

--- a/src/toil/wdl/toilwdl.py
+++ b/src/toil/wdl/toilwdl.py
@@ -106,7 +106,6 @@ def main():
     else:
         raise RuntimeError('Unsupported Secondary File Type.  Use json.')
 
-    logger.info(f"Parsing WDL file with version: '{aWDL.version}'.")
     aWDL.analyze()
 
     sWDL = SynthesizeWDL(aWDL.version,

--- a/src/toil/wdl/toilwdl.py
+++ b/src/toil/wdl/toilwdl.py
@@ -17,11 +17,7 @@ import os
 import subprocess
 import sys
 
-from toil.wdl.utils import (
-    get_analyzer,
-    dict_from_JSON,
-    write_mappings
-)
+from toil.wdl.utils import dict_from_JSON, get_analyzer, write_mappings
 from toil.wdl.wdl_synthesis import SynthesizeWDL
 
 logger = logging.getLogger(__name__)

--- a/src/toil/wdl/utils.py
+++ b/src/toil/wdl/utils.py
@@ -13,8 +13,53 @@
 # limitations under the License.
 import json
 
+from toil.wdl.wdl_analysis import AnalyzeWDL
 
-def dict_from_JSON(JSON_file):
+
+def check_version(iterable) -> str:
+    """
+    Takes in a WDL document and checks the version.
+
+    :param iterable: An iterable that contains the lines of a WDL document.
+    """
+    if isinstance(iterable, str):
+        iterable = iterable.split('\n')
+
+    for line in iterable:
+        line = line.strip()
+        # check if the first non-empty, non-comment line is the version statement
+        if line and not line.startswith('#'):
+            if line.startswith('version '):
+                return line[8:].strip()
+            break
+    # only draft-2 doesn't contain the version declaration
+    return 'draft-2'
+
+
+def get_analyzer(wdl_file: str) -> AnalyzeWDL:
+    """
+    Creates an instance of an AnalyzeWDL implementation based on the version.
+
+    :param wdl_file: The path to the WDL file.
+    :rtype: AnalyzeWDL
+    """
+    with open(wdl_file, 'r') as f:
+        version = check_version(f)
+
+    if version == 'draft-2':
+        from toil.wdl.versions.draft2 import AnalyzeDraft2WDL
+        return AnalyzeDraft2WDL(wdl_file)
+    # elif version == '1.0':
+    #     from toil.wdl.versions.v1 import AnalyzeV1WDL
+    #     return AnalyzeV1WDL(wdl_file)
+    # elif version == 'development':
+    #     from toil.wdl.versions.dev import AnalyzeDevelopmentWDL
+    #     return AnalyzeDevelopmentWDL(wdl_file)
+    else:
+        raise RuntimeError(f"Unknown WDL version: '{version}'.")
+
+
+def dict_from_JSON(JSON_file: str) -> dict:
     """
     Takes a WDL-mapped json file and creates a dict containing the bindings.
 
@@ -32,3 +77,79 @@ def dict_from_JSON(JSON_file):
         else:
             json_dict[d] = data[d]
     return json_dict
+
+
+def write_mappings(parser: AnalyzeWDL) -> None:
+    """
+    Intended to take an AnalyzeWDL instance and prints the final task dict,
+    and workflow dict.
+
+    Does not work by default with toil since Toil actively suppresses stdout
+    during the run.
+    """
+    from collections import OrderedDict
+
+    class Formatter(object):
+        def __init__(self):
+            self.types = {}
+            self.htchar = '\t'
+            self.lfchar = '\n'
+            self.indent = 0
+            self.set_formater(object, self.__class__.format_object)
+            self.set_formater(dict, self.__class__.format_dict)
+            self.set_formater(list, self.__class__.format_list)
+            self.set_formater(tuple, self.__class__.format_tuple)
+
+        def set_formater(self, obj, callback):
+            self.types[obj] = callback
+
+        def __call__(self, value, **args):
+            for key in args:
+                setattr(self, key, args[key])
+            formater = self.types[type(value) if type(value) in self.types else object]
+            return formater(self, value, self.indent)
+
+        def format_object(self, value, indent):
+            return repr(value)
+
+        def format_dict(self, value, indent):
+            items = [
+                self.lfchar + self.htchar * (indent + 1) + repr(key) + ': ' +
+                (self.types[type(value[key]) if type(value[key]) in self.types else object])(self, value[key],
+                                                                                             indent + 1)
+                for key in value]
+            return '{%s}' % (','.join(items) + self.lfchar + self.htchar * indent)
+
+        def format_list(self, value, indent):
+            items = [
+                self.lfchar + self.htchar * (indent + 1) + (
+                    self.types[type(item) if type(item) in self.types else object])(self, item, indent + 1)
+                for item in value]
+            return '[%s]' % (','.join(items) + self.lfchar + self.htchar * indent)
+
+        def format_tuple(self, value, indent):
+            items = [
+                self.lfchar + self.htchar * (indent + 1) + (
+                    self.types[type(item) if type(item) in self.types else object])(self, item, indent + 1)
+                for item in value]
+            return '(%s)' % (','.join(items) + self.lfchar + self.htchar * indent)
+
+    pretty = Formatter()
+
+    def format_ordereddict(self, value, indent):
+        items = [
+            self.lfchar + self.htchar * (indent + 1) +
+            "(" + repr(key) + ', ' + (self.types[
+                type(value[key]) if type(value[key]) in self.types else object
+            ])(self, value[key], indent + 1) + ")"
+            for key in value
+        ]
+        return 'OrderedDict([%s])' % (','.join(items) +
+                                      self.lfchar + self.htchar * indent)
+
+    pretty.set_formater(OrderedDict, format_ordereddict)
+
+    with open('mappings.out', 'w') as f:
+        f.write(pretty(parser.tasks_dictionary))
+        f.write('\n\n\n\n\n\n')
+        f.write(pretty(parser.workflows_dictionary))

--- a/src/toil/wdl/utils.py
+++ b/src/toil/wdl/utils.py
@@ -49,14 +49,14 @@ def get_analyzer(wdl_file: str) -> AnalyzeWDL:
     if version == 'draft-2':
         from toil.wdl.versions.draft2 import AnalyzeDraft2WDL
         return AnalyzeDraft2WDL(wdl_file)
-    # elif version == '1.0':
-    #     from toil.wdl.versions.v1 import AnalyzeV1WDL
-    #     return AnalyzeV1WDL(wdl_file)
-    # elif version == 'development':
-    #     from toil.wdl.versions.dev import AnalyzeDevelopmentWDL
-    #     return AnalyzeDevelopmentWDL(wdl_file)
+    elif version == '1.0':
+        from toil.wdl.versions.v1 import AnalyzeV1WDL
+        return AnalyzeV1WDL(wdl_file)
+    elif version == 'development':
+        from toil.wdl.versions.dev import AnalyzeDevelopmentWDL
+        return AnalyzeDevelopmentWDL(wdl_file)
     else:
-        raise RuntimeError(f"Unknown WDL version: '{version}'.")
+        raise RuntimeError(f"Unsupported WDL version: '{version}'.")
 
 
 def dict_from_JSON(JSON_file: str) -> dict:

--- a/src/toil/wdl/utils.py
+++ b/src/toil/wdl/utils.py
@@ -16,11 +16,12 @@ import json
 from toil.wdl.wdl_analysis import AnalyzeWDL
 
 
-def check_version(iterable) -> str:
+def get_version(iterable) -> str:
     """
-    Takes in a WDL document and checks the version.
+    Get the version of the WDL document.
 
     :param iterable: An iterable that contains the lines of a WDL document.
+    :return: The WDL version used in the workflow.
     """
     if isinstance(iterable, str):
         iterable = iterable.split('\n')
@@ -41,10 +42,9 @@ def get_analyzer(wdl_file: str) -> AnalyzeWDL:
     Creates an instance of an AnalyzeWDL implementation based on the version.
 
     :param wdl_file: The path to the WDL file.
-    :rtype: AnalyzeWDL
     """
     with open(wdl_file, 'r') as f:
-        version = check_version(f)
+        version = get_version(f)
 
     if version == 'draft-2':
         from toil.wdl.versions.draft2 import AnalyzeDraft2WDL
@@ -79,13 +79,13 @@ def dict_from_JSON(JSON_file: str) -> dict:
     return json_dict
 
 
-def write_mappings(parser: AnalyzeWDL) -> None:
+def write_mappings(parser: AnalyzeWDL, filename: str = 'mappings.out') -> None:
     """
-    Intended to take an AnalyzeWDL instance and prints the final task dict,
-    and workflow dict.
+    Takes an AnalyzeWDL instance and writes the final task dict and workflow
+    dict to the given file.
 
-    Does not work by default with toil since Toil actively suppresses stdout
-    during the run.
+    :param parser: An AnalyzeWDL instance.
+    :param filename: The name of a file to write to.
     """
     from collections import OrderedDict
 
@@ -149,7 +149,7 @@ def write_mappings(parser: AnalyzeWDL) -> None:
 
     pretty.set_formater(OrderedDict, format_ordereddict)
 
-    with open('mappings.out', 'w') as f:
+    with open(filename, 'w') as f:
         f.write(pretty(parser.tasks_dictionary))
         f.write('\n\n\n\n\n\n')
         f.write(pretty(parser.workflows_dictionary))

--- a/src/toil/wdl/versions/dev.py
+++ b/src/toil/wdl/versions/dev.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2020-2021 Regents of the University of California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from toil.wdl.wdl_analysis import AnalyzeWDL
+
+logger = logging.getLogger(__name__)
+
+
+class AnalyzeDevelopmentWDL(AnalyzeWDL):
+    """
+    AnalyzeWDL implementation for the development version.
+    """
+
+    @property
+    def version(self) -> str:
+        return 'development'
+
+    def analyze(self):
+        """
+        Analyzes the WDL file passed into the constructor and generates the two
+        intermediate data structures: `self.workflows_dictionary` and
+        `self.tasks_dictionary`.
+        """
+        raise NotImplementedError

--- a/src/toil/wdl/versions/draft2.py
+++ b/src/toil/wdl/versions/draft2.py
@@ -302,12 +302,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         output_array = []
         for j in i.attributes['attributes']:
             if j.name == 'Output':
-                var_name = self.parse_declaration_name(j.attr("name"))
-                var_type = self.parse_declaration_type(j.attr("type"))
-                var_expressn = self.parse_declaration_expressn(j.attr("expression"), es='', output_expressn=True)
-                if not (var_expressn.startswith('(') and var_expressn.endswith(')')):
-                    var_expressn = self.translate_wdl_string_to_python_string(var_expressn)
-                output_array.append((var_name, var_type, var_expressn))
+                output_array.append(self.parse_declaration(j))
             else:
                 raise NotImplementedError
         return output_array
@@ -551,7 +546,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         else:
             raise NotImplementedError
 
-    def parse_declaration_expressn(self, expressionAST, es, output_expressn=False):
+    def parse_declaration_expressn(self, expressionAST, es):
         """
         Expressions are optional.  Workflow declaration valid examples:
 
@@ -576,10 +571,11 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                     else:
                         raise TypeError('Parsed boolean ({}) must be expressed as "true" or "false".'
                                         ''.format(expressionAST.source_string))
-                elif expressionAST.str == 'string' and not output_expressn:
+                elif expressionAST.str == 'string':
                     parsed_string = self.translate_wdl_string_to_python_string(expressionAST.source_string)
                     return '{string}'.format(string=parsed_string)
                 else:
+                    # integers, floats, and variables
                     return '{string}'.format(string=expressionAST.source_string)
             elif isinstance(expressionAST, wdl_parser.Ast):
                 if expressionAST.name == 'Add':

--- a/src/toil/wdl/versions/draft2.py
+++ b/src/toil/wdl/versions/draft2.py
@@ -16,16 +16,8 @@ import os
 from collections import OrderedDict
 
 from wdlparse.draft2 import wdl_parser
-
 from toil.wdl.wdl_analysis import AnalyzeWDL
-from toil.wdl.wdl_types import (WDLArrayType,
-                                WDLBooleanType,
-                                WDLFileType,
-                                WDLFloatType,
-                                WDLIntType,
-                                WDLMapType,
-                                WDLPairType,
-                                WDLStringType)
+
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +26,10 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
     """
     AnalyzeWDL implementation for the draft-2 version.
     """
+
+    @property
+    def version(self) -> str:
+        return 'draft-2'
 
     def analyze(self):
         """
@@ -63,7 +59,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                 f.write(ast.dumps(indent=2))
 
     def find_asts(self, ast_root, name):
-        '''
+        """
         Finds an AST node with the given name and the entire subtree under it.
         A function borrowed from scottfrazer.  Thank you Scott Frazer!
 
@@ -71,7 +67,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                          any portion that you wish to search.
         :param name: The name of the subtree you're looking for, like "Task".
         :return: nodes representing the AST subtrees matching the "name" given.
-        '''
+        """
         nodes = []
         if isinstance(ast_root, wdl_parser.AstList):
             for node in ast_root:
@@ -84,20 +80,20 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         return nodes
 
     def create_tasks_dict(self, ast):
-        '''
+        """
         Parse each "Task" in the AST.  This will create self.tasks_dictionary,
         where each task name is a key.
 
         :return: Creates the self.tasks_dictionary necessary for much of the
         parser.  Returning it is only necessary for unittests.
-        '''
+        """
         tasks = self.find_asts(ast, 'Task')
         for task in tasks:
             self.parse_task(task)
         return self.tasks_dictionary
 
     def parse_task(self, task):
-        '''
+        """
         Parses a WDL task AST subtree.
 
         Currently looks at and parses 4 sections:
@@ -109,14 +105,14 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         :param task: An AST subtree of a WDL "Task".
         :return: Returns nothing but adds a task to the self.tasks_dictionary
         necessary for much of the parser.
-        '''
+        """
 
         task_name = task.attributes["name"].source_string
 
         # task declarations
         declaration_array = []
         for declaration_subAST in task.attr("declarations"):
-            declaration_array.append(self.parse_task_declaration(declaration_subAST))
+            declaration_array.append(self.parse_declaration(declaration_subAST))
             self.tasks_dictionary.setdefault(task_name, OrderedDict())['inputs'] = declaration_array
 
         for section in task.attr("sections"):
@@ -135,29 +131,6 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
             if section.name == "Outputs":
                 output_array = self.parse_task_outputs(section)
                 self.tasks_dictionary.setdefault(task_name, OrderedDict())['outputs'] = output_array
-
-    def parse_task_declaration(self, declaration_subAST):
-        '''
-        Parses the declaration section of the WDL task AST subtree.
-
-        Examples:
-
-        String my_name
-        String your_name
-        Int two_chains_i_mean_names = 0
-
-        :param declaration_subAST: Some subAST representing a task declaration
-                                   like: 'String file_name'
-        :return: var_name, var_type, var_value
-            Example:
-                Input subAST representing:   'String file_name'
-                Output:  var_name='file_name', var_type='String', var_value=None
-        '''
-        var_name = self.parse_declaration_name(declaration_subAST.attr("name"))
-        var_type = self.parse_declaration_type(declaration_subAST.attr("type"))
-        var_expressn = self.parse_declaration_expressn(declaration_subAST.attr("expression"), es='')
-
-        return (var_name, var_type, var_expressn)
 
     def parse_task_rawcommand_attributes(self, code_snippet):
         """
@@ -181,7 +154,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         return attr_dict
 
     def parse_task_rawcommand(self, rawcommand_subAST):
-        '''
+        """
         Parses the rawcommand section of the WDL task AST subtree.
 
         Task "rawcommands" are divided into many parts.  There are 2 types of
@@ -207,7 +180,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                   Where: command_var = 'GVCFs'
                          command_type = 'variable'
                          command_actions = {'sep': ' -V '}
-        '''
+        """
         command_array = []
         for code_snippet in rawcommand_subAST.attributes["parts"]:
 
@@ -259,7 +232,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
             raise NotImplementedError
 
     def parse_task_runtime(self, runtime_subAST):
-        '''
+        """
         Parses the runtime section of the WDL task AST subtree.
 
         The task "runtime" section currently supports context fields for a
@@ -271,7 +244,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                                        ('cpu','2'),
                                        ('memory','17.1 GB'),
                                        ('disks','local-disk 420 HDD')]
-        '''
+        """
         runtime_attributes = OrderedDict()
         if isinstance(runtime_subAST, wdl_parser.Terminal):
             raise NotImplementedError
@@ -287,7 +260,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         return runtime_attributes
 
     def parse_task_outputs(self, i):
-        '''
+        """
         Parse the WDL output section.
 
         Outputs are like declarations, with a type, name, and value.  Examples:
@@ -325,7 +298,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
 
         :return: output_array representing outputs generated by the job/task:
                 e.g. x = [(var_name, var_type, var_value, var_actions), ...]
-        '''
+        """
         output_array = []
         for j in i.attributes['attributes']:
             if j.name == 'Output':
@@ -340,7 +313,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         return output_array
 
     def translate_wdl_string_to_python_string(self, some_string):
-        '''
+        """
         Parses a string representing a given job's output filename into something
         python can read.  Replaces ${string}'s with normal variables and the rest
         with normal strings all concatenated with ' + '.
@@ -357,7 +330,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                         (job priority #, job ID #, Job Skeleton Name, Job Alias)
         :param some_string: e.g. '${sampleName}.vcf'
         :return: output_string, e.g. 'sampleName + ".vcf"'
-        '''
+        """
 
         try:
             # add support for 'sep'
@@ -366,7 +339,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
 
             if edited_string.find('${') != -1:
                 continue_loop = True
-                while (continue_loop):
+                while continue_loop:
                     index_start = edited_string.find('${')
                     index_end = edited_string.find('}', index_start)
 
@@ -394,26 +367,21 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
             return ''
 
     def create_workflows_dict(self, ast):
-        '''
+        """
         Parse each "Workflow" in the AST.  This will create self.workflows_dictionary,
         where each called job is a tuple key of the form: (priority#, job#, name, alias).
 
         :return: Creates the self.workflows_dictionary necessary for much of the
         parser.  Returning it is only necessary for unittests.
-        '''
+        """
         workflows = self.find_asts(ast, 'Workflow')
         for workflow in workflows:
             self.parse_workflow(workflow)
         return self.workflows_dictionary
 
     def parse_workflow(self, workflow):
-        '''
+        """
         Parses a WDL workflow AST subtree.
-
-        Currently looks at and parses 3 sections:
-        1. Declarations (e.g. string x = 'helloworld')
-        2. Calls (similar to a python def)
-        3. Scatter (which expects to map to a Call or multiple Calls)
 
         Returns nothing but creates the self.workflows_dictionary necessary for much
         of the parser.
@@ -421,40 +389,19 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         :param workflow: An AST subtree of a WDL "Workflow".
         :return: Returns nothing but adds a workflow to the
                  self.workflows_dictionary necessary for much of the parser.
-        '''
+        """
         workflow_name = workflow.attr('name').source_string
+        self.workflows_dictionary[workflow_name] = self.parse_workflow_body(workflow.attr("body"))
 
-        wf_declared_dict = OrderedDict()
-        for section in workflow.attr("body"):
-
-            if section.name == "Declaration":
-                var_name, var_map = self.parse_workflow_declaration(section)
-                wf_declared_dict[var_name] = var_map
-            self.workflows_dictionary.setdefault(workflow_name, OrderedDict())['wf_declarations'] = wf_declared_dict
-
-            if section.name == "Scatter":
-                scattertask = self.parse_workflow_scatter(section)
-                self.workflows_dictionary.setdefault(workflow_name, OrderedDict())['scatter' + str(self.scatter_number)] = scattertask
-                self.scatter_number += 1
-
-            if section.name == "Call":
-                task = self.parse_workflow_call(section)
-                self.workflows_dictionary.setdefault(workflow_name, OrderedDict())['call' + str(self.call_number)] = task
-                self.call_number += 1
-
-            if section.name == "If":
-                task = self.parse_workflow_if(section)
-                self.workflows_dictionary.setdefault(workflow_name, OrderedDict())['if' + str(self.if_number)] = task
-                self.if_number += 1
-
-    def parse_workflow_if(self, ifAST):
-        expression = self.parse_workflow_if_expression(ifAST.attr('expression'))
-        body = self.parse_workflow_if_body(ifAST.attr('body'))
-        return {'expression': expression, 'body': body}
-
-    def parse_workflow_if_body(self, i):
+    def parse_workflow_body(self, i):
+        """
+        Currently looks at and parses 3 sections:
+        1. Declarations (e.g. String x = 'helloworld')
+        2. Calls (similar to a python def)
+        3. Scatter (which expects to map to a Call or multiple Calls)
+        4. Conditionals
+        """
         subworkflow_dict = OrderedDict()
-        wf_declared_dict = OrderedDict()
         if isinstance(i, wdl_parser.Terminal):
             raise NotImplementedError
         elif isinstance(i, wdl_parser.Ast):
@@ -462,39 +409,38 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         elif isinstance(i, wdl_parser.AstList):
             for ast in i:
                 if ast.name == "Declaration":
-                    var_name, var_map = self.parse_workflow_declaration(ast)
-                    wf_declared_dict[var_name] = var_map
-                subworkflow_dict['wf_declarations'] = wf_declared_dict
+                    declaration = self.parse_declaration(ast)
+                    subworkflow_dict['declaration' + str(self.declaration_number)] = declaration
+                    self.declaration_number += 1
 
-                if ast.name == "Scatter":
+                elif ast.name == "Scatter":
                     scattertask = self.parse_workflow_scatter(ast)
                     subworkflow_dict['scatter' + str(self.scatter_number)] = scattertask
                     self.scatter_number += 1
 
-                if ast.name == "Call":
+                elif ast.name == "Call":
                     task = self.parse_workflow_call(ast)
                     subworkflow_dict['call' + str(self.call_number)] = task
                     self.call_number += 1
 
-                if ast.name == "If":
+                elif ast.name == "If":
                     task = self.parse_workflow_if(ast)
                     subworkflow_dict['if' + str(self.if_number)] = task
                     self.if_number += 1
         return subworkflow_dict
 
+    def parse_workflow_if(self, ifAST):
+        expression = self.parse_workflow_if_expression(ifAST.attr('expression'))
+        body = self.parse_workflow_body(ifAST.attr('body'))
+        return {'expression': expression, 'body': body}
+
     def parse_workflow_if_expression(self, i):
-        if isinstance(i, wdl_parser.Terminal):
-            ifthis = i.source_string
-        elif isinstance(i, wdl_parser.Ast):
-            ifthis = self.parse_declaration_expressn(i, es='')
-        elif isinstance(i, wdl_parser.AstList):
-            raise NotImplementedError
-        return ifthis
+        return self.parse_declaration_expressn(i, es='')
 
     def parse_workflow_scatter(self, scatterAST):
         item = self.parse_workflow_scatter_item(scatterAST.attr('item'))
         collection = self.parse_workflow_scatter_collection(scatterAST.attr('collection'))
-        body = self.parse_workflow_scatter_body(scatterAST.attr('body'))
+        body = self.parse_workflow_body(scatterAST.attr('body'))
         return {'item': item, 'collection': collection, 'body': body}
 
     def parse_workflow_scatter_item(self, i):
@@ -513,38 +459,28 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         elif isinstance(i, wdl_parser.AstList):
             raise NotImplementedError
 
-    def parse_workflow_scatter_body(self, i):
-        if isinstance(i, wdl_parser.Terminal):
-            raise NotImplementedError
-        elif isinstance(i, wdl_parser.Ast):
-            raise NotImplementedError
-        elif isinstance(i, wdl_parser.AstList):
-            scatterbody = OrderedDict()
-            element = 0
-            for ast in i:
-                if ast.name == "Declaration":
-                    var_name, var_map = self.parse_workflow_declaration(ast)
-                    scatterbody['variable' + str(element)] = var_map
-                    element += 1
+    def parse_declaration(self, ast):
+        """
+        Parses a WDL declaration AST subtree into a Python tuple.
 
-                if ast.name == "Scatter":
-                    scattertask = self.parse_workflow_scatter(ast)
-                    scatterbody['scatter' + str(self.scatter_number)] = scattertask
-                    self.scatter_number += 1
-                    # TODO test this
-                    raise NotImplementedError
+        Examples:
 
-                if ast.name == "Call":
-                    task = self.parse_workflow_call(ast)
-                    scatterbody['call' + str(self.call_number)] = task
-                    self.call_number += 1
+        String my_name
+        String your_name
+        Int two_chains_i_mean_names = 0
 
-                if ast.name == "If":
-                    task = self.parse_workflow_if(ast)
-                    scatterbody['if' + str(self.if_number)] = task
-                    self.if_number += 1
-        return scatterbody
+        :param ast: Some subAST representing a task declaration like:
+                     'String file_name'
+        :return: var_name, var_type, var_value
+            Example:
+                Input subAST representing:   'String file_name'
+                Output:  var_name='file_name', var_type='String', var_value=None
+        """
+        var_name = self.parse_declaration_name(ast.attr("name"))
+        var_type = self.parse_declaration_type(ast.attr("type"))
+        var_expressn = self.parse_declaration_expressn(ast.attr("expression"), es='')
 
+        return var_name, var_type, var_expressn
 
     def parse_declaration_name(self, nameAST):
         """
@@ -590,19 +526,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         :return: a WDLType instance
         """
         if isinstance(typeAST, wdl_parser.Terminal):
-            if typeAST.source_string == 'String':
-                return WDLStringType()
-            elif typeAST.source_string == 'Int':
-                return WDLIntType()
-            elif typeAST.source_string == 'Float':
-                return WDLFloatType()
-            elif typeAST.source_string == 'Boolean':
-                return WDLBooleanType()
-            elif typeAST.source_string == 'File':
-                return WDLFileType()
-            else:
-                raise NotImplementedError
-
+            return self.create_wdl_primitive_type(typeAST.source_string)
         elif isinstance(typeAST, wdl_parser.Ast):
             if typeAST.name == 'Type':
                 subtype = typeAST.attr('subtype')
@@ -617,15 +541,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                 # we're looking at a compound type
                 name = typeAST.attr('name').source_string
                 elements = [self.parse_declaration_type(element) for element in subtype]
-
-                if name == 'Array':
-                    return WDLArrayType(elements[0], optional=optional)
-                if name == 'Pair':
-                    return WDLPairType(*elements, optional=optional)
-                elif name == 'Map':
-                    return WDLMapType(*elements, optional=optional)
-                else:
-                    raise NotImplementedError
+                return self.create_wdl_compound_type(name, elements, optional=optional)
             else:
                 # either a primitive optional type OR deeply recursive types
                 # TODO: add tests #3331
@@ -936,32 +852,6 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
                 es_param = es_param[:-2]
             return es_param
 
-    def parse_workflow_declaration(self, wf_declaration_subAST):
-        '''
-        Parses a WDL declaration AST subtree into a string and a python
-        dictionary containing its 'type' and 'value'.
-
-        For example:
-        var_name = refIndex
-        var_map = {'type': File,
-                   'value': bamIndex}
-
-        :param wf_declaration_subAST: An AST subtree of a workflow declaration.
-        :return: var_name, which is the name of the declared variable
-        :return: var_map, a dictionary with keys for type and value.
-                          e.g. {'type': File, 'value': bamIndex}
-        '''
-        var_map = OrderedDict()
-        var_name = self.parse_declaration_name(wf_declaration_subAST.attr("name"))
-        var_type = self.parse_declaration_type(wf_declaration_subAST.attr("type"))
-        var_expressn = self.parse_declaration_expressn(wf_declaration_subAST.attr("expression"), es='')
-
-        var_map['name'] = var_name
-        var_map['type'] = var_type
-        var_map['value'] = var_expressn
-
-        return var_name, var_map
-
     def parse_workflow_call_taskname(self, i):
         """
         Required.
@@ -1004,7 +894,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
             raise NotImplementedError
         elif isinstance(i, wdl_parser.AstList):
             for ast in i:
-                declaration_array.append(self.parse_task_declaration(ast))
+                declaration_array.append(self.parse_declaration(ast))
 
         # have not seen this used so raise to check
         if declaration_array:
@@ -1063,7 +953,7 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
         io_map = OrderedDict()
 
         if isinstance(i, wdl_parser.Terminal):
-            return i.source_string # no io mappings; represents just a blank call
+            return i.source_string  # no io mappings; represents just a blank call
         elif isinstance(i, wdl_parser.Ast):
             if i.name == 'CallBody':
                 declarations = self.parse_workflow_call_body_declarations(i.attr("declarations")) # have not seen this used
@@ -1075,15 +965,14 @@ class AnalyzeDraft2WDL(AnalyzeWDL):
 
         return io_map
 
-
     def parse_workflow_call(self, i):
-        '''
+        """
         Parses a WDL workflow call AST subtree to give the variable mappings for
         that particular job/task "call".
 
         :param i: WDL workflow job object
         :return: python dictionary of io mappings for that job call
-        '''
+        """
         task_being_called = self.parse_workflow_call_taskname(i.attr("task"))
         task_alias = self.parse_workflow_call_taskalias(i.attr("alias"))
         io_map = self.parse_workflow_call_body(i.attr("body"))

--- a/src/toil/wdl/versions/v1.py
+++ b/src/toil/wdl/versions/v1.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2020-2021 Regents of the University of California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from toil.wdl.wdl_analysis import AnalyzeWDL
+
+logger = logging.getLogger(__name__)
+
+
+class AnalyzeV1WDL(AnalyzeWDL):
+    """
+    AnalyzeWDL implementation for the 1.0 version.
+    """
+
+    @property
+    def version(self) -> str:
+        return '1.0'
+
+    def analyze(self):
+        """
+        Analyzes the WDL file passed into the constructor and generates the two
+        intermediate data structures: `self.workflows_dictionary` and
+        `self.tasks_dictionary`.
+        """
+        raise NotImplementedError

--- a/src/toil/wdl/wdl_analysis.py
+++ b/src/toil/wdl/wdl_analysis.py
@@ -14,16 +14,14 @@
 import logging
 from collections import OrderedDict
 
-from toil.wdl.wdl_types import (
-    WDLArrayType,
-    WDLBooleanType,
-    WDLFileType,
-    WDLFloatType,
-    WDLIntType,
-    WDLMapType,
-    WDLPairType,
-    WDLStringType
-)
+from toil.wdl.wdl_types import (WDLArrayType,
+                                WDLBooleanType,
+                                WDLFileType,
+                                WDLFloatType,
+                                WDLIntType,
+                                WDLMapType,
+                                WDLPairType,
+                                WDLStringType)
 
 logger = logging.getLogger(__name__)
 

--- a/src/toil/wdl/wdl_analysis.py
+++ b/src/toil/wdl/wdl_analysis.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 UCSC Computational Genomics Lab
+# Copyright (C) 2018-2021 UCSC Computational Genomics Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,17 @@
 # limitations under the License.
 import logging
 from collections import OrderedDict
+
+from toil.wdl.wdl_types import (
+    WDLArrayType,
+    WDLBooleanType,
+    WDLFileType,
+    WDLFloatType,
+    WDLIntType,
+    WDLMapType,
+    WDLPairType,
+    WDLStringType
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +50,8 @@ class AnalyzeWDL:
         # holds workflow structure from WDL workflow objects
         self.workflows_dictionary = OrderedDict()
 
-        # unique iterator to add to cmd names
-        self.command_number = 0
+        # unique iterator to add to declaration names
+        self.declaration_number = 0
 
         # unique iterator to add to call names
         self.call_number = 0
@@ -50,6 +61,13 @@ class AnalyzeWDL:
 
         # unique iterator to add to if names
         self.if_number = 0
+
+    @property
+    def version(self) -> str:
+        """
+        Returns the version of the WDL document as a string.
+        """
+        raise NotImplementedError
 
     def analyze(self):
         """
@@ -66,3 +84,37 @@ class AnalyzeWDL:
         Writes a file with the AST for a wdl file in the out_dir.
         """
         pass
+
+    primitive_types = {
+        'String': WDLStringType,
+        'Int': WDLIntType,
+        'Float': WDLFloatType,
+        'Boolean': WDLBooleanType,
+        'File': WDLFileType
+    }
+
+    compound_types = {
+        'Array': WDLArrayType,
+        'Pair': WDLPairType,
+        'Map': WDLMapType
+    }
+
+    def create_wdl_primitive_type(self, key: str, optional: bool = False):
+        """
+        Returns an instance of WDLType.
+        """
+        type_ = self.primitive_types.get(key)
+        if type_:
+            return type_(optional=optional)
+        else:
+            raise RuntimeError(f'Unsupported primitive type: {key}')
+
+    def create_wdl_compound_type(self, key: str, elements: list, optional: bool = False):
+        """
+        Returns an instance of WDLCompoundType.
+        """
+        type_ = self.compound_types.get(key)
+        if type_:
+            return type_(*elements, optional=optional)
+        else:
+            raise RuntimeError(f'Unsupported compound type: {key}')

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -877,6 +877,9 @@ class SynthesizeWDL:
             if fn_section.endswith(' + '):
                 fn_section = fn_section[:-3]
             fn_section += '\n        cmd = textwrap.dedent(cmd.strip("{nl}"))\n'.format(nl=r"\n")
+        else:
+            # empty command section
+            fn_section += '        cmd = ""'
 
         return fn_section
 

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -563,6 +563,10 @@ class SynthesizeWDL:
                 # reusing write_main_jobwrappers_if() here, but it needs to be indented one more level.
                 fn_section += self.indent_docstring(self.write_main_jobwrappers_if(job['body'][statement]['body']))
 
+        # check for empty scatter section
+        if len(job['body']) == 0:
+            fn_section += '            pass'
+
         for var in scatter_outputs:
             fn_section += '            {var}.append({task}.rv("{output}"))\n'.format(var=var['task'] + '_' + var['output'],
                                                                                      task='job_' + var['task'],

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -305,7 +305,7 @@ class SynthesizeWDL:
     def write_main_jobwrappers_if(self, if_statement):
         # check for empty if statement
         if not if_statement:
-            return self.indent_docstring('        pass')
+            return self.indent('        pass')
 
         main_section = ''
         for assignment in if_statement:
@@ -320,7 +320,7 @@ class SynthesizeWDL:
             if assignment.startswith('if'):
                 main_section += '        if {}:\n'.format(if_statement[assignment]['expression'])
                 main_section += self.write_main_jobwrappers_if(if_statement[assignment]['body'])
-        main_section = self.indent_docstring(main_section)
+        main_section = self.indent(main_section)
         return main_section
 
     def write_main_jobwrappers_scatter(self, task, assignment):
@@ -549,7 +549,7 @@ class SynthesizeWDL:
         for statement in job['body']:
             if statement.startswith('declaration'):
                 # reusing write_main_jobwrappers_declaration() here, but it needs to be indented one more level.
-                fn_section += self.indent_docstring(
+                fn_section += self.indent(
                     self.write_main_jobwrappers_declaration(job['body'][statement]))
             elif statement.startswith('call'):
                 fn_section += self.write_scatter_callwrapper(job['body'][statement], previous_dependency)
@@ -559,7 +559,7 @@ class SynthesizeWDL:
             elif statement.startswith('if'):
                 fn_section += '            if {}:\n'.format(job['body'][statement]['expression'])
                 # reusing write_main_jobwrappers_if() here, but it needs to be indented one more level.
-                fn_section += self.indent_docstring(self.write_main_jobwrappers_if(job['body'][statement]['body']))
+                fn_section += self.indent(self.write_main_jobwrappers_if(job['body'][statement]['body']))
 
         # check for empty scatter section
         if len(job['body']) == 0:
@@ -962,12 +962,12 @@ class SynthesizeWDL:
 
         return fn_section
 
-    def indent_docstring(self, string2indent):
+    def indent(self, string2indent: str) -> str:
+        """
+        Indent the input string by 4 spaces.
+        """
         split_string = string2indent.split('\n')
-        new_string = ''
-        for line in split_string:
-            new_string += '    {}\n'.format(line)
-        return new_string
+        return '\n'.join(f'    {line}' for line in split_string)
 
     def needsdocker(self, job):
         """

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -13,20 +13,23 @@
 # limitations under the License.
 import logging
 import os
+from typing import Optional
 
 from toil.wdl.wdl_functions import heredoc_wdl
-from toil.wdl.wdl_types import (WDLArrayType,
-                                WDLCompoundType,
-                                WDLFileType,
-                                WDLMapType,
-                                WDLPairType,
-                                WDLType)
+from toil.wdl.wdl_types import (
+    WDLArrayType,
+    WDLCompoundType,
+    WDLFileType,
+    WDLMapType,
+    WDLPairType,
+    WDLType
+)
 
 logger = logging.getLogger(__name__)
 
 
 class SynthesizeWDL:
-    '''
+    """
     SynthesizeWDL takes the "workflows_dictionary" and "tasks_dictionary" produced by
     wdl_analysis.py and uses them to write a native python script for use with Toil.
 
@@ -41,16 +44,19 @@ class SynthesizeWDL:
     For example: write the imports, then write all functions defining jobs (which have subsections
     like: write header, define variables, read "File" types into the jobstore, docker call, etc.),
     then write the main and all of its subsections.
-    '''
+    """
 
     def __init__(self,
-                 tasks_dictionary,
-                 workflows_dictionary,
-                 output_directory,
-                 json_dict,
-                 docker_user,
-                 jobstore=None,
-                 destBucket=None):
+                 version: str,
+                 tasks_dictionary: dict,
+                 workflows_dictionary: dict,
+                 output_directory: str,
+                 json_dict: dict,
+                 docker_user: str,
+                 jobstore: Optional[str] = None,
+                 destBucket: Optional[str] = None):
+
+        self.version = version
         self.output_directory = output_directory
         if not os.path.exists(self.output_directory):
             try:
@@ -155,7 +161,7 @@ class SynthesizeWDL:
         return module_string
 
     def write_main(self):
-        '''
+        """
         Writes out a huge string representing the main section of the python
         compiled toil script.
 
@@ -173,18 +179,13 @@ class SynthesizeWDL:
         addChild and encapsulate commands provided by toil.
 
         :return: giant string containing the main def for the toil script.
-        '''
+        """
 
         main_section = ''
 
         # write out the main header
         main_header = self.write_main_header()
         main_section = main_section + main_header
-
-        # write out the workflow declarations
-        main_section = main_section + '        # WF Declarations\n'
-        wf_declarations_to_write = self.write_main_wfdeclarations()
-        main_section = main_section + wf_declarations_to_write
 
         # write toil job wrappers with input vars
         jobs_to_write = self.write_main_jobwrappers()
@@ -206,43 +207,23 @@ class SynthesizeWDL:
             ''', {'jobstore': self.jobstore})
         return main_header
 
-    def write_main_wfdeclarations(self):
-        main_section = ''
-        for wfname, wf in self.workflows_dictionary.items():
-            if 'wf_declarations' in wf:
-                for var, var_expressn in wf['wf_declarations'].items():
-                    var_type = var_expressn['type']
-
-                    # check the json file for the expression's value
-                    # this is a higher priority and overrides anything written in the .wdl
-                    json_expressn = self.json_var(wf=wfname, var=var)
-                    if json_expressn is not None:
-                        var_expressn['value'] = json_expressn
-
-                    main_section += '        {} = {}.create(\n                {})\n'\
-                        .format(var, self.write_declaration_type(var_type), var_expressn['value'])
-
-                    # import filepath into jobstore
-                    if self.needs_file_import(var_type) and var_expressn['value']:
-                        main_section += '        {} = process_infile({}, fileStore)\n'.format(var, var)
-
-        return main_section
-
     def write_main_jobwrappers(self):
-        '''
+        """
         Writes out 'jobs' as wrapped toil objects in preparation for calling.
 
         :return: A string representing this.
-        '''
+        """
         main_section = ''
 
         # toil cannot technically start with multiple jobs, so an empty
         # 'initialize_jobs' function is always called first to get around this
-        main_section = main_section + '\n        job0 = Job.wrapJobFn(initialize_jobs)\n'
+        main_section = main_section + '        job0 = Job.wrapJobFn(initialize_jobs)\n'
 
         # declare each job in main as a wrapped toil function in order of priority
         for wf in self.workflows_dictionary:
             for assignment in self.workflows_dictionary[wf]:
+                if assignment.startswith('declaration'):
+                    main_section += self.write_main_jobwrappers_declaration(self.workflows_dictionary[wf][assignment])
                 if assignment.startswith('call'):
                     main_section += '        job0 = job0.encapsulate()\n'
                     main_section += self.write_main_jobwrappers_call(self.workflows_dictionary[wf][assignment])
@@ -258,12 +239,33 @@ class SynthesizeWDL:
 
         return main_section
 
+    def write_main_jobwrappers_declaration(self, declaration):
+
+        main_section = ''
+        wf = next(iter(self.workflows_dictionary))
+        var_name, var_type, var_expr = declaration
+
+        # check the json file for the expression's value
+        # this is a higher priority and overrides anything written in the .wdl
+        json_expressn = self.json_var(wf=wf, var=var_name)
+        if json_expressn is not None:
+            var_expr = json_expressn
+
+        main_section += '        {} = {}.create(\n                {})\n' \
+            .format(var_name, self.write_declaration_type(var_type), var_expr)
+
+        # import filepath into jobstore
+        if self.needs_file_import(var_type) and var_expr:
+            main_section += '        {} = process_infile({}, fileStore)\n'.format(var_name, var_name)
+
+        return main_section
+
     def write_main_destbucket(self):
-        '''
+        """
         Writes out a loop for exporting outputs to a cloud bucket.
 
         :return: A string representing this.
-        '''
+        """
         main_section = heredoc_wdl('''
             outdir = '{outdir}'
             onlyfiles = [os.path.join(outdir, f) for f in os.listdir(outdir) if os.path.isfile(os.path.join(outdir, f))]
@@ -300,8 +302,14 @@ class SynthesizeWDL:
         return False
 
     def write_main_jobwrappers_if(self, if_statement):
+        # check for empty if statement
+        if not if_statement:
+            return self.indent_docstring('        pass')
+
         main_section = ''
         for assignment in if_statement:
+            if assignment.startswith('declaration'):
+                main_section += self.write_main_jobwrappers_declaration(if_statement[assignment])
             if assignment.startswith('call'):
                 main_section += '        job0 = job0.encapsulate()\n'
                 main_section += self.write_main_jobwrappers_call(if_statement[assignment])
@@ -350,15 +358,14 @@ class SynthesizeWDL:
 
         scatternamespace = []
 
-        for wfname, wf in self.workflows_dictionary.items():
-            if 'wf_declarations' in wf:
-                for var in wf['wf_declarations']:
-                    scatternamespace.append(var)
-
         for wf in self.workflows_dictionary:
             for assignment in self.workflows_dictionary[wf]:
                 if assignment == assigned:
                     return scatternamespace
+                elif assignment.startswith('declaration'):
+                    declaration = self.workflows_dictionary[wf][assignment]
+                    name, _, _ = declaration
+                    scatternamespace.append(name)
                 elif assignment.startswith('call'):
                     if 'outputs' in self.tasks_dictionary[self.workflows_dictionary[wf][assignment]['task']]:
                         for output in self.tasks_dictionary[self.workflows_dictionary[wf][assignment]['task']]['outputs']:
@@ -416,11 +423,11 @@ class SynthesizeWDL:
         return calloutputs
 
     def write_functions(self):
-        '''
+        """
         Writes out a python function for each WDL "task" object.
 
         :return: a giant string containing the meat of the job defs.
-        '''
+        """
 
         # toil cannot technically start with multiple jobs, so an empty
         # 'initialize_jobs' function is always called first to get around this
@@ -449,9 +456,9 @@ class SynthesizeWDL:
         return fn_section
 
     def write_scatterfunction(self, job, scattername):
-        '''
+        """
         Writes out a python function for each WDL "scatter" object.
-        '''
+        """
 
         scatter_outputs = self.fetch_scatter_outputs(job)
 
@@ -540,17 +547,24 @@ class SynthesizeWDL:
 
         previous_dependency = 'self'
         for statement in job['body']:
-            if statement.startswith('call'):
+            if statement.startswith('declaration'):
+                # reusing write_main_jobwrappers_declaration() here, but it needs to be indented one more level.
+                fn_section += self.indent_docstring(
+                    self.write_main_jobwrappers_declaration(job['body'][statement]))
+            elif statement.startswith('call'):
                 fn_section += self.write_scatter_callwrapper(job['body'][statement], previous_dependency)
                 previous_dependency = 'job_' + job['body'][statement]['alias']
-            elif statement.startswith('variable'):
-                fn_section += '            {var} = {expr}\n'.format(var=job['body'][statement]['name'],
-                                                                    expr=job['body'][statement]['value'])
+            elif statement.startswith('scatter'):
+                raise NotImplementedError('nested scatter not implemented.')
+            elif statement.startswith('if'):
+                fn_section += '            if {}:\n'.format(job['body'][statement]['expression'])
+                # reusing write_main_jobwrappers_if() here, but it needs to be indented one more level.
+                fn_section += self.indent_docstring(self.write_main_jobwrappers_if(job['body'][statement]['body']))
 
         for var in scatter_outputs:
             fn_section += '            {var}.append({task}.rv("{output}"))\n'.format(var=var['task'] + '_' + var['output'],
-                                                                                   task='job_' + var['task'],
-                                                                                   output=var['output'])
+                                                                                     task='job_' + var['task'],
+                                                                                     output=var['output'])
         return fn_section
 
     def write_scatter_callwrapper(self, job, previous_dependency):
@@ -564,26 +578,8 @@ class SynthesizeWDL:
         fn_section += '))\n'
         return fn_section
 
-    def fetch_scatter_varwrapper_inputs(self, job, scattername):
-        varwrapper_inputs = self.fetch_scatter_inputs(scattername)
-
-        for wf in self.workflows_dictionary:
-            for assignment in self.workflows_dictionary[wf]:
-                if assignment == scattername:
-                    for scatterassignment in self.workflows_dictionary[wf][assignment]['body']:
-                        if scatterassignment.startswith('variable'):
-                            if job['name'] == self.workflows_dictionary[wf][assignment]['body'][scatterassignment]['name']:
-                                varwrapper_inputs.append(self.workflows_dictionary[wf][assignment]['item'])
-                                return varwrapper_inputs
-                            else:
-                                varwrapper_inputs.append(self.workflows_dictionary[wf][assignment]['body'][scatterassignment]['name'])
-                        if scatterassignment.startswith('call'):
-                            varwrapper_inputs.append(self.workflows_dictionary[wf][assignment]['body'][scatterassignment]['alias'])
-                    varwrapper_inputs.append(self.workflows_dictionary[wf][assignment]['item'])
-        return varwrapper_inputs
-
     def write_function(self, job):
-        '''
+        """
         Writes out a python function for each WDL "task" object.
 
         Each python function is a unit of work written out as a string in
@@ -600,7 +596,7 @@ class SynthesizeWDL:
         7: Write the section returning the outputs.  Also logs stats.
 
         :return: a giant string containing the meat of the job defs for the toil script.
-        '''
+        """
 
         # write the function header
         fn_section = self.write_function_header(job)
@@ -623,7 +619,7 @@ class SynthesizeWDL:
         return fn_section
 
     def write_function_header(self, job):
-        '''
+        """
         Writes the header that starts each function, for example, this function
         can write and return:
 
@@ -633,7 +629,7 @@ class SynthesizeWDL:
                         (job priority #, job ID #, Job Skeleton Name, Job Alias)
         :param job_declaration_array: A list of all inputs that job requires.
         :return: A string representing this.
-        '''
+        """
         fn_section = '\n\nclass {jobname}Cls(Job):\n'.format(jobname=job)
         fn_section += '    def __init__(self, '
         if 'inputs' in self.tasks_dictionary[job]:
@@ -793,14 +789,14 @@ class SynthesizeWDL:
         return section + ')'
 
     def write_function_bashscriptline(self, job):
-        '''
+        """
         Writes a function to create a bashscript for injection into the docker
         container.
 
         :param job_task_reference: The job referenced in WDL's Task section.
         :param job_alias: The actual job name to be written.
         :return: A string writing all of this.
-        '''
+        """
         fn_section = "        generate_docker_bashscript_file(temp_dir=tempDir, docker_dir=tempDir, globs=["
         # TODO: Add glob
         # if 'outputs' in self.tasks_dictionary[job]:
@@ -813,14 +809,14 @@ class SynthesizeWDL:
         return fn_section
 
     def write_function_dockercall(self, job):
-        '''
+        """
         Writes a string containing the apiDockerCall() that will run the job.
 
         :param job_task_reference: The name of the job calling docker.
         :param docker_image: The corresponding name of the docker image.
                                                             e.g. "ubuntu:latest"
         :return: A string containing the apiDockerCall() that will run the job.
-        '''
+        """
         docker_dict = {"docker_image": self.tasks_dictionary[job]['runtime']['docker'],
                        "job_task_reference": job,
                        "docker_user": str(self.docker_user)}
@@ -846,7 +842,7 @@ class SynthesizeWDL:
         return docker_template
 
     def write_function_cmdline(self, job):
-        '''
+        """
         Write a series of commandline variables to be concatenated together
         eventually and either called with subprocess.Popen() or with
         apiDockerCall() if a docker image is called for.
@@ -854,7 +850,7 @@ class SynthesizeWDL:
         :param job: A list such that:
                         (job priority #, job ID #, Job Skeleton Name, Job Alias)
         :return: A string representing this.
-        '''
+        """
 
         fn_section = '\n'
         cmd_array = []
@@ -883,14 +879,14 @@ class SynthesizeWDL:
         return fn_section
 
     def write_function_subprocesspopen(self):
-        '''
+        """
         Write a subprocess.Popen() call for this function and write it out as a
         string.
 
         :param job: A list such that:
                         (job priority #, job ID #, Job Skeleton Name, Job Alias)
         :return: A string representing this.
-        '''
+        """
         fn_section = heredoc_wdl('''
                 this_process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 _toil_wdl_internal__stdout, _toil_wdl_internal__stderr = this_process.communicate()\n''', indent='        ')
@@ -898,7 +894,7 @@ class SynthesizeWDL:
         return fn_section
 
     def write_function_outputreturn(self, job, docker=False):
-        '''
+        """
         Find the output values that this function needs and write them out as a
         string.
 
@@ -906,7 +902,7 @@ class SynthesizeWDL:
                         (job priority #, job ID #, Job Skeleton Name, Job Alias)
         :param job_task_reference: The name of the job to look up values for.
         :return: A string representing this.
-        '''
+        """
 
         fn_section = ''
 
@@ -983,7 +979,7 @@ class SynthesizeWDL:
                           fn_section,
                           main_section,
                           output_file):
-        '''
+        """
         Just takes three strings and writes them to output_file.
 
         :param module_section: A string of 'import modules'.
@@ -991,86 +987,8 @@ class SynthesizeWDL:
         :param main_section: A string declaring toil options and main's header.
         :param job_section: A string import files into toil and declaring jobs.
         :param output_file: The file to write the compiled toil script to.
-        '''
+        """
         with open(output_file, 'w') as file:
             file.write(module_section)
             file.write(fn_section)
             file.write(main_section)
-
-    def write_mappings(self, i):
-        '''
-        Intended to take a ToilWDL_instance (i) and prints the final task dict,
-        and workflow dict.
-
-        Does not work by default with toil since Toil actively suppresses stdout
-        during the run.
-
-        :param i: A class object instance with the following dict variables:
-                                self.tasks_dictionary
-                                self.workflows_dictionary
-        '''
-        from collections import OrderedDict
-
-        class Formatter(object):
-            def __init__(self):
-                self.types = {}
-                self.htchar = '\t'
-                self.lfchar = '\n'
-                self.indent = 0
-                self.set_formater(object, self.__class__.format_object)
-                self.set_formater(dict, self.__class__.format_dict)
-                self.set_formater(list, self.__class__.format_list)
-                self.set_formater(tuple, self.__class__.format_tuple)
-
-            def set_formater(self, obj, callback):
-                self.types[obj] = callback
-
-            def __call__(self, value, **args):
-                for key in args:
-                    setattr(self, key, args[key])
-                formater = self.types[type(value) if type(value) in self.types else object]
-                return formater(self, value, self.indent)
-
-            def format_object(self, value, indent):
-                return repr(value)
-
-            def format_dict(self, value, indent):
-                items = [
-                    self.lfchar + self.htchar * (indent + 1) + repr(key) + ': ' +
-                    (self.types[type(value[key]) if type(value[key]) in self.types else object])(self, value[key], indent + 1)
-                    for key in value]
-                return '{%s}' % (','.join(items) + self.lfchar + self.htchar * indent)
-
-            def format_list(self, value, indent):
-                items = [
-                    self.lfchar + self.htchar * (indent + 1) + (
-                    self.types[type(item) if type(item) in self.types else object])(self, item, indent + 1)
-                    for item in value]
-                return '[%s]' % (','.join(items) + self.lfchar + self.htchar * indent)
-
-            def format_tuple(self, value, indent):
-                items = [
-                    self.lfchar + self.htchar * (indent + 1) + (
-                    self.types[type(item) if type(item) in self.types else object])(self, item, indent + 1)
-                    for item in value]
-                return '(%s)' % (','.join(items) + self.lfchar + self.htchar * indent)
-
-        pretty = Formatter()
-
-        def format_ordereddict(self, value, indent):
-            items = [
-                self.lfchar + self.htchar * (indent + 1) +
-                "(" + repr(key) + ', ' + (self.types[
-                    type(value[key]) if type(value[key]) in self.types else object
-                ])(self, value[key], indent + 1) + ")"
-                for key in value
-            ]
-            return 'OrderedDict([%s])' % (','.join(items) +
-                                          self.lfchar + self.htchar * indent)
-
-        pretty.set_formater(OrderedDict, format_ordereddict)
-
-        with open('mappings.out', 'w') as f:
-            f.write(pretty(i.tasks_dictionary))
-            f.write('\n\n\n\n\n\n')
-            f.write(pretty(i.workflows_dictionary))

--- a/src/toil/wdl/wdl_synthesis.py
+++ b/src/toil/wdl/wdl_synthesis.py
@@ -16,14 +16,12 @@ import os
 from typing import Optional
 
 from toil.wdl.wdl_functions import heredoc_wdl
-from toil.wdl.wdl_types import (
-    WDLArrayType,
-    WDLCompoundType,
-    WDLFileType,
-    WDLMapType,
-    WDLPairType,
-    WDLType
-)
+from toil.wdl.wdl_types import (WDLArrayType,
+                                WDLCompoundType,
+                                WDLFileType,
+                                WDLMapType,
+                                WDLPairType,
+                                WDLType)
 
 logger = logging.getLogger(__name__)
 

--- a/src/toil/wdl/wdl_types.py
+++ b/src/toil/wdl/wdl_types.py
@@ -47,6 +47,9 @@ class WDLType:
             else:
                 raise WDLRuntimeError(f"Required input for '{self.name}' type not specified.")
 
+        if isinstance(value, Promise):
+            return value
+
         return self._create(value)
 
     def _create(self, value: Any) -> Any:


### PR DESCRIPTION
A few internal structural changes to `self.workflows_dictionary` in AnalyzeWDL to make integration with the other versions easier. In preparation for #3384.

Summary
* draft-2 implementation changes
  - Use `parse_declaration()` and return a `tuple=(name, type, expr)` for both workflow and task declarations
  - Use the same `parse_workflow_body()` function to parse all inner workflow elements (declarations, calls, scatters, and conditionals) 
    * declarations are treated the same as calls, scatters, and conditionals instead of declaring them at the top, so the order will be preserved in cases like [this example workflow](https://github.com/openwdl/wdl/blob/main/versions/draft-2/SPEC.md#declarations):
```wdl
workflow wf {
  call test as x {input: var="x"}
  call test as y {input: var="y"}
  Array[String] strs = [x.value, y.value]  # declaration should come after the calls in this case
  call test2 as z {input: array=strs}
}
```

* Add `get_analyzer()` function to detect WDL version and return the correct AnalyzeWDL instance
* Misc
  - Some docstring/import formatting
  - Move `write_mappings()` to `wdl/utils.py`
  - Handle cases where `if`, `scatter`, or `command` sections are empty


## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Internal update to the dictionary structures in AnalyzeWDL
