### PR TITLE
Migrate cloud-config to ignition

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -458,7 +458,7 @@ class AWSProvisioner(AbstractProvisioner):
         bdm = self._getBoto2BlockDeviceMapping(instanceType, rootVolSize=self._nodeStorageOverrides.get(nodeType, self._nodeStorage))
 
         keyPath = self._sseKey if self._sseKey else None
-        userData = self._getCloudConfigUserData('worker', keyPath, preemptable)
+        userData = self._getIgnitionConfigUserData('worker', keyPath, preemptable)
         if isinstance(userData, str):
             # Spot-market provisioning requires bytes for user data.
             userData = userData.encode('utf-8')
@@ -929,7 +929,7 @@ class AWSProvisioner(AbstractProvisioner):
         bdms = self._getBoto3BlockDeviceMappings(instanceType, rootVolSize=rootVolSize)
 
         keyPath = self._sseKey if self._sseKey else None
-        userData = self._getCloudConfigUserData('worker', keyPath, preemptable)
+        userData = self._getIgnitionConfigUserData('worker', keyPath, preemptable)
 
         # The name has the cluster name in it
         lt_name = f'{self.clusterName}-lt-{nodeType}'

--- a/src/toil/provisioners/gceProvisioner.py
+++ b/src/toil/provisioners/gceProvisioner.py
@@ -139,7 +139,7 @@ class GCEProvisioner(AbstractProvisioner):
             tags.update(kwargs['userTags'])
         self._tags = json.dumps(tags)
 
-        metadata = {'items': [{'key': 'user-data', 'value': self._getCloudConfigUserData('leader')}]}
+        metadata = {'items': [{'key': 'user-data', 'value': self._getIgnitionConfigUserData('leader')}]}
         imageType = 'flatcar-stable'
         sa_scopes = [{'scopes': ['compute', 'storage-full']}]
         disk = {}
@@ -252,7 +252,7 @@ class GCEProvisioner(AbstractProvisioner):
             logger.debug('Launching %s preemptable nodes', numNodes)
 
         #kwargs["subnet_id"] = self.subnetID if self.subnetID else self._getClusterInstance(self.instanceMetaData).subnet_id
-        userData =  self._getCloudConfigUserData('worker', keyPath, preemptable)
+        userData =  self._getIgnitionConfigUserData('worker', keyPath, preemptable)
         metadata = {'items': [{'key': 'user-data', 'value': userData}]}
         imageType = 'flatcar-stable'
         sa_scopes = [{'scopes': ['compute', 'storage-full']}]


### PR DESCRIPTION
The cloud-config should be migrated over to Ignition as per documentation: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/ignition/

The documentation recommends starting with a Container Linux Config and converting it over to Ignition using a config transpiler: 
https://github.com/kinvolk/container-linux-config-transpiler/
https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/

However, the benefits of doing so don't apply as much to our situation so I want to attempt directly using Ignition.