### PR TITLE
Run make docs step in gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,8 +44,8 @@ lint:
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make docs
     - make mypy
+    - make docs
 
 
 # Python3.6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,11 +33,19 @@ after_script:
   - stopdocker || true
 
 stages:
+
+  - docs
   - linting
   - basic_tests
   - main_tests
   - integration
 
+doc:
+  stage: docs
+  script:
+    - pwd
+    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make docs
 
 lint:
   stage: linting

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,6 @@ after_script:
   - stopdocker || true
 
 stages:
-
   - docs
   - linting
   - basic_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ stages:
   - main_tests
   - integration
 
+
 lint:
   stage: linting
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,24 +33,17 @@ after_script:
   - stopdocker || true
 
 stages:
-  - docs
   - linting
   - basic_tests
   - main_tests
   - integration
-
-doc:
-  stage: docs
-  script:
-    - pwd
-    - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
-    - make docs
 
 lint:
   stage: linting
   script:
     - pwd
     - virtualenv -p python3.6 venv && . venv/bin/activate && make prepare && make develop extras=[all] && pip install htcondor
+    - make docs
     - make mypy
 
 


### PR DESCRIPTION
Closes #3431.

This PR adds a step in gitlab-ci.yml that runs make docs to ensure that the docs don't break.