### PR TITLE
Stop checkpoints from being reissued multiple times

### DIFF
--- a/src/toil/bus.py
+++ b/src/toil/bus.py
@@ -42,7 +42,7 @@ class MessageBus:
 
     All messages are NamedTuple objects of various subtypes.
 
-    Message order is not necessarily preserved.
+    Message order is guranteed to be preserved within a type.
 
     TODO: Not yet thread safe, but should be made thread safe if we want e.g.
     the ServiceManager to talk to it. Note that defaultdict itself isn't
@@ -102,6 +102,8 @@ class MessageBus:
         # threads could have a reference to the old buffer.
         self.__messages_by_type[message_type] = []
 
+        # Flip around to chronological order
+        message_list.reverse()
         try:
             while len(message_list) > 0:
                 # We need to handle the case where a new message of this type comes
@@ -124,8 +126,10 @@ class MessageBus:
                         # later with another for_each call.
                         message_list.append(message)
         finally:
-            # Dump anything remaining in our buffer back into the main buffer.
-            self.__messages_by_type[message_type] += message_list
+            # Dump anything remaining in our buffer back into the main buffer,
+            # in the right order, and before the later messages.
+            message_list.reverse()
+            self.__messages_by_type[message_type] = message_list + self.__messages_by_type[message_type]
 
 
 

--- a/src/toil/bus.py
+++ b/src/toil/bus.py
@@ -42,7 +42,7 @@ class MessageBus:
 
     All messages are NamedTuple objects of various subtypes.
 
-    Message order is guranteed to be preserved within a type.
+    Message order is guaranteed to be preserved within a type.
 
     TODO: Not yet thread safe, but should be made thread safe if we want e.g.
     the ServiceManager to talk to it. Note that defaultdict itself isn't

--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -1871,10 +1871,11 @@ class CachingFileStore(AbstractFileStore):
 
             for dbCandidate in os.listdir(dir_):
                 # For each thing in the directory
-                match = re.match('cache-([0-9]+).db', dbCandidate)
+                match = re.match('^cache-([0-9]+).db$', dbCandidate)
                 if match and int(match.group(1)) > dbAttempt:
-                    # If it looks like a caching database and it has a higher
-                    # number than any other one we have seen, use it.
+                    # If it looks like a caching database (and not a journal
+                    # file itself) and it has a higher number than any other
+                    # one we have seen, use it.
                     dbFilename = dbCandidate
                     dbAttempt = int(match.group(1))
 

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -959,7 +959,6 @@ class Leader:
         :return: Job description as it was issued.
         """
         assert jobBatchSystemID in self.issued_jobs_by_batch_system_id
-        assert jobBatchSystemID in self.toilState.jobs_issued
         issuedDesc = self.toilState.get_job(self.issued_jobs_by_batch_system_id[jobBatchSystemID])
         if issuedDesc.preemptable:
             # len(issued_jobs_by_batch_system_id) should always be greater than or equal to preemptableJobsIssued,
@@ -968,6 +967,7 @@ class Leader:
             self.preemptableJobsIssued -= 1
         # It's not issued anymore.
         del self.issued_jobs_by_batch_system_id[jobBatchSystemID]
+        assert issuedDesc.jobStoreID in self.toilState.jobs_issued, f"Job {issuedDesc} came back without being issued"
         self.toilState.jobs_issued.remove(issuedDesc.jobStoreID)
         # If service job
         if issuedDesc.jobStoreID in self.toilState.service_to_client:

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -463,7 +463,7 @@ class Leader:
                          predecessor, predecessor_id)
         elif (isinstance(predecessor, CheckpointJobDescription) and
               predecessor.checkpoint is not None and
-              predecessor.remainingTryCount > 1 and):
+              predecessor.remainingTryCount > 1):
             # If the job is a checkpoint and has remaining retries...
             # The logic behind using > 1 rather than > 0 here: Since this job has
             # been tried once (without decreasing its try count as the job

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -461,15 +461,25 @@ class Leader:
             # are done
             logger.debug("Job %s with ID: %s with failed successors still has successor jobs running",
                          predecessor, predecessor_id)
-        elif isinstance(predecessor, CheckpointJobDescription) and predecessor.checkpoint is not None and predecessor.remainingTryCount > 1:
-            # If the job is a checkpoint and has remaining retries then reissue it.
+        elif (isinstance(predecessor, CheckpointJobDescription) and
+              predecessor.checkpoint is not None and
+              predecessor.remainingTryCount > 1 and):
+            # If the job is a checkpoint and has remaining retries...
             # The logic behind using > 1 rather than > 0 here: Since this job has
             # been tried once (without decreasing its try count as the job
             # itself was successful), and its subtree failed, it shouldn't be retried
             # unless it has more than 1 try.
-            logger.warning('Job: %s is being restarted as a checkpoint after the total '
-                        'failure of jobs in its subtree.', predecessor_id)
-            self.issueJob(predecessor)
+            if predecessor_id in self.toilState.jobs_issued:
+                logger.debug('Checkpoint job %s was updated while issued', predecessor_id)
+            else:
+                # It hasn't already been reissued.
+                # This check lets us be robust against repeated job update
+                # messages (such as from services starting *and* failing), by
+                # making sure that we don't stay in a state that where we
+                # reissue the job every time we get one.
+                logger.warning('Job: %s is being restarted as a checkpoint after the total '
+                            'failure of jobs in its subtree.', predecessor_id)
+                self.issueJob(predecessor)
         else:
             # Mark it totally failed
             logger.debug("Job %s is being processed as completely failed", predecessor_id)
@@ -483,10 +493,13 @@ class Leader:
                      readyJob, result_status)
 
         if self.serviceManager.services_are_starting(readyJob.jobStoreID):
-            # This stops a job with services being issued by the serviceManager from
-            # being considered further in this loop. This catch is necessary because
-            # the job's service's can fail while being issued, causing the job to be
-            # added to updated jobs.
+            # This stops a job with services being issued by the serviceManager
+            # from being considered further in this loop. This catch is
+            # necessary because the job's service's can fail while being
+            # issued, causing the job to be sent an update message. We don't
+            # want to act on it; we want to wait until it gets the update it
+            # gets when the service manager is done trying to start its
+            # services.
             logger.debug("Got a job to update which is still owned by the service "
                          "manager: %s", readyJob.jobStoreID)
         elif readyJob.jobStoreID in self.toilState.hasFailedSuccessors:
@@ -838,9 +851,16 @@ class Leader:
             'OMP_NUM_THREADS': omp_threads,
         }
 
-        # jobBatchSystemID is an int that is an incremented counter for each job
+        # Never issue the same job multiple times simultaneously
+        assert jobNode.jobStoreID not in self.toilState.jobs_issued, \
+            f"Attempted to issue {jobNode} multiple times simultaneously!"
+
+        # jobBatchSystemID is an int for each job
         jobBatchSystemID = self.batchSystem.issueBatchJob(jobNode, job_environment=job_environment)
+        # Record the job by the ID the batch system will use to talk about it with us
         self.issued_jobs_by_batch_system_id[jobBatchSystemID] = jobNode.jobStoreID
+        # Record that this job is issued right now and shouldn't e.g. be issued again.
+        self.toilState.jobs_issued.add(jobNode.jobStoreID)
         if jobNode.preemptable:
             # len(issued_jobs_by_batch_system_id) should always be greater than or equal to preemptableJobsIssued,
             # so increment this value after the job is added to the issuedJob dict
@@ -934,18 +954,21 @@ class Leader:
 
     def removeJob(self, jobBatchSystemID: int) -> JobDescription:
         """
-        Removes a job from the system bu batch system ID. Returns its JobDescription.
+        Removes a job from the system by batch system ID. Returns its JobDescription.
 
         :return: Job description as it was issued.
         """
         assert jobBatchSystemID in self.issued_jobs_by_batch_system_id
+        assert jobBatchSystemID in self.toilState.jobs_issued
         issuedDesc = self.toilState.get_job(self.issued_jobs_by_batch_system_id[jobBatchSystemID])
         if issuedDesc.preemptable:
             # len(issued_jobs_by_batch_system_id) should always be greater than or equal to preemptableJobsIssued,
             # so decrement this value before removing the job from the issuedJob map
             assert self.preemptableJobsIssued > 0
             self.preemptableJobsIssued -= 1
+        # It's not issued anymore.
         del self.issued_jobs_by_batch_system_id[jobBatchSystemID]
+        self.toilState.jobs_issued.remove(issuedDesc.jobStoreID)
         # If service job
         if issuedDesc.jobStoreID in self.toilState.service_to_client:
             # Decrement the number of services

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -478,7 +478,7 @@ class Leader:
                 # making sure that we don't stay in a state that where we
                 # reissue the job every time we get one.
                 logger.warning('Job: %s is being restarted as a checkpoint after the total '
-                            'failure of jobs in its subtree.', predecessor_id)
+                               'failure of jobs in its subtree.', predecessor_id)
                 self.issueJob(predecessor)
         else:
             # Mark it totally failed

--- a/src/toil/serviceManager.py
+++ b/src/toil/serviceManager.py
@@ -332,14 +332,10 @@ class ServiceManager:
                     if (not self.__toil_state.job_exists(service_job_desc.jobStoreID)
                         and self.__job_store.file_exists(service_job_desc.startJobStoreID)):
                         # The service job has gone away but the service never flipped its start flag.
+                        # That's not what the worker is supposed to do when running a service at all.
                         logger.error('Service %s has completed and been removed without ever starting', service_job_desc)
-                        # Stop waiting on the service because we know it won't
-                        # flip the flag.
-                        # TODO: We don't protect the user from this problem
-                        # here. But when this eventually comes up as a user
-                        # issue we'll have a log that might help us track down
-                        # who removed the service.
-                        continue
+                        # Stop everything.
+                        raise RuntimeError(f"Service {service_job_desc} is in an inconsistent state")
 
                 # We don't bail out early here.
 

--- a/src/toil/toilState.py
+++ b/src/toil/toilState.py
@@ -75,8 +75,15 @@ class ToilState:
         self.service_to_client: Dict[str, str] = {}
 
         # Holds, for each client job ID, the job IDs of its services that are
-        # currently issued.
+        # possibly currently issued. Includes every service host that has been
+        # given to the service manager by the leader, and hasn't been seen by
+        # the leader as stopped yet.
         self.servicesIssued: Dict[str, Set[str]] = {}
+
+        # Holds the IDs of jobs that are currently issued to the batch system
+        # and haven't come back yet.
+        # TODO: a bit redundant with leader's issued_jobs_by_batch_system_id
+        self.jobs_issued: Set[str] = set()
 
         # The set of totally failed jobs - this needs to be filtered at the
         # end to remove jobs that were removed by checkpoints


### PR DESCRIPTION
This implements a couple fixes to #3925. I'm now making sure that the job update messages are actually handled in chronological order, so the update that services are started, which was sent *before* the last service failed, doesn't get mistaken for the update that services are all stopped.

I'm also making sure that if checkpoint jobs get updates while they're running, they don't start running again.

And I'm insisting that we not issue jobs that are already running, and that we should crash if we try. Similarly, if a service job goes away without ever starting, we now crash instead of hanging around waiting forever for it to start.

So far, this has passed a couple iterations of this very vigorous test (which turned up an unrelated caching database bug which I also fix); hopefully the test is seriously fixed now.

```
FOUND_PROBLEM=0
    BAD_THREAD=0
    ITERATION=0
    THREAD_COUNT=64
    while [[ "${FOUND_PROBLEM}" == "0" ]] ; do
        echo "Starting iteration ${ITERATION}..."
        PIDS=()
        for THREAD in $(seq ${THREAD_COUNT}) ; do
            make test cov='' tests=src/toil/test/src/jobServiceTest.py::JobServiceTest::testServiceRecursive >log${THREAD}.txt 2>&1 &
            PIDS+=("${!}")
            echo "${THREAD} [ GO ]"
        done
        echo "Waiting in iteration ${ITERATION}..."
        THREAD=1
        for PID in "${PIDS[@]}" ; do
            wait "${PID}"
            if [[ "${?}" != "0" ]] ; then
                FOUND_PROBLEM=1
                BAD_THREAD="${THREAD}"
                echo "${THREAD} [FAIL]"
            else
                echo "${THREAD} [ OK ]"
            fi
            THREAD=$((THREAD+1))
        done
        ITERATION=$((ITERATION+1))
    done
    echo "Problem found in log${BAD_THREAD}.txt"
```

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

* Checkpoint jobs can no longer be reissued multiple times simultaneously, which could lead to services starting for one reconstruction of the checkpoint being deleted by the other reconstruction job.
* Caching database journals can no longer be mistaken for caching databases.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

