### PR TITLE
Ensure that python3 and not python (2) is used

### DIFF
--- a/src/toil/test/utils/toilDebugTest.py
+++ b/src/toil/test/utils/toilDebugTest.py
@@ -19,7 +19,7 @@ import unittest
 
 from toil.test import ToilTest, slow, travis_test
 from toil.utils.toilDebugFile import recursiveGlob
-
+from toil.version import python
 logger = logging.getLogger(__name__)
 
 class ToilDebugFileTest(ToilTest):
@@ -27,7 +27,7 @@ class ToilDebugFileTest(ToilTest):
 
     def setUp(self):
         """Initial set up of variables for the test."""
-        subprocess.check_call(['python', os.path.abspath('src/toil/test/utils/ABCWorkflowDebug/debugWorkflow.py')])
+        subprocess.check_call([python, os.path.abspath('src/toil/test/utils/ABCWorkflowDebug/debugWorkflow.py')])
         self.jobStoreDir = os.path.abspath('toilWorkflowRun')
         self.tempDir = self._createTempDir(purpose='tempDir')
         self.outputDir = os.path.abspath('testoutput')
@@ -54,7 +54,7 @@ class ToilDebugFileTest(ToilTest):
 
         contents = ['A.txt', 'B.txt', 'C.txt', 'ABC.txt', 'mkFile.py']
 
-        subprocess.check_call(['python', os.path.abspath('src/toil/utils/toilDebugFile.py'), self.jobStoreDir, '--listFilesInJobStore=True'])
+        subprocess.check_call([python, os.path.abspath('src/toil/utils/toilDebugFile.py'), self.jobStoreDir, '--listFilesInJobStore=True'])
         jobstoreFileContents = os.path.abspath('jobstore_files.txt')
         files = []
         match = 0
@@ -95,7 +95,7 @@ class ToilDebugFileTest(ToilTest):
         then delete them.
         """
         contents = ['A.txt', 'B.txt', 'C.txt', 'ABC.txt', 'mkFile.py']
-        cmd = ['python', os.path.abspath('src/toil/utils/toilDebugFile.py'),
+        cmd = [python, os.path.abspath('src/toil/utils/toilDebugFile.py'),
                self.jobStoreDir,
                '--fetch', '*A.txt', '*B.txt', '*C.txt', '*ABC.txt', '*mkFile.py',
                '--localFilePath=' + self.outputDir,


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * src/toil/test/utils/toilDebugTest.py no longer assumes that there is a executable named `python`; fixes tests for systems without Python2 (like the upcoming 'Bullseye' release of Debian, which does not install Python2 by default)

