### PR TITLE
Check google storage import as evidence of google extras installed.

### DIFF
--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -310,7 +310,7 @@ def needs_google(test_item):
     """Use as a decorator before test classes or methods to run only if Google is usable."""
     test_item = _mark_test('google', test_item)
     try:
-        from boto import config
+        from google.cloud import storage
     except ImportError:
         return unittest.skip("Install Toil with the 'google' extra to include this test.")(test_item)
 


### PR DESCRIPTION
I'm not sure why we were checking boto for our tests.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Better Google check when testing.
