### PR TITLE
Do not set default for statePollingWait

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -96,7 +96,7 @@ class Config:
         self.maxServiceJobs: int = sys.maxsize
         self.deadlockWait: Union[float, int] = 60  # Number of seconds we must be stuck with all services before declaring a deadlock
         self.deadlockCheckInterval: Union[float, int] = 30  # Minimum polling delay for deadlocks
-        self.statePollingWait: Union[float, int] = 1  # Number of seconds to wait before querying job state
+        self.statePollingWait: Optional[Union[float, int]] = None  # Number of seconds to wait before querying job state
 
         # Resource requirements
         self.defaultMemory: int = 2147483648
@@ -409,7 +409,7 @@ def addOptions(parser: ArgumentParser, config: Config = Config()):
         title="Toil options for specifying the batch system.",
         description="Allows the specification of the batch system."
     )
-    batchsystem_options.add_argument("--statePollingWait", dest="statePollingWait", default=1, type=int,
+    batchsystem_options.add_argument("--statePollingWait", dest="statePollingWait", type=int,
                                      help="Time, in seconds, to wait before doing a scheduler query for job state.  "
                                           "Return cached results if within the waiting period.")
     add_all_batchsystem_options(batchsystem_options)


### PR DESCRIPTION
Fixes issue #3770

`Config.statePollingWait` should not be set by default, but only when the command-line option `--statePollingWait` is provided. Otherwise, when using `--batchSystem slurm`, the function `SlurmBatchSystem.Work.getWaitDuration()` will never be called in line 54 of `batchSystems/abstractGridEngineBatchSystem.py`. This will effectively set the state polling interval to 1 second, which could overload the Slurm Job accouting service.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Don't set Config.statePollingWait to 1 by default. Fixing this allows the Slurm backend to query the SchedulerTimeSlice or AcctGatherNodeFreq for a sane default; the code to do so previously existed but was being bypassed.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [x] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [x] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [x] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [x] Read through the code changes. Make sure that it doesn't have:
    * [x] Addition of trailing whitespace.
    * [x] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [x] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [x] New functions or classes without informative docstrings.
    * [x] Changes to semantics not reflected in the relevant docstrings.
    * [x] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [x] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

