### PR TITLE
Add new version of Toil logo from Slack [ci skip]

### DIFF
--- a/contrib/assets/toil-slug-logo-wordmark-2022.svg
+++ b/contrib/assets/toil-slug-logo-wordmark-2022.svg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="155.42715pt"
+   height="199.26981pt"
+   viewBox="0 0 155.42715 199.26981"
+   version="1.2"
+   id="svg266"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata270">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview268"
+     showgrid="false"
+     fit-margin-top="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     fit-margin-left="5"
+     inkscape:zoom="0.81802549"
+     inkscape:cx="-161.65143"
+     inkscape:cy="149.6662"
+     inkscape:window-x="1352"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg266" />
+  <defs
+     id="defs31">
+    <g
+       id="g29">
+      <symbol
+         overflow="visible"
+         id="glyph0-0"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 39.015625,0 h -34.1875 v -70.3125 h 34.1875 z M 36.40625,-4.0625 V -66.203125 L 23.171875,-35.15625 Z M 7.4375,-65.625 V -4.640625 L 20.375,-35.15625 Z M 9.375,-2.609375 H 34.234375 L 21.78125,-31.875 Z M 21.78125,-38.4375 34.234375,-67.703125 H 9.375 Z m 0,0"
+           id="path2"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph0-1"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 59.203125,-58.578125 H 37.65625 V 0 H 23.171875 V -58.578125 H 1.9375 V -70.3125 h 57.265625 z m 0,0"
+           id="path5"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph0-2"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 3.1875,-26.609375 c 0,-5.175781 0.992188,-9.789063 2.984375,-13.84375 2,-4.0625 4.875,-7.203125 8.625,-9.421875 3.75,-2.226562 8.101563,-3.34375 13.0625,-3.34375 7.050781,0 12.804687,2.164062 17.265625,6.484375 4.457031,4.3125 6.941406,10.167969 7.453125,17.5625 l 0.109375,3.578125 c 0,8.023438 -2.242188,14.453125 -6.71875,19.296875 -4.480469,4.84375 -10.484375,7.265625 -18.015625,7.265625 -7.53125,0 -13.542969,-2.410156 -18.03125,-7.234375 C 5.429688,-11.097656 3.1875,-17.671875 3.1875,-25.984375 Z m 13.953125,1.015625 c 0,4.960938 0.929687,8.75 2.796875,11.375 1.875,2.625 4.546875,3.9375 8.015625,3.9375 3.382813,0 6.023437,-1.296875 7.921875,-3.890625 1.894531,-2.59375 2.84375,-6.738281 2.84375,-12.4375 0,-4.851563 -0.949219,-8.613281 -2.84375,-11.28125 -1.898438,-2.675781 -4.570312,-4.015625 -8.015625,-4.015625 -3.40625,0 -6.046875,1.328125 -7.921875,3.984375 -1.867188,2.648437 -2.796875,6.757813 -2.796875,12.328125 z m 0,0"
+           id="path8"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph0-3"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 20.09375,0 H 6.078125 V -52.25 H 20.09375 Z M 5.265625,-65.765625 c 0,-2.09375 0.695313,-3.8125 2.09375,-5.15625 1.40625,-1.351563 3.3125,-2.03125 5.71875,-2.03125 2.382813,0 4.285156,0.679687 5.703125,2.03125 1.414062,1.34375 2.125,3.0625 2.125,5.15625 0,2.125 -0.71875,3.867187 -2.15625,5.21875 -1.429688,1.355469 -3.320312,2.03125 -5.671875,2.03125 -2.34375,0 -4.234375,-0.675781 -5.671875,-2.03125 -1.429688,-1.351563 -2.140625,-3.09375 -2.140625,-5.21875 z m 0,0"
+           id="path11"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph0-4"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 20.09375,0 H 6.078125 V -74.171875 H 20.09375 Z m 0,0"
+           id="path14"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph1-0"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 59.1875,0 H 7.328125 V -106.64063 H 59.1875 Z m -3.96875,-6.15625 v -94.26563 l -20.0625,47.093755 z m -43.9375,-93.375 v 92.5 l 19.625,-46.296875 z m 2.921875,95.578125 h 37.71875 L 33.03125,-48.34375 Z M 33.03125,-58.296875 51.921875,-102.6875 h -37.71875 z m 0,0"
+           id="path17"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph1-1"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 89.796875,-88.84375 H 57.125 V 0 H 35.15625 V -88.84375 H 2.9375 v -17.79688 h 86.859375 z m 0,0"
+           id="path20"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph1-2"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 30.46875,0 H 9.234375 V -79.25 H 30.46875 Z M 7.984375,-99.75 c 0,-3.17578 1.0625,-5.78906 3.1875,-7.84375 2.125,-2.05078 5.015625,-3.07813 8.671875,-3.07813 3.613281,0 6.492188,1.02735 8.640625,3.07813 2.15625,2.05469 3.234375,4.66797 3.234375,7.84375 0,3.21875 -1.089844,5.855469 -3.265625,7.90625 -2.167969,2.054688 -5.039063,3.078125 -8.609375,3.078125 -3.5625,0 -6.433594,-1.023437 -8.609375,-3.078125 -2.167969,-2.050781 -3.25,-4.6875 -3.25,-7.90625 z m 0,0"
+           id="path23"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph1-3"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 30.46875,0 H 9.234375 V -112.5 H 30.46875 Z m 0,0"
+           id="path26"
+           inkscape:connector-curvature="0" />
+      </symbol>
+    </g>
+  </defs>
+  <g
+     id="surface798"
+     transform="translate(-459.10501,-260.70774)">
+    <path
+       style="fill:#fdc500;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 546.80859,297.15234 h -14.95312 v -10.1875 h 14.95312 z m 0,0"
+       id="path219"
+       inkscape:connector-curvature="0" />
+    <g
+       style="fill:#003a6b;fill-opacity:1"
+       id="g223">
+      <use
+         xlink:href="#glyph0-1"
+         x="462.16751"
+         y="454.00879"
+         id="use221"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#003a6b;fill-opacity:1"
+       id="g227">
+      <use
+         xlink:href="#glyph0-2"
+         x="511.31564"
+         y="454.00879"
+         id="use225"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#003a6b;fill-opacity:1"
+       id="g231">
+      <use
+         xlink:href="#glyph0-3"
+         x="565.21045"
+         y="454.00879"
+         id="use229"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#003a6b;fill-opacity:1"
+       id="g235">
+      <use
+         xlink:href="#glyph0-4"
+         x="589.43842"
+         y="454.00879"
+         id="use233"
+         width="100%"
+         height="100%" />
+    </g>
+    <path
+       style="fill:#fdc500;fill-opacity:1;fill-rule:nonzero;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m 0.001075,-8.875e-4 c 0,0 3.84375,6.4570315 2.238281,17.0546875 0,0 31.195313,14.941406 51.164063,-13.855469"
+       transform="matrix(1,0,0,-1,530.1083,288.0538)"
+       id="path237"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#eb1923;fill-opacity:1;fill-rule:nonzero;stroke:#003a6b;stroke-width:2.47799993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -0.0012625,-2.125e-4 c 0,0 -6.8320315,0.3046875 -11.5000005,0.9882815 -4.667968,0.683593 -10.019531,-3.300782 -9.929687,-4.757813 0,0 15.035156,0.9375 6.59375,-4.214844 -8.445313,-5.148437 -12.1875,-3.679687 -15.734375,-13.148437 0,0 5.578125,4.242187 13.472656,2.542969 7.894531,-1.699219 10.761719,10.894531 10.761719,10.894531 0,0 5.992187,-6.28125 1.183594,-11.207031 0,0 7.410156,6.140625 6.515625,12.660156"
+       transform="matrix(1,0,0,-1,512.7747,303.7576)"
+       id="path239"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#fdc500;fill-opacity:1;fill-rule:nonzero;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m 4.125e-4,0.0015375 c 0,0 1.8984375,-4.1132815 5.8007815,15.9882815 0,0 42.929687,16.027344 47.746094,-30.96875 0,0 -13.082032,18.203125 -17.214844,-4.617188 0,0 -10.558594,19.832032 -21.808594,-2.988281 0,0 3.207031,24.78125 -13.78125,13.914063"
+       transform="matrix(1,0,0,-1,541.0074,296.2281)"
+       id="path241"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m 9.5625e-4,0.0012 c 0,0 21.25781275,4.628906 27.39843775,-6.675781"
+       transform="matrix(1,0,0,-1,532.3467,271.0012)"
+       id="path243"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -1.5625e-4,5.8125e-4 c 0,0 2.94921925,29.87109375 -24.76171875,37.33984375"
+       transform="matrix(1,0,0,-1,577.34,315.8248)"
+       id="path245"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -7.5e-4,5e-4 c 0,0 11.4375,27.132812 -8.722656,38.574219"
+       transform="matrix(1,0,0,-1,555.532,318.813)"
+       id="path247"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m 0.001875,-0.001025 c 0.195313,-0.425781 -6.40625,3.375 -5.695312,9.753906"
+       transform="matrix(1,0,0,-1,516.7325,291.8271)"
+       id="path249"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -0.001325,-0.00168125 c 0,0 -3.40625,3.58984425 -2.511719,8.97265625"
+       transform="matrix(1,0,0,-1,520.5482,288.1741)"
+       id="path251"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#003a6b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 512.46484,282.34375 c 0,1.08984 -0.88281,1.97656 -1.97265,1.97656 -1.08985,0 -1.97266,-0.88672 -1.97266,-1.97656 0,-1.08984 0.88281,-1.97266 1.97266,-1.97266 1.08984,0 1.97265,0.88282 1.97265,1.97266"
+       id="path253"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -0.00185625,0.00115 c 0,-1.089844 -0.88281275,-1.976563 -1.97265575,-1.976563 -1.089844,0 -1.972657,0.886719 -1.972657,1.976563 0,1.089844 0.882813,1.972656 1.972657,1.972656 1.089843,0 1.97265575,-0.882812 1.97265575,-1.972656 z m 0,0"
+       transform="matrix(1,0,0,-1,512.4667,282.3449)"
+       id="path255"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#003a6b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 520.01172,276.69141 c 0,1.08984 -0.88672,1.97265 -1.97656,1.97265 -1.08985,0 -1.97266,-0.88281 -1.97266,-1.97265 0,-1.08985 0.88281,-1.97657 1.97266,-1.97657 1.08984,0 1.97656,0.88672 1.97656,1.97657"
+       id="path257"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.83500004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="M 0.00181875,-0.00170625 C 0.00181875,-1.09155 -0.8849,-1.974362 -1.974744,-1.974362 c -1.089844,0 -1.972656,0.882812 -1.972656,1.97265575 0,1.08984425 0.882812,1.97656225 1.972656,1.97656225 1.089844,0 1.97656275,-0.886718 1.97656275,-1.97656225 z m 0,0"
+       transform="matrix(1,0,0,-1,520.0099,276.6897)"
+       id="path259"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#fdc500;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 511.95312,302.42187 c 0,0 6.53516,-22.08203 22.57422,-12.16015 16.03907,9.91797 3.75391,31.89844 3.75391,31.89844 0,0 -7.8125,13.76953 -2.41797,22.32421 10.21875,16.20704 47.3125,-3.35156 48.1875,-3.16015 11.16016,2.41797 -8.93359,19.34765 -21.48828,25.39453 -13.04688,6.28125 -45.27734,6.03906 -49.11719,-9.92188 -3.8125,-15.84375 4.71485,-29.37109 8.46485,-36.86718 3.34765,-6.69922 3.32421,-19.53125 -5.5,-14.94922 -5.40625,2.80859 -4.45704,-2.5586 -4.45704,-2.5586"
+       id="path261"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#003a6b;stroke-width:2.94199991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -9.75e-4,-7.75e-4 c 0,0 6.535156,22.082031 22.574219,12.160156 16.039062,-9.917968 3.753906,-31.898437 3.753906,-31.898437 0,0 -7.8125,-13.769531 -2.417969,-22.324219 10.21875,-16.207031 47.3125,3.351563 48.1875,3.160156 C 83.256838,-41.321087 63.163088,-58.250775 50.6084,-64.29765 37.561525,-70.5789 5.331056,-70.336712 1.491213,-54.375775 c -3.8125,15.84375 4.714843,29.371094 8.464843,36.867188 3.347657,6.699218 3.324219,19.53125 -5.5,14.949218 -5.40625,-2.808593 -4.457031,2.558594 -4.457031,2.558594 z m 0,0"
+       transform="matrix(1,0,0,-1,511.9541,302.4211)"
+       id="path263"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
Here's the logo update we were kicking around in Slack.

I think the ends of the antennae might need to be hidden behind the main outline still, but we can run with this.

I am going to see if Gitlab is willing to skip CI-ing this.