### PR TITLE
Don't consult LSF config when explicitly defining memory units.

### DIFF
--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -37,8 +37,7 @@ from toil.batchSystems.abstractGridEngineBatchSystem import (
 from toil.batchSystems.lsfHelper import (
     check_lsf_json_output_supported,
     parse_mem_and_cmd_from_output,
-    parse_memory_limit,
-    parse_memory_resource,
+    parse_memory,
     per_core_reservation,
 )
 from toil.lib.misc import call_command
@@ -307,15 +306,14 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             """
             bsubMem = []
             if mem:
-                mem = float(mem) / 1024 ** 3
+                mem = float(mem)
                 if per_core_reservation() and cpu:
                     mem = mem / math.ceil(cpu)
-                mem_resource = parse_memory_resource(mem)
-                mem_limit = parse_memory_limit(mem)
+                mem = parse_memory(mem)
                 bsubMem = ['-R',
-                           f'select[mem>{mem_resource}] '
-                           f'rusage[mem={mem_resource}]',
-                           '-M', mem_limit]
+                           f'select[mem>{mem}] '
+                           f'rusage[mem={mem}]',
+                           '-M', mem]
             bsubCpu = [] if cpu is None else ['-n', str(math.ceil(cpu))]
             bsubline = ["bsub", "-cwd", ".", "-J", f"toil_job_{jobID}"]
             bsubline.extend(bsubMem)

--- a/src/toil/batchSystems/lsfHelper.py
+++ b/src/toil/batchSystems/lsfHelper.py
@@ -195,20 +195,9 @@ def check_lsf_json_output_supported():
     return False
 
 
-def parse_memory_resource(mem: float) -> str:
-    """Parse memory parameter for -R."""
-    return parse_memory(mem, True)
-
-
-def parse_memory_limit(mem: float) -> str:
-    """Parse memory parameter for -M."""
-    return parse_memory(mem, False)
-
-
-def parse_memory(mem: float, resource: bool) -> str:
+def parse_memory(mem: float) -> str:
     """Parse memory parameter."""
-    lsf_unit = get_lsf_units(resource=resource)
-    megabytes_of_mem = convert_units(float(mem), src_unit=lsf_unit, dst_unit='MB')
+    megabytes_of_mem = convert_units(float(mem), src_unit='B', dst_unit='MB')
     if megabytes_of_mem < 1:
         megabytes_of_mem = 1.0
     # round as a string here to avoid returning something like 1.231e+12


### PR DESCRIPTION
Since LSF10 supports explicitly labeling the units for memory resource
and limits, we don't need to parse the proper units from the LSF
configuration.  This removes the need for separate calls for resource
and for limits, and we also don't need to convert from B to GB just to
convert back to MB.  I believe this will also address some issues from
previous changes:
    
* DataBiosphere/toil#3442 reversed the conversion logic, so
   this would've resulted in improper limits in configurations where
   the value isn't already in MB.
* DataBiosphere/toil#3608 removed a multiplier such that it now would
   result in improper limits in configurations where the value isn't
   already in GB.
    
(Our local LSF configuration has historically relied on the weird
default where one unit is in MB and one is in GB, so neither of the
above would work correctly for us!)

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Simplified handling of memory requests in LSF backend.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

