### PR TITLE
Replace mentions of CoreOS with flatcar

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -26,7 +26,7 @@ export TOIL_APPLIANCE_SELF?=$(TOIL_DOCKER_REGISTRY)/$(TOIL_DOCKER_NAME):$(TOIL_D
 export TOIL_AWS_ZONE?=us-west-2a
 export TOIL_AWS_NODE_DEBUG?=False  # Don't shut down EC2 instances that fail so that they can be debugged
 
-# TOIL_AWS_AMI=''  # ID of the (normally CoreOS) AMI to use in node provisioning.  Defaults to latest.
+# TOIL_AWS_AMI=''  # ID of the Flatcar AMI to use in node provisioning.  Defaults to latest.
 
 #######################
 ### KUBERNETES ONLY ###

--- a/docs/running/cloud/amazon.rst
+++ b/docs/running/cloud/amazon.rst
@@ -28,8 +28,6 @@ during the computation of a workflow, first set up and configure an account with
 
 #. If necessary, create and activate an `AWS account`_
 
-#. Only needed once, but AWS requires that users "subscribe" to use the `Container Linux by CoreOS AMI`_.  You will encounter errors if this is not done.
-
 #. Next, generate a key pair for AWS with the command (do NOT generate your key pair with the Amazon browser): ::
 
     $ ssh-keygen -t rsa

--- a/docs/running/cloud/amazon.rst
+++ b/docs/running/cloud/amazon.rst
@@ -113,7 +113,6 @@ To further break down each of these commands:
 
     **--keyPairName id_rsa** --- The name of your key pair, which should be "id_rsa" if you've followed this tutorial.
 
-.. _Container Linux by CoreOS AMI: https://aws.amazon.com/marketplace/pp/B01H62FDJM/
 .. _AWS account: https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/
 .. _key pair: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 .. _Amazon's instructions : http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -867,7 +867,7 @@ class AbstractProvisioner(ABC):
             chown $(id -u):$(id -g) $HOME/.kube/config
 
             # Install network
-            kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/{FLANNEL_VERSION}/Documentation/kube-flannel.yml
+            kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/{FLANNEL_VERSION}/Documentation/kube-flannel.yml
 
             # Deploy rubber stamp CSR signing bot
             kubectl apply -f https://raw.githubusercontent.com/kontena/kubelet-rubber-stamp/release/{RUBBER_STAMP_VERSION}/deploy/service_account.yaml

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -566,8 +566,7 @@ class AWSProvisioner(AbstractProvisioner):
     @memoize
     def _discoverAMI(self) -> str:
         """
-        :return: The AMI ID (a string like 'ami-0a9a5d2b65cce04eb') for CoreOS
-                 or a compatible replacement like Flatcar.
+        :return: The AMI ID (a string like 'ami-0a9a5d2b65cce04eb') for Flatcar.
         :rtype: str
         """
 
@@ -576,9 +575,7 @@ class AWSProvisioner(AbstractProvisioner):
         if ami is not None:
             return ami
 
-        # CoreOS is dead, long live Flatcar
-
-        # Flatcar images, however, only live for 9 months.
+        # Flatcar images only live for 9 months.
         # Rather than hardcode a list of AMIs by region that will die, we use
         # their JSON feed of the current ones.
         JSON_FEED_URL = 'https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_ami_all.json'


### PR DESCRIPTION
Closes #3435.

Removed mentions of CoreOS in the docs and in comments.

Migrated to Container Linux Config for provisioning since cloud-config is deprecated.