### PR TITLE
Quality of life improvements for cactus.

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -411,10 +411,12 @@ def addOptions(parser: ArgumentParser, config: Config = Config()):
                     "as well as parameters to control the level of provisioning."
     )
     provisioner_choices = ['aws', 'gce', None]
-    # TODO: Better consolidate this provisioner arg and the one in toil/__init__.py?
+    # TODO: Better consolidate this provisioner arg and the one in provisioners/__init__.py?
     autoscaling_options.add_argument('--provisioner', '-p', dest="provisioner", choices=provisioner_choices,
-                                     help=f"The provisioner for cluster auto-scaling. The currently supported choices "
-                                          f"are {provisioner_choices}.  The default is {config.provisioner}.")
+                                     help=f"The provisioner for cluster auto-scaling.  This is the main Toil "
+                                          f"'--provisioner' option, and defaults to None for running on single "
+                                          f"machine and non-auto-scaling batch systems.  The currently supported "
+                                          f"choices are {provisioner_choices}.  The default is {config.provisioner}.")
     autoscaling_options.add_argument('--nodeTypes', default=None,
                                      help="List of worker node types separated by commas. The syntax for each node "
                                           "type depends on the provisioner used.  For the AWS provisioner this is the "

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -410,7 +410,8 @@ def addOptions(parser: ArgumentParser, config: Config = Config()):
         description="Allows the specification of the minimum and maximum number of nodes in an autoscaled cluster, "
                     "as well as parameters to control the level of provisioning."
     )
-    provisioner_choices = ['aws', 'gce']
+    provisioner_choices = ['aws', 'gce', None]
+    # TODO: Better consolidate this provisioner arg and the one in toil/__init__.py?
     autoscaling_options.add_argument('--provisioner', '-p', dest="provisioner", choices=provisioner_choices,
                                      help=f"The provisioner for cluster auto-scaling. The currently supported choices "
                                           f"are {provisioner_choices}.  The default is {config.provisioner}.")

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -564,12 +564,11 @@ class Leader(object):
         except KeyError:
             logger.warning("A result seems to already have been processed for job %s", jobID)
         else:
-            if exitStatus == 0 and exitReason == None:
-                cur_logger = (logger.debug if str(updatedJob.jobName).startswith(CWL_INTERNAL_JOBS)
-                              else logger.info)
-                cur_logger('Job ended: %s', updatedJob)
+            if exitStatus == 0:
+                logger.debug('Job ended: %s', updatedJob)
             else:
-                logger.warning(f'Job failed with exit value {exitStatus}: {updatedJob}')
+                logger.warning(f'Job failed with exit value {exitStatus}: {updatedJob}\n'
+                               f'Exit reason: {exitReason}')
             if self.toilMetrics:
                 self.toilMetrics.logCompletedJob(updatedJob)
             self.processFinishedJob(jobID, exitStatus, wallTime=wallTime, exitReason=exitReason)

--- a/src/toil/provisioners/__init__.py
+++ b/src/toil/provisioners/__init__.py
@@ -55,8 +55,9 @@ def add_provisioner_options(parser):
     provisioner_choices = ['aws', 'gce']
     # TODO: Better consolidate this provisioner arg and the one in common.py?
     group.add_argument('--provisioner', '-p', dest="provisioner", choices=provisioner_choices, default='aws',
-                       help=f"The provisioner for cluster auto-scaling. The currently supported choices "
-                            f"are {provisioner_choices}.  The default is: %(default)s.")
+                       help=f"The provisioner for cluster auto-scaling.  This is the '--provisioner' option set for "
+                            f"Toil utils like launch-cluster and destroy-cluster, which always require a provisioner, "
+                            f"and so this defaults to: %(default)s.  Choices: {provisioner_choices}.")
     group.add_argument('-z', '--zone', dest='zone', required=False, default=None,
                        help="The availability zone of the master. This parameter can also be set via the 'TOIL_X_ZONE' "
                             "environment variable, where X is AWS or GCE, or by the ec2_region_name parameter "

--- a/src/toil/provisioners/__init__.py
+++ b/src/toil/provisioners/__init__.py
@@ -52,10 +52,11 @@ def cluster_factory(provisioner, clusterName=None, clusterType='mesos', zone=Non
 def add_provisioner_options(parser):
     group = parser.add_argument_group("Provisioner Options.")
 
-    # TODO: Duplicate "--provisioner" argument in common.py; consolidate
-    group.add_argument('-p', '--provisioner', dest='provisioner', choices=['aws', 'gce'],
-                help=f"The provisioner for cluster auto-scaling. The currently supported choices are"
-                     f"'gce', or 'aws'.")
+    provisioner_choices = ['aws', 'gce']
+    # TODO: Better consolidate this provisioner arg and the one in common.py?
+    group.add_argument('--provisioner', '-p', dest="provisioner", choices=provisioner_choices, default='aws',
+                       help=f"The provisioner for cluster auto-scaling. The currently supported choices "
+                            f"are {provisioner_choices}.  The default is: %(default)s.")
     group.add_argument('-z', '--zone', dest='zone', required=False, default=None,
                        help="The availability zone of the master. This parameter can also be set via the 'TOIL_X_ZONE' "
                             "environment variable, where X is AWS or GCE, or by the ec2_region_name parameter "


### PR DESCRIPTION
This should fix #3414 for cactus.

There are two `--provisioner` args, unfortunately.  One is used with our utils like `launch-cluster` and `destroy-cluster` and should default to `aws`, whereas the the other is the main toil arg, and should default to `None` for single machine.  We should probably consolidate these to do the Right Thing when it detects `single_machine`, etc. but that might involve a larger refactor of how all of our options are set, so this is a lighter weight fix to restore old behavior.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Restore `--provisioner` to not error when unset ("Error: None is not a valid choice").
 * Stop printing that jobs have failed when they exit with a `0`.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [x] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [x] Read through the code changes. Make sure that it doesn't have:
    * [x] Addition of trailing whitespace.
    * [x] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [x] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [x] New functions or classes without informative docstrings.
    * [x] Changes to semantics not reflected in the relevant docstrings.
    * [x] New or changed command line options for Toil workflows that are not reflected in `docs/running/cliOptions.rst`
    * [x] New features without tests.
* [x] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [x] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

