### PR TITLE
Revert "Add Owner tags to our AWS buckets when testing."

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,6 @@ image: quay.io/vgteam/vg_ci_prebake:latest
 variables:
   PYTHONIOENCODING: "utf-8"
   DEBIAN_FRONTEND: "noninteractive"
-  TOIL_OWNER_TAG: "shared"
 
 before_script:
   # Configure Docker to use a mirror for Docker Hub and restart the daemon

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,8 @@ clean_sdist:
 	- rm src/toil/version.py
 
 # We always claim to be Travis, so that local test runs will not skip Travis tests.
-# Setting SET_OWNER_TAG will tag cloud resources so that UCSC's cloud murder bot won't kill them.
 test: check_venv check_build_reqs
-	TRAVIS=true TOIL_OWNER_TAG="shared" \
+	TRAVIS=true \
 	    python -m pytest --durations=0 --log-level DEBUG --log-cli-level INFO -r s $(cov) $(tests)
 
 

--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -165,11 +165,6 @@ There are several environment variables that affect the way Toil runs.
 |                                  | to S3 (``True`` by default).                       |
 |                                  | Example: ``TOIL_S3_USE_SSL=False``                 |
 +----------------------------------+----------------------------------------------------+
-| TOIL_OWNER_TAG                   | This will tag cloud resources with a tag reading:  |
-|                                  | "Owner: $TOIL_OWNER_TAG".  Currently only on AWS   |
-|                                  | buckets, this is an internal UCSC flag to stop a   |
-|                                  | bot we have that terminates untagged resources.    |
-+----------------------------------+----------------------------------------------------+
 | SINGULARITY_DOCKER_HUB_MIRROR    | An http or https URL for the Singularity wrapper   |
 |                                  | in the Toil Docker container to use as a mirror    |
 |                                  | for Docker Hub.                                    |

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -746,7 +746,7 @@ class AWSJobStore(AbstractJobStore):
                             bucket = self.s3_resource.create_bucket(
                                 Bucket=bucket_name,
                                 CreateBucketConfiguration={'LocationConstraint': location})
-                            # Wait until the bucket exists before checking the region and adding tags
+                            # Wait until the bucket exists before checking the region
                             bucket.wait_until_exists()
 
                             # It is possible for create_bucket to return but
@@ -755,11 +755,6 @@ class AWSJobStore(AbstractJobStore):
                             # NoSuchBucket. We let that kick us back up to the
                             # main retry loop.
                             assert self.getBucketRegion(bucket_name) == self.region
-
-                            owner_tag = os.environ.get('TOIL_OWNER_TAG')
-                            if owner_tag:
-                                bucket_tagging = self.s3_resource.BucketTagging(bucket_name)
-                                bucket_tagging.put(Tagging={'TagSet': [{'Key': 'Owner', 'Value': owner_tag}]})
                         elif block:
                             raise
                         else:

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -1256,8 +1256,8 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
         from toil.jobStores.aws.jobStore import BucketLocationConflictException
         from toil.jobStores.aws.utils import retry_s3
         from toil.jobStores.aws.jobStore import establish_boto3_session
-
         externalAWSLocation = 'us-west-1'
+
         for testRegion in 'us-east-1', 'us-west-2':
             # We run this test twice, once with the default s3 server us-east-1 as the test region
             # and once with another server (us-west-2).  The external server is always us-west-1.
@@ -1267,22 +1267,14 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
             # Create the bucket at the external region
             bucketName = 'domain-test-' + testJobStoreUUID + '--files'
             client = establish_boto3_session().client('s3', region_name=externalAWSLocation)
-            resource = establish_boto3_session().resource('s3', region_name=externalAWSLocation)
 
             for attempt in retry_s3(delays=(2, 5, 10, 30, 60), timeout=600):
                 with attempt:
-                    # Create the bucket at the home region
                     client.create_bucket(Bucket=bucketName,
                                          CreateBucketConfiguration={'LocationConstraint': externalAWSLocation})
 
-            owner_tag = os.environ.get('TOIL_OWNER_TAG')
-            if owner_tag:
-                for attempt in retry_s3(delays=(1, 1, 2, 4, 8, 16), timeout=33):
-                    with attempt:
-                        bucket_tagging = resource.BucketTagging(bucketName)
-                        bucket_tagging.put(Tagging={'TagSet': [{'Key': 'Owner', 'Value': owner_tag}]})
-
-            options = Job.Runner.getDefaultOptions('aws:' + testRegion + ':domain-test-' + testJobStoreUUID)
+            options = Job.Runner.getDefaultOptions('aws:' + testRegion + ':domain-test-' +
+                                                   testJobStoreUUID)
             options.logLevel = 'DEBUG'
             try:
                 with Toil(options) as toil:


### PR DESCRIPTION
Temporarily reverting since this causes cactus to fail.

Reverts #3577.