### PR TITLE
cope with an invalid HTTP_PROXY

### DIFF
--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -37,6 +37,10 @@ from toil.lib.retry import ErrorCondition, retry
 
 logger = logging.getLogger(__name__)
 
+try:
+    from botocore.exceptions import ProxyConnectionError
+except ImportError:
+    ProxyConnectionError = None
 
 class InvalidImportExportUrlException(Exception):
     def __init__(self, url):
@@ -243,7 +247,7 @@ class AbstractJobStore(ABC):
             from importlib import import_module
             try:
                 module = import_module(moduleName)
-            except ImportError:
+            except (ImportError, ProxyConnectionError):
                 logger.debug("Unable to import '%s' as is expected if the corresponding extra was "
                              "omitted at installation time.", moduleName)
             else:


### PR DESCRIPTION
Debian purposely sets an invalid HTTP_PROXY during some build situations

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Improve the tests ability to cope with an invalid HTTP_PROXY

