### PR TITLE
Add basic WDL development support

### DIFF
--- a/src/toil/wdl/versions/dev.py
+++ b/src/toil/wdl/versions/dev.py
@@ -17,6 +17,7 @@ from wdlparse.dev.WdlLexer import WdlLexer, FileStream
 from wdlparse.dev.WdlParser import WdlParser, CommonTokenStream
 
 from toil.wdl.versions.v1 import AnalyzeV1WDL, is_context
+from toil.wdl.wdl_types import WDLType
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class AnalyzeDevelopmentWDL(AnalyzeV1WDL):  # extend from 1.0
         tree = parser.document()
         self.visit_document(tree)
 
-    def visit_document(self, ctx):
+    def visit_document(self, ctx: WdlParser.DocumentContext) -> None:
         """
         Similar to version 1.0, except the 'workflow' element is included in
         `ctx.document_element()`.
@@ -52,18 +53,18 @@ class AnalyzeDevelopmentWDL(AnalyzeV1WDL):  # extend from 1.0
         for element in ctx.document_element():
             self.visit_document_element(element)
 
-    def visit_document_element(self, ctx):
+    def visit_document_element(self, ctx: WdlParser.Document_elementContext) -> None:
         """
         Similar to version 1.0, except this also contains 'workflow'.
         """
         element = ctx.children[0]
         if is_context(element, 'WorkflowContext'):
-            return self.visit_workflow(element)
+            self.visit_workflow(element)
         else:
             # let super take care of the rest.
-            return super(AnalyzeDevelopmentWDL, self).visit_document_element(ctx)
+            super(AnalyzeDevelopmentWDL, self).visit_document_element(ctx)
 
-    def visit_call(self, ctx):
+    def visit_call(self, ctx: WdlParser.CallContext) -> dict:
         """
         Similar to version 1.0, except `ctx.call_afters()` is added.
         """
@@ -71,7 +72,7 @@ class AnalyzeDevelopmentWDL(AnalyzeV1WDL):  # extend from 1.0
         # See: https://github.com/openwdl/wdl/blob/main/versions/development/SPEC.md#call-statement
         return super(AnalyzeDevelopmentWDL, self).visit_call(ctx)
 
-    def visit_string_expr_part(self, ctx):
+    def visit_string_expr_part(self, ctx: WdlParser.String_expr_partContext) -> str:
         """
         Similar to version 1.0, except `ctx.expression_placeholder_option()`
         is removed.
@@ -81,7 +82,7 @@ class AnalyzeDevelopmentWDL(AnalyzeV1WDL):  # extend from 1.0
 
         return self.visit_expr(ctx.expr())
 
-    def visit_wdl_type(self, ctx):
+    def visit_wdl_type(self, ctx: WdlParser.Wdl_typeContext) -> WDLType:
         """
         Similar to version 1.0, except Directory type is added.
         """
@@ -94,7 +95,7 @@ class AnalyzeDevelopmentWDL(AnalyzeV1WDL):  # extend from 1.0
             # let super take care of the rest.
             return super(AnalyzeDevelopmentWDL, self).visit_wdl_type(ctx)
 
-    def visit_expr_core(self, expr):
+    def visit_expr_core(self, expr: WdlParser.Expr_coreContext) -> str:
         """
         Similar to version 1.0, except struct literal is added.
         """

--- a/src/toil/wdl/versions/dev.py
+++ b/src/toil/wdl/versions/dev.py
@@ -57,12 +57,50 @@ class AnalyzeDevelopmentWDL(AnalyzeV1WDL):  # extend from 1.0
         Similar to version 1.0, except this also contains 'workflow'.
         """
         element = ctx.children[0]
-
-        # workflow
         if is_context(element, 'WorkflowContext'):
             return self.visit_workflow(element)
         else:
-            # hand the rest to super.
+            # let super take care of the rest.
             return super(AnalyzeDevelopmentWDL, self).visit_document_element(ctx)
 
-    # TODO: implement the rest of the changes since WDL 1.0.
+    def visit_call(self, ctx):
+        """
+        Similar to version 1.0, except `ctx.call_afters()` is added.
+        """
+        # TODO: implement call_afters
+        # See: https://github.com/openwdl/wdl/blob/main/versions/development/SPEC.md#call-statement
+        return super(AnalyzeDevelopmentWDL, self).visit_call(ctx)
+
+    def visit_string_expr_part(self, ctx):
+        """
+        Similar to version 1.0, except `ctx.expression_placeholder_option()`
+        is removed.
+        """
+        # expression placeholder options are removed in development
+        # See: https://github.com/openwdl/wdl/blob/main/versions/development/parsers/antlr4/WdlParser.g4#L55
+
+        return self.visit_expr(ctx.expr())
+
+    def visit_wdl_type(self, ctx):
+        """
+        Similar to version 1.0, except Directory type is added.
+        """
+        identifier = ctx.type_base().children[0]
+
+        if identifier == 'Directory':
+            # TODO: implement Directory type
+            raise NotImplementedError('Directory type is not implemented.')
+        else:
+            # let super take care of the rest.
+            return super(AnalyzeDevelopmentWDL, self).visit_wdl_type(ctx)
+
+    def visit_expr_core(self, expr):
+        """
+        Similar to version 1.0, except struct literal is added.
+        """
+        if is_context(expr, 'Struct_literalContext'):
+            # TODO: implement struct literal
+            raise NotImplementedError(f'WDL struct is not implemented.')
+        else:
+            # let super take care of the rest.
+            return super(AnalyzeDevelopmentWDL, self).visit_expr_core(expr)

--- a/src/toil/wdl/versions/v1.py
+++ b/src/toil/wdl/versions/v1.py
@@ -23,7 +23,7 @@ from toil.wdl.wdl_analysis import AnalyzeWDL
 logger = logging.getLogger(__name__)
 
 
-def is_context(ctx, classname: Union[str, tuple]):
+def is_context(ctx, classname: Union[str, tuple]) -> bool:
     """
     Returns whether an ANTLR4 context object is of the precise type `classname`.
 

--- a/src/toil/wdl/versions/v1.py
+++ b/src/toil/wdl/versions/v1.py
@@ -27,9 +27,12 @@ def is_context(ctx, classname: Union[str, tuple]):
     """
     Returns whether an ANTLR4 context object is of the precise type `classname`.
 
-    If a tuple is provided as classname, this returns True if the context object
-    matches one of the string class names.
+    :param ctx: An ANTLR4 context object.
+    :param classname: The class name(s) as a string or a tuple of strings. If a
+                      tuple is provided, this returns True if the context object
+                      matches one of the class names.
     """
+    # we check for `ctx.__class__.__name__` so that it's portable across multiple similar auto-generated parsers.
     if isinstance(classname, str):
         return ctx.__class__.__name__ == classname
     return ctx.__class__.__name__ in classname


### PR DESCRIPTION
This can probably close #3384, but we still need to implement the following to fully support the development version of WDL: 

- [Import statements](https://github.com/openwdl/wdl/blob/main/versions/development/SPEC.md#import-statements)
- [Directory type](https://github.com/openwdl/wdl/blob/main/versions/development/SPEC.md#types)
- [Structs](https://github.com/openwdl/wdl/blob/main/versions/development/SPEC.md#struct-definition)
- [`after` keyword in call statements](https://github.com/openwdl/wdl/blob/main/versions/development/SPEC.md#call-statement)

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Add basic WDL development support.
