### PR TITLE
Revert "Bump cwltool from 3.1.20221201130942 to 3.1.20230127121939"

### DIFF
--- a/requirements-cwl.txt
+++ b/requirements-cwl.txt
@@ -1,4 +1,4 @@
-cwltool==3.1.20230127121939
+cwltool==3.1.20221201130942
 schema-salad>=8.4.20230128170514,<9
 galaxy-tool-util
 ruamel.yaml>=0.15,<=0.17.21

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -98,7 +98,6 @@ from schema_salad.avro.schema import Names
 from schema_salad.exceptions import ValidationException
 from schema_salad.ref_resolver import file_uri, uri_file_path
 from schema_salad.sourceline import SourceLine
-from typing_extensions import Literal
 
 from toil.batchSystems.registry import DEFAULT_BATCH_SYSTEM
 from toil.common import Config, Toil, addOptions
@@ -2992,10 +2991,7 @@ def scan_for_unsupported_requirements(
                 # The hint cannot be fulfilled. Issue a warning.
                 logger.warning(msg)
 
-
-def determine_load_listing(
-    tool: Process,
-) -> Literal["no_listing", "shallow_listing", "deep_listing"]:
+def determine_load_listing(tool: Process) -> str:
     """
     Determine the directory.listing feature in CWL.
 
@@ -3040,9 +3036,9 @@ def determine_load_listing(
     listing_choices = ("no_listing", "shallow_listing", "deep_listing")
     if load_listing not in listing_choices:
         raise ValueError(
-            f"Unknown loadListing specified: {load_listing!r}.  Valid choices: {listing_choices}"
+            f'Unknown loadListing specified: "{load_listing}".  Valid choices: {listing_choices}'
         )
-    return cast(Literal["no_listing", "shallow_listing", "deep_listing"], load_listing)
+    return load_listing
 
 
 class NoAvailableJobStoreException(Exception):


### PR DESCRIPTION
Reverts DataBiosphere/toil#4344

I'm going to immediately merge this, because force-merging a revert PR narrowly beats tampering with the branch protection and force pushing.

We will see if the new run of CI tests pass or not, which will help us work out if what I'm reverting here is in fact the source of the problem.