### PR TITLE
Use environment variable to set parallel partition name

### DIFF
--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -126,6 +126,10 @@ There are several environment variables that affect the way Toil runs.
 |                                  | Instead, define resource requirements for the job. |
 |                                  | There is no default value for this variable.       |
 +----------------------------------+----------------------------------------------------+
+| TOIL_SLURM_PE                    | Name of the slurm partition to use for parallel    |
+|                                  | jobs.                                              |
+|                                  | There is no default value for this variable.       |
++----------------------------------+----------------------------------------------------+
 | TOIL_GRIDENGINE_ARGS             | Arguments for qsub for the gridengine batch        |
 |                                  | system. Do not pass CPU or memory specifications   |
 |                                  | here. Instead, define resource requirements for    |

--- a/docs/developingWorkflows/toilAPIBatchsystem.rst
+++ b/docs/developingWorkflows/toilAPIBatchsystem.rst
@@ -15,9 +15,11 @@ Batch System Enivronmental Variables
 
 Environmental variables allow passing of scheduler specific parameters.
 
-For SLURM::
+For SLURM there are two environment variables - the first applies to all jobs,
+while the second defined the partition to use for parallel jobs::
 
     export TOIL_SLURM_ARGS="-t 1:00:00 -q fatq"
+    export TOIL_SLURM_PE='multicore'
 
 For TORQUE there are two environment variables - one for everything but the resource
 requirements, and another - for resources requirements (without the `-l` prefix)::

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -281,6 +281,10 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
                 sbatch_line.append('--export=' + ','.join(argList))
 
+            parallel_env = os.getenv('TOIL_SLURM_PE')
+            if cpu and cpu > 1 and parallel_env:
+                sbatch_line.append(f'--partition={parallel_env}')
+
             if mem is not None and self.boss.config.allocate_mem:
                 # memory passed in is in bytes, but slurm expects megabytes
                 sbatch_line.append(f'--mem={math.ceil(mem / 2 ** 20)}')


### PR DESCRIPTION
Previously, setting `--partition=multicore` in TOIL_SLURM_ARGS
was trying to force serial tasks into the parallel partition,
which were failing to run due to requesting a single core.

I was running a CWL workflow with multiple steps, 
some of which were serial, and some parallel.
TOIL was not sending jobs to the appropriate queue -
if `--partition=serial` was set in `TOIL_SLURM_ARGS`,
or no partition was set, serial steps would run, but not
parallel.
If `--partition=multicore` was set in `TOIL_SLURM_ARGS`,
serial steps would not run, as this option applies to
all steps.

The proposed fix uses an environment variable to store 
the name of the parallel partition, and add this to the
sbatch command for tasks requiring more than 1 core.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * PR submitter writes their recommendation for a changelog entry here

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [x] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [x] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [x] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

