### PR TITLE
Allow setOptions to accept an argparse group.

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -337,7 +337,7 @@ def parser_with_common_options(provisioner_options=False, jobstore_option=True):
 
 def addOptions(parser: ArgumentParser, config: Config = Config()):
     if not (isinstance(parser, ArgumentParser) or isinstance(parser, _ArgumentGroup)):
-        raise ValueError(f"Unanticipated class: {parser.__class__}.  Must be: argparse.ArgumentParser.")
+        raise ValueError(f"Unanticipated class: {parser.__class__}.  Must be: argparse.ArgumentParser or ArgumentGroup.")
 
     add_logging_options(parser)
     parser.register("type", "bool", parseBool)  # Custom type for arg=True/False.

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -336,7 +336,7 @@ def parser_with_common_options(provisioner_options=False, jobstore_option=True):
 
 
 def addOptions(parser: ArgumentParser, config: Config = Config()):
-    if not isinstance(parser, ArgumentParser) or not isinstance(parser, _ArgumentGroup):
+    if not (isinstance(parser, ArgumentParser) or isinstance(parser, _ArgumentGroup)):
         raise ValueError(f"Unanticipated class: {parser.__class__}.  Must be: argparse.ArgumentParser.")
 
     add_logging_options(parser)

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -22,7 +22,7 @@ import tempfile
 import time
 import uuid
 
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from argparse import _ArgumentGroup, ArgumentParser, ArgumentDefaultsHelpFormatter
 from typing import Optional, Callable, Any, List
 
 from toil import logProcessContext, lookupEnvVar
@@ -336,7 +336,7 @@ def parser_with_common_options(provisioner_options=False, jobstore_option=True):
 
 
 def addOptions(parser: ArgumentParser, config: Config = Config()):
-    if not isinstance(parser, ArgumentParser):
+    if not isinstance(parser, ArgumentParser) or not isinstance(parser, _ArgumentGroup):
         raise ValueError(f"Unanticipated class: {parser.__class__}.  Must be: argparse.ArgumentParser.")
 
     add_logging_options(parser)


### PR DESCRIPTION
Resolves #1632.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Allow setOptions to accept argparse groups.

