### PR TITLE
AWS: Handle socket timeout during AWS discovery

### DIFF
--- a/src/toil/provisioners/aws/__init__.py
+++ b/src/toil/provisioners/aws/__init__.py
@@ -14,6 +14,7 @@
 import datetime
 import logging
 import os
+import socket
 from collections import namedtuple
 from operator import attrgetter
 from statistics import mean, stdev
@@ -40,7 +41,7 @@ def running_on_ec2():
     try:
         urlopen('http://169.254.169.254/latest/dynamic/instance-identity/document', timeout=1)
         return True
-    except URLError:
+    except (URLError, socket.timeout):
         return False
 
 def get_current_aws_region():


### PR DESCRIPTION
If a proxy is configured, but the proxy can't connect to the
target host, the request times out with socket.timeout instead
of failing with URLError.

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/toil/test/batchSystems/batchSystemTest.py", line 360, in <module>
    class KubernetesBatchSystemTest(hidden.AbstractBatchSystemTest):
  File "/usr/lib/python3/dist-packages/toil/test/__init__.py", line 286, in needs_aws_s3
    if not (boto_credentials or os.path.exists(os.path.expanduser('~/.aws/credentials')) or running_on_ec2()):
  File "/usr/lib/python3/dist-packages/toil/provisioners/aws/__init__.py", line 39, in running_on_ec2
    urlopen('http://169.254.169.254/latest/dynamic/instance-identity/document', timeout=1)
  File "/usr/lib/python3.9/urllib/request.py", line 214, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.9/urllib/request.py", line 517, in open
    response = self._open(req, data)
  File "/usr/lib/python3.9/urllib/request.py", line 534, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.9/urllib/request.py", line 1375, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.9/urllib/request.py", line 1350, in do_open
    r = h.getresponse()
  File "/usr/lib/python3.9/http/client.py", line 1347, in getresponse
    response.begin()
  File "/usr/lib/python3.9/http/client.py", line 307, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.9/http/client.py", line 268, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib/python3.9/socket.py", line 704, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * AWS: Handle socket timeout during AWS discovery
 * 
## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [x] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [x] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [x] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [x] Read through the code changes. Make sure that it doesn't have:
    * [x] Addition of trailing whitespace.
    * [x] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [x] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [x] New functions or classes without informative docstrings.
    * [x] Changes to semantics not reflected in the relevant docstrings.
    * [x] New or changed command line options for Toil workflows that are not reflected in `docs/running/cliOptions.rst`
    * [x] New features without tests.
* [x] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [x] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

