### PR TITLE
Handle streaming reads from the cache when the data isn't written back yet

### DIFF
--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -1140,60 +1140,59 @@ class CachingFileStore(AbstractFileStore):
         # read a file that is 'uploadable' or 'uploading' and hasn't hit
         # the backing job store yet.
 
-        # Try and make a 'copying' reference to such a file
-        self._write([('INSERT INTO refs SELECT ?, id, ?, ? FROM files WHERE id = ? AND (state = ? OR state = ?)',
-            (localFilePath, readerID, 'copying', fileStoreID, 'uploadable', 'uploading'))])
+        with self._with_copying_reference_to_upload(fileStoreID, readerID, localFilePath) as ref_path:
+            if ref_path is not None:
+                # We got a copying reference, so the file is being uploaded and
+                # must be read from the cache for consistency. And it will
+                # stick around until the end of the block.
 
-        # See if we got it
-        have_reference = False
-        for row in self.cur.execute('SELECT COUNT(*) FROM refs WHERE path = ? and file_id = ?', (localFilePath, fileStoreID)):
-            have_reference = row[0] > 0
+                assert ref_path == localFilePath
 
-        if have_reference:
-            # If we succeed, copy the file. We know the job has space for it
-            # because if we didn't do this we'd be getting a fresh copy from
-            # the job store.
+                # If we succeed, copy the file. We know the job has space for it
+                # because if we didn't do this we'd be getting a fresh copy from
+                # the job store.
 
-            # Find where the file is cached
-            cachedPath = None
-            for row in self.cur.execute('SELECT path FROM files WHERE id = ?', (fileStoreID,)):
-                cachedPath = row[0]
+                # Find where the file is cached
+                cachedPath = None
+                for row in self.cur.execute('SELECT path FROM files WHERE id = ?', (fileStoreID,)):
+                    cachedPath = row[0]
 
-            if cachedPath is None:
-                raise RuntimeError('File %s went away while we had a reference to it!' % fileStoreID)
+                if cachedPath is None:
+                    raise RuntimeError('File %s went away while we had a reference to it!' % fileStoreID)
 
-            if self.forceDownloadDelay is not None:
-                # Wait around to simulate a big file for testing
-                time.sleep(self.forceDownloadDelay)
+                if self.forceDownloadDelay is not None:
+                    # Wait around to simulate a big file for testing
+                    time.sleep(self.forceDownloadDelay)
 
-            atomic_copy(cachedPath, localFilePath)
+                atomic_copy(cachedPath, ref_path)
 
-            # Change the reference to mutable
-            self._write([('UPDATE refs SET state = ? WHERE path = ? and file_id = ?', ('mutable', localFilePath, fileStoreID))])
-
-        else:
-
-            # If we fail, the file isn't cached here in 'uploadable' or
-            # 'uploading' state, so that means it must actually be in the
-            # backing job store, so we can get it from the backing job store.
-
-            # Create a 'mutable' reference (even if we end up with a link)
-            # so we can see this file in deleteLocalFile.
-            self._write([('INSERT INTO refs VALUES (?, ?, ?, ?)',
-                (localFilePath, fileStoreID, readerID, 'mutable'))])
-
-            if self.forceDownloadDelay is not None:
-                # Wait around to simulate a big file for testing
-                time.sleep(self.forceDownloadDelay)
-
-            # Just read directly
-            if mutable or self.forceNonFreeCaching:
-                # Always copy
-                with self.jobStore.readFileStream(fileStoreID) as inStream:
-                    atomic_copyobj(inStream, localFilePath)
+                # Change the reference to mutable so it sticks around
+                self._write([('UPDATE refs SET state = ? WHERE path = ? and file_id = ?',
+                             ('mutable', ref_path, fileStoreID))])
             else:
-                # Link or maybe copy
-                self.jobStore.readFile(fileStoreID, localFilePath, symlink=symlink)
+                # File is not being uploaded currently.
+
+                # If we fail, the file isn't cached here in 'uploadable' or
+                # 'uploading' state, so that means it must actually be in the
+                # backing job store, so we can get it from the backing job store.
+
+                # Create a 'mutable' reference (even if we end up with a link)
+                # so we can see this file in deleteLocalFile.
+                self._write([('INSERT INTO refs VALUES (?, ?, ?, ?)',
+                    (localFilePath, fileStoreID, readerID, 'mutable'))])
+
+                if self.forceDownloadDelay is not None:
+                    # Wait around to simulate a big file for testing
+                    time.sleep(self.forceDownloadDelay)
+
+                # Just read directly
+                if mutable or self.forceNonFreeCaching:
+                    # Always copy
+                    with self.jobStore.readFileStream(fileStoreID) as inStream:
+                        atomic_copyobj(inStream, localFilePath)
+                else:
+                    # Link or maybe copy
+                    self.jobStore.readFile(fileStoreID, localFilePath, symlink=symlink)
 
         # Now we got the file, somehow.
         return localFilePath
@@ -1589,6 +1588,50 @@ class CachingFileStore(AbstractFileStore):
                     # Wait for other people's downloads to progress.
                     time.sleep(self.contentionBackoff)
 
+    @contextmanager
+    def _with_copying_reference_to_upload(self, file_store_id: FileID, reader_id: str, local_file_path: Optional[str] = None) -> Generator:
+        """
+        Get a context manager that gives you either the local file path for a
+        copyuing reference to the given file, or None if that file is not in an
+        'uploadable' or 'uploading' state.
+
+        It is the caller's responsibility to actually do the copy, if they
+        intend to. The local file is not created.
+
+        If the reference remains a copying reference, it is removed at the end
+        of the context manager.
+
+        :param file_store_id: job store id for the file
+        :param str reader_id: Job ID of the job reading the file
+        :param str local_file_path: absolute destination path, if a particular one is desired
+        """
+
+        if not local_file_path:
+            # Generate a file path for the reference if one is not provided.
+            local_file_path = self.getLocalTempFileName()
+
+        # Try and make a 'copying' reference to such a file
+        self._write([('INSERT INTO refs SELECT ?, id, ?, ? FROM files WHERE id = ? AND (state = ? OR state = ?)',
+            (local_file_path, reader_id, 'copying', file_store_id, 'uploadable', 'uploading'))])
+
+        # See if we got it
+        have_reference = False
+        for row in self.cur.execute('SELECT COUNT(*) FROM refs WHERE path = ? and file_id = ?', (local_file_path, file_store_id)):
+            have_reference = row[0] > 0
+
+        if have_reference:
+            try:
+                # Show the path we got the reference for
+                yield local_file_path
+            finally:
+                # Clean up the reference if it is unmodified
+                self._write([('DELETE FROM refs WHERE path = ? AND file_id = ? AND state = ?',
+                             (local_file_path, file_store_id, 'copying'))])
+        else:
+            # No reference was obtained.
+            yield None
+
+    @contextmanager
     def readGlobalFileStream(self, fileStoreID, encoding=None, errors=None):
         if str(fileStoreID) in self.filesToDelete:
             # File has already been deleted
@@ -1596,9 +1639,32 @@ class CachingFileStore(AbstractFileStore):
 
         self.logAccess(fileStoreID)
 
-        # TODO: can we fulfil this from the cache if the file is in the cache?
-        # I think we can because if a job is keeping the file data on disk due to having it open, it must be paying for it itself.
-        return self.jobStore.readFileStream(fileStoreID, encoding=encoding, errors=errors)
+        with self._with_copying_reference_to_upload(fileStoreID, self.jobDesc.jobStoreID) as ref_path:
+            # Try and grab a reference to the file if it is being uploaded.
+            if ref_path is not None:
+                # We have an update in the cache that isn't written back yet.
+                # So we must stream from the ceche for consistency.
+
+                # The ref file is not actually copied to; find the actual file
+                # in the cache
+                cached_path = None
+                for row in self.cur.execute('SELECT path FROM files WHERE id = ?', (fileStoreID,)):
+                    cached_path = row[0]
+
+                if cached_path is None:
+                    raise RuntimeError('File %s went away while we had a reference to it!' % fileStoreID)
+
+                with open(cached_path, 'r', encoding=encoding, errors=errors) as result:
+                    # Pass along the results of the open context manager on the
+                    # file in the cache.
+                    yield result
+                # When we exit the with the copying reference will go away and
+                # the file will be allowed to leave the cache again.
+            else:
+                # No local update, so we can stream from the job store
+                # TODO: Maybe stream from cache even when not required for consistency?
+                with self.jobStore.readFileStream(fileStoreID, encoding=encoding, errors=errors) as result:
+                    yield result
 
     def deleteLocalFile(self, fileStoreID):
         # What job are we operating as?

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -257,8 +257,6 @@ class Leader(object):
 
             if len(self.toilState.totalFailedJobs):
                 logger.info("Failed jobs at end of the run: %s", ' '.join(str(job) for job in self.toilState.totalFailedJobs))
-            # Cleanup
-            if len(self.toilState.totalFailedJobs) > 0:
                 raise FailedJobsException(self.config.jobStore, self.toilState.totalFailedJobs, self.jobStore)
 
             return self.jobStore.getRootJobReturnValue()

--- a/src/toil/test/src/jobFileStoreTest.py
+++ b/src/toil/test/src/jobFileStoreTest.py
@@ -76,7 +76,6 @@ class JobFileStoreTest(ToilTest):
                                                testStrings, chainLength),
                                  options)
 
-    @retry_flaky_test()
     def testJobFileStore(self):
         """
         Tests case that about half the files are cached


### PR DESCRIPTION
We were seeing some failures in our file job store tests because the caching file store was actually inconsistent: you wouldn't have read your own writes consistency when writing a file and then trying to stream it back, because the file would be uploaded asynchronously but the streaming read would always come from the backing job store.

This fixes the problem by making sure to do streaming reads from the cache when the file being read is there and in an uploading/uploadable state.

I ran the offending `src/toil/test/src/jobFileStoreTest.py::JobFileStoreTest::testJobFileStore` test in a loop, and this change stopped me being able to reproduce the error:

```
FAILED=0
for TRY_NUM in {1..5} ; do
    for ITER in {1..32} ; do
        make test_offline cov="" tests=src/toil/test/src/jobFileStoreTest.py::JobFileStoreTest::testJobFileStore >iter${ITER}.log 2>&1 &
    done
    
    for ITER in {1..32} ; do
        wait
    done
    
    for ITER in {1..32} ; do
        grep "failed job" "iter${ITER}.log"
        if [[ "${?}" == "0" ]] ; then
            echo "Failure observed in iter${ITER}.log!"
            FAILED=1
            break
        fi
    done
    
    if [[ "${FAILED}" == "1" ]] ; then
        break
    fi
    echo "No failures observed in try ${TRY_NUM}"
done
```

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Streaming reads with the caching file store can now read your own writes consistently

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/cliOptions.rst`
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

