### PR TITLE
Account for overhead in Cluster Scaler

### DIFF
--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -249,6 +249,8 @@ the logging module:
                         where some tasks require much more disk than others.
   --metrics             Enable the prometheus/grafana dashboard for monitoring
                         CPU/RAM usage, queue size, and issued jobs.
+  --assumeZeroOverhead  Ignore scheduler and OS overhead and assume jobs can use every
+                        last byte of memory and disk on a node when autoscaling.
   --defaultMemory INT   The default amount of memory to request for a job.
                         Only applicable to jobs that do not specify an
                         explicit value for this requirement. Standard suffixes

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -155,6 +155,7 @@ class Config:
         self.nodeStorage: int = 50
         self.nodeStorageOverrides: List[str] = []
         self.metrics: bool = False
+        self.assume_zero_overhead: bool = False
 
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
         self.maxPreemptableServiceJobs: int = sys.maxsize
@@ -346,6 +347,7 @@ class Config:
             raise RuntimeError(f'betaInertia ({self.betaInertia}) must be between 0.0 and 0.9!')
         set_option("scaleInterval", float)
         set_option("metrics")
+        set_option("assume_zero_overhead")
         set_option("preemptableCompensation", float)
         if not 0.0 <= self.preemptableCompensation <= 1.0:
             raise RuntimeError(f'preemptableCompensation ({self.preemptableCompensation}) must be between 0.0 and 1.0!')
@@ -634,6 +636,9 @@ def addOptions(parser: ArgumentParser, config: Optional[Config] = None) -> None:
     autoscaling_options.add_argument("--metrics", dest="metrics", default=False, action="store_true",
                                      help="Enable the prometheus/grafana dashboard for monitoring CPU/RAM usage, "
                                           "queue size, and issued jobs.")
+    autoscaling_options.add_argument("--assumeZeroOverhead", dest="assume_zero_overhead", default=False, action="store_true",
+                                     help="Ignore scheduler and OS overhead and assume jobs can use every last byte "
+                                          "of memory and disk on a node when autoscaling.")
 
     # Parameters to limit service jobs / detect service deadlocks
     if not config.cwl:

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -447,8 +447,10 @@ class ClusterScaler:
         outputs.
         """
 
-        # See https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#memory_cpu for how EKS works.
-        # We are going to just implement their scheme and hope it is a good enough overestimate of actual overhead.
+        # See
+        # https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#memory_cpu
+        # for how EKS works. We are going to just implement their scheme and
+        # hope it is a good enough overestimate of actual overhead.
         smaller = copy.copy(full_node)
 
         # Take away some memory to account for how much the scheduler is going to use.
@@ -456,7 +458,7 @@ class ClusterScaler:
         # And some disk to account for the OS and possibly superuser reservation
         # TODO: Figure out if the disk is an OS disk of a scratch disk
         smaller.disk -= self._disk_overhead(smaller.disk)
-        
+
         logger.debug('Node shape %s can hold jobs of shape %s', full_node, smaller)
 
         return smaller

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -129,7 +129,7 @@ class BinPackedFit:
                     # the user to raise the memory on the smallest machine?
                     fewest_constraints = failures
             
-            return jobShape, fewest_constraints
+            return jobShape, fewest_constraints if fewest_constraints is not None else []
 
         # grab current list of job objects appended to this instance type
         nodeReservations = self.nodeReservations[chosenNodeShape]
@@ -1047,7 +1047,7 @@ class JobTooBigError(Exception):
         self.msg = ''.join(parts)
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Stringify the exception, including the message.
         """

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -495,7 +495,7 @@ class ClusterScaler:
                 break
         logger.debug('Reserved %sB/%sB memory for overhead', bytes2human(reserved), bytes2human(memory_bytes))
 
-        return int(reserved)
+        return int(reserved) + EVICTION_THRESHOLD
 
     def _disk_overhead(self, disk_bytes: int) -> int:
         """

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -445,7 +445,7 @@ class ClusterScaler:
         self.nodeShapes.sort()
 
         # Nodes might not actually provide all the resources of their nominal shapes
-        self.node_shapes_after_overhead = [self._reserve_overhead(s) for s in self.nodeShapes]
+        self.node_shapes_after_overhead = self.nodeShapes if config.assume_zero_overhead else [self._reserve_overhead(s) for s in self.nodeShapes]
         self.without_overhead = {k: v for k, v in zip(self.node_shapes_after_overhead, self.nodeShapes)}
 
         #Node shape to number of currently provisioned nodes
@@ -549,12 +549,12 @@ class ClusterScaler:
             # since the previous breakpoint, like a progressive income tax.
             limit = min(breakpoint, memory_bytes)
             reservation = fraction * (limit - accounted)
-            logger.debug('Reserve %sB of memory between %sB and %sB', bytes2human(reservation), bytes2human(accounted), bytes2human(limit))
+            logger.debug('Reserve %s of memory between %s and %s', bytes2human(reservation), bytes2human(accounted), bytes2human(limit))
             reserved += reservation
             accounted = limit
             if accounted >= memory_bytes:
                 break
-        logger.debug('Reserved %sB/%sB memory for overhead', bytes2human(reserved), bytes2human(memory_bytes))
+        logger.debug('Reserved %s/%s memory for overhead', bytes2human(reserved), bytes2human(memory_bytes))
 
         return int(reserved) + EVICTION_THRESHOLD
 

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -452,7 +452,7 @@ class ClusterScalerTest(ToilTest):
         # actual GB or GiB here.
         
         # Set a small node (60G) and a big node (260G)
-        self.provisioner.setAutoscaledNodeTypes([({c4_8xlarge}, {r3_8xlarge})])
+        self.provisioner.setAutoscaledNodeTypes([({c4_8xlarge}, None), ({r3_8xlarge}, None)])
         self.config.targetTime = 1
         self.config.betaInertia = 0.0
         self.config.maxNodes = [2, 2]
@@ -469,6 +469,7 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
@@ -484,20 +485,22 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
         
-        # If the job needs 92% of the memory of the instance type, it will fit.
+        # If the job needs 90% of the memory of the instance type, it will fit.
         jobs = [
             Shape(
                 wallTime=3600,
                 cores=2,
-                memory=int(h2b('60G') * 0.92),
+                memory=int(h2b('60G') * 0.90),
                 disk=h2b('2G'),
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 1)
         self.assertEqual(counts.get(r3_8xlarge, 0), 0)
@@ -513,6 +516,7 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
@@ -528,11 +532,12 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
         
-        # If the job leaves 10% and 10GB of the disk free, it fits
+        # If the job leaves 10% and 10G of the disk free, it fits
         jobs = [
             Shape(
                 wallTime=3600,
@@ -542,6 +547,7 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 1)
         self.assertEqual(counts.get(r3_8xlarge, 0), 0)
@@ -560,7 +566,7 @@ class ClusterScalerTest(ToilTest):
         # actual GB or GiB here.
         
         # Set a small node (1G) and a big node (260G)
-        self.provisioner.setAutoscaledNodeTypes([({t2_micro}, {r3_8xlarge})])
+        self.provisioner.setAutoscaledNodeTypes([({t2_micro}, None), ({r3_8xlarge}, None)])
         self.config.targetTime = 1
         self.config.betaInertia = 0.0
         self.config.maxNodes = [2, 2]
@@ -577,6 +583,7 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(t2_micro, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
@@ -592,6 +599,7 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(t2_micro, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
@@ -608,6 +616,7 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
+        logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(t2_micro, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -636,15 +636,15 @@ class ScalerThreadTest(ToilTest):
         config = Config()
 
         # Make defaults dummy values
-        config.defaultMemory = 1
+        config.defaultMemory = h2b('1Gi')
         config.defaultCores = 1
-        config.defaultDisk = 1
+        config.defaultDisk = h2b('1Gi')
 
         # No preemptable nodes/jobs
         config.maxPreemptableNodes = []  # No preemptable nodes
 
         # Non-preemptable parameters
-        config.nodeTypes = [Shape(20, 10, 10, 10, False)]
+        config.nodeTypes = [Shape(20, h2b('10Gi'), 10, h2b('100Gi'), False)]
         config.minNodes = [0]
         config.maxNodes = [10]
 
@@ -659,18 +659,18 @@ class ScalerThreadTest(ToilTest):
     @slow
     def testClusterScalingMultipleNodeTypes(self):
 
-        smallNode = Shape(20, 5, 10, 10, False)
-        mediumNode = Shape(20, 10, 10, 10, False)
-        largeNode = Shape(20, 20, 10, 10, False)
+        smallNode = Shape(20, h2b('5Gi'), 10, h2b('10Gi'), False)
+        mediumNode = Shape(20, h2b('10Gi'), 10, h2b('10Gi'), False)
+        largeNode = Shape(20, h2b('20Gi'), 10, h2b('10Gi'), False)
 
         numJobs = 100
 
         config = Config()
 
         # Make defaults dummy values
-        config.defaultMemory = 1
+        config.defaultMemory = h2b('1Gi')
         config.defaultCores = 1
-        config.defaultDisk = 1
+        config.defaultDisk = h2b('1Gi')
 
         # No preemptable nodes/jobs
         config.preemptableNodeTypes = []
@@ -732,13 +732,13 @@ class ScalerThreadTest(ToilTest):
         """
         config = Config()
 
-        jobShape = Shape(20, 10, 10, 10, False)
-        preemptableJobShape = Shape(20, 10, 10, 10, True)
+        jobShape = Shape(20, h2b('10Gi'), 10, h2b('10Gi'), False)
+        preemptableJobShape = Shape(20, h2b('10Gi'), 10, h2b('10Gi'), True)
 
         # Make defaults dummy values
-        config.defaultMemory = 1
+        config.defaultMemory = h2b('1Gi')
         config.defaultCores = 1
-        config.defaultDisk = 1
+        config.defaultDisk = h2b('1Gi')
 
         # non-preemptable node parameters
         config.nodeTypes = [jobShape, preemptableJobShape]

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -354,7 +354,7 @@ class ClusterScalerTest(ToilTest):
         # preemptableCompensation applies.
         self.config.nodeTypes = [c4_8xlarge_preemptable, c4_8xlarge]
         self.provisioner.setAutoscaledNodeTypes([({t}, None) for t in self.config.nodeTypes])
-        
+
         scaler = ClusterScaler(self.provisioner, self.leader, self.config)
         # Simulate a situation where a previous run caused a
         # "deficit" of 5 preemptable nodes (e.g. a spot bid was lost)
@@ -437,7 +437,7 @@ class ClusterScalerTest(ToilTest):
         for _ in range(1000):
             scaler.smoothEstimate(c4_8xlarge_preemptable, 100)
         self.assertEqual(scaler.smoothEstimate(c4_8xlarge_preemptable, 100), 100)
-    
+
     def test_overhead_accounting_large(self):
         """
         If a node has a certain raw memory or disk capacity, that won't all be
@@ -450,16 +450,16 @@ class ClusterScalerTest(ToilTest):
         # reporting "61.0 GB" available, and a nominally 32 GiB node with Mesos
         # reporting "29.9 GB" available. It's not clear if Mesos is thinking in
         # actual GB or GiB here.
-        
+
         # Set a small node (60G) and a big node (260G)
         self.provisioner.setAutoscaledNodeTypes([({c4_8xlarge}, None), ({r3_8xlarge}, None)])
         self.config.targetTime = 1
         self.config.betaInertia = 0.0
         self.config.maxNodes = [2, 2]
         scaler = ClusterScaler(self.provisioner, self.leader, self.config)
-        
+
         # If the job needs 100% of the memory of the instance type, it won't
-        # fit and will need a bigger node. 
+        # fit and will need a bigger node.
         jobs = [
             Shape(
                 wallTime=3600,
@@ -473,9 +473,9 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
-        
+
         # If the job needs 98% of the memory of the instance type, it won't
-        # fit and will need a bigger node. 
+        # fit and will need a bigger node.
         jobs = [
             Shape(
                 wallTime=3600,
@@ -489,7 +489,7 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
-        
+
         # If the job needs 90% of the memory of the instance type, it will fit.
         jobs = [
             Shape(
@@ -504,9 +504,9 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 1)
         self.assertEqual(counts.get(r3_8xlarge, 0), 0)
-        
+
         # If the job needs 100% of the disk of the instance type, it won't
-        # fit and will need a bigger node. 
+        # fit and will need a bigger node.
         jobs = [
             Shape(
                 wallTime=3600,
@@ -520,9 +520,9 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
-        
+
         # If the job needs all but 7G of the disk of the instance type, it won't
-        # fit and will need a bigger node. 
+        # fit and will need a bigger node.
         jobs = [
             Shape(
                 wallTime=3600,
@@ -536,7 +536,7 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
-        
+
         # If the job leaves 10% and 10G of the disk free, it fits
         jobs = [
             Shape(
@@ -551,7 +551,7 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(c4_8xlarge, 0), 1)
         self.assertEqual(counts.get(r3_8xlarge, 0), 0)
-        
+
     def test_overhead_accounting_small(self):
         """
         If a node has a certain raw memory or disk capacity, that won't all be
@@ -564,16 +564,16 @@ class ClusterScalerTest(ToilTest):
         # reporting "61.0 GB" available, and a nominally 32 GiB node with Mesos
         # reporting "29.9 GB" available. It's not clear if Mesos is thinking in
         # actual GB or GiB here.
-        
+
         # Set a small node (1G) and a big node (260G)
         self.provisioner.setAutoscaledNodeTypes([({t2_micro}, None), ({r3_8xlarge}, None)])
         self.config.targetTime = 1
         self.config.betaInertia = 0.0
         self.config.maxNodes = [2, 2]
         scaler = ClusterScaler(self.provisioner, self.leader, self.config)
-        
+
         # If the job needs 100% of the memory of the instance type, it won't
-        # fit and will need a bigger node. 
+        # fit and will need a bigger node.
         jobs = [
             Shape(
                 wallTime=3600,
@@ -587,9 +587,9 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(t2_micro, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
-        
+
         # If the job needs all but 100M of the memory of the instance type, it
-        # won't fit and will need a bigger node. 
+        # won't fit and will need a bigger node.
         jobs = [
             Shape(
                 wallTime=3600,
@@ -603,7 +603,7 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(t2_micro, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
-        
+
         # If the job needs no more than 90% of the memory on the node *and*
         # leaves at least 384M free for overhead, we can rely on it fitting on a 1G
         # memory node.
@@ -620,7 +620,7 @@ class ClusterScalerTest(ToilTest):
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         self.assertEqual(counts.get(t2_micro, 0), 0)
         self.assertEqual(counts.get(r3_8xlarge, 0), 1)
-        
+
 class ScalerThreadTest(ToilTest):
     def _testClusterScaling(self, config, numJobs, numPreemptableJobs, jobShape):
         """

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -455,7 +455,7 @@ class ClusterScalerTest(ToilTest):
         If a node has a certain raw memory or disk capacity, that won't all be
         available when it actually comes up; some disk and memory will be used
         by the OS, and the backing scheduler (Mesos, Kubernetes, etc.).
-        
+
         Make sure this overhead is accounted for for large nodes.
         """
 
@@ -488,7 +488,7 @@ class ClusterScalerTest(ToilTest):
         If a node has a certain raw memory or disk capacity, that won't all be
         available when it actually comes up; some disk and memory will be used
         by the OS, and the backing scheduler (Mesos, Kubernetes, etc.).
-        
+
         Make sure this overhead is accounted for for small nodes.
         """
 
@@ -515,13 +515,13 @@ class ClusterScalerTest(ToilTest):
             )
         ]
         self._check_job_estimate([(t2_micro, 1), (r3_8xlarge, 0)], memory=h2b('1G') - h2b('384M'))
-        
+
     def test_overhead_accounting_observed(self):
         """
         If a node has a certain raw memory or disk capacity, that won't all be
         available when it actually comes up; some disk and memory will be used
         by the OS, and the backing scheduler (Mesos, Kubernetes, etc.).
-        
+
         Make sure this overhead is accounted for so that real-world observed
         failures cannot happen again.
         """
@@ -531,23 +531,23 @@ class ClusterScalerTest(ToilTest):
         # (r5.2xlarge?) with Mesos reporting "61.0 GB" available, and a
         # nominally 32 GiB node with Mesos reporting "29.9 GB" available. It's
         # not clear if Mesos is thinking in actual GB or GiB here.
-        
+
         # A 62.5Gi job is sent to the larger node
         self._check_job_estimate([(r5_2xlarge, 0), (r5_4xlarge, 1)], memory=h2b('62.5 Gi'))
-        
+
     def _check_job_estimate(self, nodes: List[Tuple[Shape, int]], cores=1, memory=1, disk=1) -> None:
         """
         Make sure that a job with the given requirements, when run on the given
         nodes, produces the given numbers of them.
         """
-        
+
         self.provisioner.setAutoscaledNodeTypes([({node}, None) for node, _ in nodes])
         self.config.targetTime = 1
         self.config.betaInertia = 0.0
         # We only need up to one node
-        self.config.maxNodes = [1] * len(nodes) 
+        self.config.maxNodes = [1] * len(nodes)
         scaler = ClusterScaler(self.provisioner, self.leader, self.config)
-        
+
         jobs = [
             Shape(
                 wallTime=3600,
@@ -557,7 +557,7 @@ class ClusterScalerTest(ToilTest):
                 preemptable=True
             )
         ]
-        
+
         logger.debug('Try and fit jobs: %s', jobs)
         counts = scaler.getEstimatedNodeCounts(jobs, defaultdict(int))
         for node, count in nodes:


### PR DESCRIPTION
This will fix #2103. This is also relevant to https://github.com/DataBiosphere/toil/issues/4147#issuecomment-1179587561 where a node with memory size very close to the job's requirements was provisioned but not able to be used.

This changes the cluster scaler so that it preprocesses its node sizes to remove some resources for overhead (i.e. the kernel, other processes on the system, and Mesos/Kubernetes). Currently we reserve memory and disk.

To guess at how much memory might be used, in the absence of much real data, we use [a formula from Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#memory_cpu) which describes how much memory GKE clusters keep for themselves, as a function of node memory size. We assume that Toil-managed Mesos and Kubernetes clusters use that much memory or less.

To guess at how much disk space might be used, we take 5% of the disk space (commonly a fraction reserved for superuser) and add 5 GiB. If this is more than the size of the disk on the node, we complain that the disk is weirdly small and assume all of it will be reserved (which may come back to haunt the autoscaler later if we ever try to use ~6 GB nodes).

None of this is user-configurable. **Unless you pass `--assumeZeroOverhead` in which case we turn it off.**

I've added some tests for made-up and real-world cases to constrain the overhead behavior to something sensible. Those pass, but I'm not sure if any live Toil autoscaler tests will now not scale up because they think they can't fit jobs where they will actually fit.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Toil's built-in autoscaler now guesses that some memory and disk space on nodes will not actually be available for jobs; pass `--assumeZeroOverhead` to revert to the old behavior (#2103) 

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [x] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [x] Read through the code changes. Make sure that it doesn't have:
    * [x] Addition of trailing whitespace.
    * [x] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [x] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [x] New functions or classes without informative docstrings.
    * [x] Changes to semantics not reflected in the relevant docstrings.
    * [x] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [x] New features without tests.
* [x] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [x] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

