### PR TITLE
CWL: fix false warning when `outputSource` contains only one `None` value

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -299,12 +299,6 @@ class ResolveSource:
         self.name, self.input, self.source_key = name, input, source_key
 
         source_names = aslist(self.input[self.source_key])
-        # with open("/Users/wlgao/Desktop/log.txt", "a") as f:
-        #     f.write(f"{name=}\n")
-        #     f.write(f"{input=}\n")
-        #     f.write(f"{source_key=}\n")
-        #     f.write(f"{source_names=}\n\n")
-
         # Rule is that source: [foo] is just foo
         #                      unless it also has linkMerge: merge_nested
         if input.get("linkMerge") or len(source_names) > 1:
@@ -341,9 +335,6 @@ class ResolveSource:
         else:
             name, rv = self.promise_tuples
             result = cast(Dict[str, Any], rv).get(name)
-
-        # logger.warning(f"{result=}")
-        # logger.warning(f"{self.promise_tuples=}")
 
         result = self.pick_value(result)
         result = filter_skip_null(self.name, result)

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -299,6 +299,12 @@ class ResolveSource:
         self.name, self.input, self.source_key = name, input, source_key
 
         source_names = aslist(self.input[self.source_key])
+        # with open("/Users/wlgao/Desktop/log.txt", "a") as f:
+        #     f.write(f"{name=}\n")
+        #     f.write(f"{input=}\n")
+        #     f.write(f"{source_key=}\n")
+        #     f.write(f"{source_names=}\n\n")
+
         # Rule is that source: [foo] is just foo
         #                      unless it also has linkMerge: merge_nested
         if input.get("linkMerge") or len(source_names) > 1:
@@ -329,12 +335,15 @@ class ResolveSource:
         if isinstance(self.promise_tuples, list):
             result = self.link_merge(
                 cast(
-                    CWLObjectType, [v[1][v[0]] for v in self.promise_tuples]  # type: ignore[index]
+                    CWLObjectType, [rv[name] for name, rv in self.promise_tuples]  # type: ignore[index]
                 )
             )
         else:
-            value = self.promise_tuples
-            result = cast(Dict[str, Any], value[1]).get(value[0])
+            name, rv = self.promise_tuples
+            result = cast(Dict[str, Any], rv).get(name)
+
+        # logger.warning(f"{result=}")
+        # logger.warning(f"{self.promise_tuples=}")
 
         result = self.pick_value(result)
         result = filter_skip_null(self.name, result)
@@ -379,6 +388,9 @@ class ResolveSource:
 
         if pick_value_type is None:
             return values
+
+        if isinstance(values, SkipNull):
+            return None
 
         if not isinstance(values, list):
             logger.warning("pickValue used but input %s is not a list." % self.name)

--- a/src/toil/test/cwl/conditional_wf.cwl
+++ b/src/toil/test/cwl/conditional_wf.cwl
@@ -1,0 +1,25 @@
+class: Workflow
+cwlVersion: v1.2
+
+inputs:
+  message: string
+  sleep: int
+outputs:
+  out1:
+    type: File
+    outputSource:
+      - echo/echoOut
+    pickValue: first_non_null
+
+requirements:
+  InlineJavascriptRequirement: {}
+
+steps:
+  echo:
+    in:
+      message: message
+      sleep: sleep
+    run: echo.cwl
+    out: [echoOut]
+    when: $(inputs.sleep > 1)
+

--- a/src/toil/test/cwl/conditional_wf.yaml
+++ b/src/toil/test/cwl/conditional_wf.yaml
@@ -1,0 +1,2 @@
+sleep: 1
+message: hello

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -1127,6 +1127,25 @@ def test_filename_conflict_resolution(tmp_path: Path):
 
 @needs_cwl
 @pytest.mark.cwl_small
+def test_pick_value_with_one_null_value(caplog):
+    """
+    Make sure toil-cwl-runner does not false log a warning when pickValue is
+    used but outputSource only contains one null value. See: #3991.
+    """
+    from toil.cwl import cwltoil
+
+    cwl_file = os.path.join(os.path.dirname(__file__), "conditional_wf.cwl")
+    job_file = os.path.join(os.path.dirname(__file__), "conditional_wf.yaml")
+    args = [cwl_file, job_file]
+
+    with caplog.at_level(logging.WARNING, logger="toil.cwl.cwltoil"):
+        cwltoil.main(args)
+        for line in caplog.messages:
+            assert "You had a conditional step that did not run, but you did not use pickValue to handle the skipped input." not in line
+
+
+@needs_cwl
+@pytest.mark.cwl_small
 def test_usage_message():
     """
     This is purely to ensure a (more) helpful error message is printed if a user does

--- a/src/toil/test/cwl/echo.cwl
+++ b/src/toil/test/cwl/echo.cwl
@@ -1,0 +1,12 @@
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: [echo]
+id: "echo"
+inputs: 
+  message: 
+    type: string
+    inputBinding:
+      position: 1
+outputs: 
+  echoOut:
+    type: stdout


### PR DESCRIPTION
Fix #3991 by adding a condition to check if the input is `SkipNull` in `ResolveSource::pick_value()`.

```cwl
# example from the issue
...
outputs:
  out1:
    type: File
    outputSource:
      - echo/echoOut
    pickValue: first_non_null
...
```

When the `outputSource` only has one element, we internally store it as a tuple instead of a list of tuples. This source could evaluate to null but our [`pick_value()` function](https://github.com/DataBiosphere/toil/blob/releases/5.7.x/src/toil/cwl/cwltoil.py#L370) would return early and not filter out the SkipNull. 

<!-- https://sb-biodatacatalyst.readme.io/docs/cwl-v12-conditional-execution#managing-conditional-step-outputs-with-pickvalue -->

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

- CWL: fix false warning when `outputSource` contains only one `None` value

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

