### PR TITLE
Issues/4435 support hprc assembly wdls

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -559,11 +559,7 @@ class InsufficientSystemResources(Exception):
         :param details: Any extra details about the problem that can be attached to the error.
         """
 
-        self.job_name : Optional[str] = None
-        if hasattr(requirer, 'jobName') and isinstance(getattr(requirer, 'jobName'), str):
-            # Keep the job name if any
-            self.job_name = cast(str, getattr(requirer, 'jobName'))
-
+        self.job_name : Optional[str] = str(requirer)
         self.resource = resource
         self.requested = cast(ParsedRequirement, getattr(requirer, resource))
         self.available = available
@@ -582,7 +578,7 @@ class InsufficientSystemResources(Exception):
 
         msg = []
         if self.job_name is not None:
-            msg.append(f'The job {self} is requesting ')
+            msg.append(f'The job {self.job_name} is requesting ')
         else:
             msg.append(f'Requesting ')
         msg.append(f'{self.requested} {unit}{self.resource}')

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -447,6 +447,7 @@ class BatchSystemSupport(AbstractBatchSystem):
         :param WorkerCleanupInfo info: A named tuple consisting of all the relevant information
                for cleaning up the worker.
         """
+        logger.debug('Attempting worker cleanup')
         assert isinstance(info, WorkerCleanupInfo)
         assert info.workflow_id is not None
         workflowDir = Toil.getLocalWorkflowDir(info.workflow_id, info.work_dir)
@@ -456,9 +457,11 @@ class BatchSystemSupport(AbstractBatchSystem):
         AbstractFileStore.shutdownFileStore(info.workflow_id, info.work_dir, info.coordination_dir)
         if info.clean_work_dir in ('always', 'onSuccess', 'onError'):
             if workflowDirContents in ([], [cacheDirName(info.workflow_id)]):
+                logger.debug('Deleting workflow directory %s', workflowDir)
                 shutil.rmtree(workflowDir, ignore_errors=True)
             if coordination_dir != workflowDir:
                 # No more coordination to do here either.
+                logger.debug('Deleting coordination directory %s', coordination_dir)
                 shutil.rmtree(coordination_dir, ignore_errors=True)
 
 class NodeInfo:

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -582,7 +582,7 @@ class InsufficientSystemResources(Exception):
 
         msg = []
         if self.job_name is not None:
-            msg.append(f'The job {self.job_name} is requesting ')
+            msg.append(f'The job {self} is requesting ')
         else:
             msg.append(f'Requesting ')
         msg.append(f'{self.requested} {unit}{self.resource}')

--- a/src/toil/batchSystems/cleanup_support.py
+++ b/src/toil/batchSystems/cleanup_support.py
@@ -71,7 +71,9 @@ class WorkerCleanupContext:
         # Set up an arena so we know who is the last worker to leave
         self.arena = LastProcessStandingArena(Toil.get_toil_coordination_dir(self.workerCleanupInfo.work_dir, self.workerCleanupInfo.coordination_dir),
                                               self.workerCleanupInfo.workflow_id + '-cleanup')
+        logger.debug('Entering cleanup arena')
         self.arena.enter()
+        logger.debug('Cleanup arena entered')
 
     # This is exactly the signature MyPy demands.
     # Also, it demands we not say we can return a bool if we return False
@@ -79,10 +81,12 @@ class WorkerCleanupContext:
     # context managers never eat exceptions. So it decides any context manager
     # that is always falsey but claims to return a bool is an error.
     def __exit__(self, type: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+        logger.debug('Leaving cleanup arena')
         for _ in self.arena.leave():
             # We are the last concurrent worker to finish.
             # Do batch system cleanup.
             logger.debug('Cleaning up worker')
             BatchSystemSupport.workerCleanup(self.workerCleanupInfo)
+        logger.debug('Cleanup arena left')
 
 

--- a/src/toil/batchSystems/cleanup_support.py
+++ b/src/toil/batchSystems/cleanup_support.py
@@ -68,7 +68,6 @@ class WorkerCleanupContext:
         # Don't set self.arena or MyPy will be upset that sometimes it doesn't have the right type.
 
     def __enter__(self) -> None:
-        assert os.path.exists(self.workerCleanupInfo.coordination_dir), f"{self.workerCleanupInfo.coordination_dir} has vanished unexpectedly!"
         # Set up an arena so we know who is the last worker to leave
         self.arena = LastProcessStandingArena(Toil.get_toil_coordination_dir(self.workerCleanupInfo.work_dir, self.workerCleanupInfo.coordination_dir),
                                               self.workerCleanupInfo.workflow_id + '-cleanup')
@@ -83,7 +82,6 @@ class WorkerCleanupContext:
     # that is always falsey but claims to return a bool is an error.
     def __exit__(self, type: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         logger.debug('Leaving cleanup arena')
-        assert os.path.exists(self.workerCleanupInfo.coordination_dir), f"{self.workerCleanupInfo.coordination_dir} has vanished unexpectedly!"
         for _ in self.arena.leave():
             # We are the last concurrent worker to finish.
             # Do batch system cleanup.

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -68,7 +68,23 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
 
         def submitJob(self, subLine):
             try:
-                output = call_command(subLine)
+                # Slurm is not quite clever enough to follow the XDG spec on
+                # its own. If the submission command sees e.g. XDG_RUNTIME_DIR
+                # in our environment, it will send it along (especially with
+                # --export=ALL), even though it makes a promise to the job that
+                # Slurm isn't going to keep. It also has a tendency to create
+                # /run/user/<uid> *at the start* of a job, but *not* keep it
+                # around for the duration of the job.
+                #
+                # So we hide the whole XDG universe from Slurm before we make
+                # the submission.
+                no_xdg_environment = os.environ.copy()
+                xdg_names = [n for n in no_xdg_environment.keys() if n.startswith('XDG_')]
+                for name in xdg_names:
+                    del no_xdg_environment[name]
+
+                output = call_command(subLine, env=no_xdg_environment)
+
                 # sbatch prints a line like 'Submitted batch job 2954103'
                 result = int(output.strip().split()[-1])
                 logger.debug("sbatch submitted job %d", result)

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -78,13 +78,15 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
                 #
                 # So we hide the whole XDG universe from Slurm before we make
                 # the submission.
-                no_xdg_environment = os.environ.copy()
-                xdg_names = [n for n in no_xdg_environment.keys() if n.startswith('XDG_')]
-                for name in xdg_names:
-                    del no_xdg_environment[name]
+                # Might as well hode DBUS also.
+                # This doesn't get us a trustworthy XDG session in Slurm, but
+                # it does let us see the one Slurm tries to give us.
+                no_session_environment = os.environ.copy()
+                session_names = [n for n in no_session_environment.keys() if n.startswith('XDG_') or n.startswith('DBUS_')]
+                for name in session_names:
+                    del no_session_environment[name]
 
-                output = call_command(subLine, env=no_xdg_environment)
-
+                output = call_command(subLine, env=no_session_environment)
                 # sbatch prints a line like 'Submitted batch job 2954103'
                 result = int(output.strip().split()[-1])
                 logger.debug("sbatch submitted job %d", result)

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1364,6 +1364,10 @@ class Toil(ContextManager["Toil"]):
                  POSIX filesystem that allows directories containing open files to be
                  deleted.
         """
+        
+        if 'XDG_RUNTIME_DIR' in os.environ and not os.path.exists(os.environ['XDG_RUNTIME_DIR']):
+            # Slurm has been observed providing this variable but not the directory.
+            logger.warning('XDG_RUNTIME_DIR is set to nonexistent directory %s; your environment may be out of spec!', os.environ['XDG_RUNTIME_DIR'])
 
         # Go get a coordination directory, using a lot of short-circuiting of
         # or and the fact that and returns its second argument when it

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1366,7 +1366,8 @@ class Toil(ContextManager["Toil"]):
         """
 
         if 'XDG_RUNTIME_DIR' in os.environ and not os.path.exists(os.environ['XDG_RUNTIME_DIR']):
-            # Slurm has been observed providing this variable but not the directory.
+            # Slurm has been observed providing this variable but not keeping
+            # the directory live as long as we run for.
             logger.warning('XDG_RUNTIME_DIR is set to nonexistent directory %s; your environment may be out of spec!', os.environ['XDG_RUNTIME_DIR'])
 
         # Go get a coordination directory, using a lot of short-circuiting of
@@ -1385,7 +1386,9 @@ class Toil(ContextManager["Toil"]):
             # session that has the env var set. Otherwise it might belong to a
             # different set of sessions and get cleaned up out from under us
             # when that session ends.
-            ('XDG_RUNTIME_DIR' in os.environ and try_path(os.path.join(os.environ['XDG_RUNTIME_DIR'], 'toil'))) or
+            # We don't think Slurm XDG sessions are trustworthy, depending on
+            # the cluster's PAM configuration, so don't use them.
+            ('XDG_RUNTIME_DIR' in os.environ and 'SLURM_JOBID' not in os.environ and try_path(os.path.join(os.environ['XDG_RUNTIME_DIR'], 'toil'))) or
             # Try under /run/lock. It might be a temp dir style sticky directory.
             try_path('/run/lock') or
             # Finally, fall back on the work dir and hope it's a legit filesystem.

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1364,7 +1364,7 @@ class Toil(ContextManager["Toil"]):
                  POSIX filesystem that allows directories containing open files to be
                  deleted.
         """
-        
+
         if 'XDG_RUNTIME_DIR' in os.environ and not os.path.exists(os.environ['XDG_RUNTIME_DIR']):
             # Slurm has been observed providing this variable but not the directory.
             logger.warning('XDG_RUNTIME_DIR is set to nonexistent directory %s; your environment may be out of spec!', os.environ['XDG_RUNTIME_DIR'])

--- a/src/toil/deferred.py
+++ b/src/toil/deferred.py
@@ -300,6 +300,10 @@ class DeferredFunctionManager:
                     # So skip it.
                     continue
 
+                # We need to make sure that we don't hold two
+                # DeferredFunctionManagers at once! So make sure to del yours
+                # when you are done with it. TODO: Make it a singleton!
+
                 fd = None
 
                 try:

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -247,7 +247,7 @@ class NonCachingFileStore(AbstractFileStore):
         jobStateFiles = []
 
         assert os.path.exists(coordination_dir), f"{coordination_dir} has vanished unexpectedly!"
-        
+
         # Note that the directory may contain files whose names are not decodable to Unicode.
         # So we need to work in bytes.
         for entry in os.scandir(os.fsencode(coordination_dir)):
@@ -255,7 +255,7 @@ class NonCachingFileStore(AbstractFileStore):
             if entry.name.endswith(b'.jobState'):
                 # This is the state of a job
                 jobStateFiles.append(os.fsdecode(entry.path))
-        
+
         for fname in jobStateFiles:
             try:
                 logger.debug('Considering other job state file %s', fname)

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -58,6 +58,8 @@ class NonCachingFileStore(AbstractFileStore):
         self.jobStateFile: Optional[str] = None
         self.localFileMap: DefaultDict[str, List[str]] = defaultdict(list)
 
+        assert os.path.exists(self.coordination_dir), f"{self.coordination_dir} has vanished unexpectedly!"
+
     @contextmanager
     def open(self, job: Job) -> Generator[None, None, None]:
         jobReqs = job.disk
@@ -88,6 +90,7 @@ class NonCachingFileStore(AbstractFileStore):
             os.chdir(startingDir)
             # Finally delete the job from the worker
             logger.debug('Removing own job state file %s', self.jobStateFile)
+            assert os.path.exists(self.coordination_dir), f"{self.coordination_dir} has vanished unexpectedly!"
             os.remove(self.jobStateFile)
 
     def writeGlobalFile(self, localFileName: str, cleanup: bool=False) -> FileID:
@@ -196,6 +199,8 @@ class NonCachingFileStore(AbstractFileStore):
         :return:
         """
 
+        assert os.path.exists(coordination_dir), f"{coordination_dir} has vanished unexpectedly!"
+
         for jobState in cls._getAllJobStates(coordination_dir):
             if not process_name_exists(coordination_dir, jobState['jobProcessName']):
                 # We need to have a race to pick someone to clean up.
@@ -240,6 +245,8 @@ class NonCachingFileStore(AbstractFileStore):
         :return: dict with keys (jobName,  jobProcessName, jobDir)
         """
         jobStateFiles = []
+
+        assert os.path.exists(coordination_dir), f"{coordination_dir} has vanished unexpectedly!"
         
         # Note that the directory may contain files whose names are not decodable to Unicode.
         # So we need to work in bytes.
@@ -276,6 +283,7 @@ class NonCachingFileStore(AbstractFileStore):
         :return: Path to the job state file
         :rtype: str
         """
+        assert os.path.exists(self.coordination_dir), f"{self.coordination_dir} has vanished unexpectedly!"
         jobState = {'jobProcessName': get_process_name(self.coordination_dir),
                     'jobName': self.jobName,
                     'jobDir': self.localTempDir}

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -786,34 +786,6 @@ class WDLBaseJob(Job):
         # bindings are actually linked lists or something?
         sys.setrecursionlimit(10000)
 
-class WDLInputJob(WDLBaseJob):
-    """
-    Job that evaluates a WDL input, or sources it from the workflow inputs.
-    """
-    def __init__(self, node: WDL.Tree.Decl, prev_node_results: Sequence[Promised[WDLBindings]], **kwargs: Any) -> None:
-        """
-        Make a new job to evaluate a WDL input.
-        """
-        super().__init__(unitName=node.workflow_node_id, displayName=node.workflow_node_id, **kwargs)
-
-        self._node = node
-        self._prev_node_results = prev_node_results
-
-    def run(self, file_store: AbstractFileStore) -> WDLBindings:
-        """
-        Evaluate the input.
-        """
-        super().run(file_store)
-
-        logger.info("Running node %s", self._node.workflow_node_id)
-
-        # Combine the bindings we get from previous jobs
-        incoming_bindings = combine_bindings(unwrap_all(self._prev_node_results))
-        # Set up the WDL standard library
-        standard_library = ToilWDLStdLibBase(file_store)
-
-        return incoming_bindings.bind(self._node.name, evaluate_defaultable_decl(self._node, incoming_bindings, standard_library))
-
 class WDLTaskJob(WDLBaseJob):
     """
     Job that runs a WDL task.

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -835,19 +835,22 @@ class WDLTaskJob(WDLBaseJob):
     All bindings are in terms of task-internal names.
     """
 
-    def __init__(self, task: WDL.Tree.Task, prev_node_results: Sequence[Promised[WDLBindings]], task_id: List[str], called_as: str, **kwargs: Any) -> None:
+    def __init__(self, task: WDL.Tree.Task, prev_node_results: Sequence[Promised[WDLBindings]], task_id: List[str], namespace: str, **kwargs: Any) -> None:
         """
         Make a new job to run a task.
+
+        :param namespace: The namespace that the task's *contents* exist in.
+               The caller has alredy added the task's own name.
         """
 
-        super().__init__(unitName=task.name, displayName=task.name, **kwargs)
+        super().__init__(unitName=namespace, displayName=namespace, **kwargs)
         
-        logger.info("Preparing to run task %s", task.name)
+        logger.info("Preparing to run task %s as %s", task.name, namespace)
 
         self._task = task
         self._prev_node_results = prev_node_results
         self._task_id = task_id
-        self._called_as = called_as
+        self._namespace = namespace
 
     def can_fake_root(self) -> bool:
         """
@@ -874,7 +877,7 @@ class WDLTaskJob(WDLBaseJob):
         Actually run the task.
         """
         super().run(file_store)
-        logger.info("Running task %s (%s) called as %s", self._task.name, self._task_id, self._called_as)
+        logger.info("Running task %s (%s) called as %s", self._task.name, self._task_id, self._namespace)
 
         # Combine the bindings we get from previous jobs.
         # For a task we are only passed the inside-the-task namespace.
@@ -997,7 +1000,7 @@ class WDLTaskJob(WDLBaseJob):
             # resources.
             # TODO: What if the runtime section says we need a lot of disk to
             # hold the large files that the inputs section is going to write???
-            rescheduled = WDLTaskJob(self._task, self._prev_node_results, self._task_id, self._called_as, cores=runtime_cores or self.cores, memory=runtime_memory or self.memory, disk=runtime_disk or self.disk, accelerators=runtime_accelerators or self.accelerators)
+            rescheduled = WDLTaskJob(self._task, self._prev_node_results, self._task_id, self._namespace, cores=runtime_cores or self.cores, memory=runtime_memory or self.memory, disk=runtime_disk or self.disk, accelerators=runtime_accelerators or self.accelerators)
             # Run that as a child
             self.addChild(rescheduled)
             # And return its result.
@@ -1202,7 +1205,7 @@ class WDLWorkflowNodeJob(WDLBaseJob):
     Job that evaluates a WDL workflow node.
     """
 
-    def __init__(self, node: WDL.Tree.WorkflowNode, prev_node_results: Sequence[Promised[WDLBindings]], **kwargs: Any) -> None:
+    def __init__(self, node: WDL.Tree.WorkflowNode, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, **kwargs: Any) -> None:
         """
         Make a new job to run a workflow node to completion.
         """
@@ -1210,6 +1213,7 @@ class WDLWorkflowNodeJob(WDLBaseJob):
 
         self._node = node
         self._prev_node_results = prev_node_results
+        self._namespace = namespace
         
         if isinstance(self._node, WDL.Tree.Call):
             logger.debug("Preparing job for call node %s", self._node.workflow_node_id)
@@ -1247,11 +1251,11 @@ class WDLWorkflowNodeJob(WDLBaseJob):
 
             if isinstance(self._node.callee, WDL.Tree.Workflow):
                 # This is a call of a workflow
-                subjob: Job = WDLWorkflowJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, self._node.name)
+                subjob: Job = WDLWorkflowJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, f'{self._namespace}.{self._node.name}')
                 self.addChild(subjob)
             elif isinstance(self._node.callee, WDL.Tree.Task):
                 # This is a call of a task
-                subjob = WDLTaskJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, self._node.name)
+                subjob = WDLTaskJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, f'{self._namespace}.{self._node.name}')
                 self.addChild(subjob)
             else:
                 raise WDL.Error.InvalidType(self._node, "Cannot call a " + str(type(self._node.callee)))
@@ -1267,13 +1271,13 @@ class WDLWorkflowNodeJob(WDLBaseJob):
 
             return combine_job.rv()
         elif isinstance(self._node, WDL.Tree.Scatter):
-            subjob = WDLScatterJob(self._node, [incoming_bindings])
+            subjob = WDLScatterJob(self._node, [incoming_bindings], self._namespace)
             self.addChild(subjob)
             # Scatters don't really make a namespace, just kind of a scope?
             # TODO: Let stuff leave scope!
             return subjob.rv()
         elif isinstance(self._node, WDL.Tree.Conditional):
-            subjob = WDLConditionalJob(self._node, [incoming_bindings])
+            subjob = WDLConditionalJob(self._node, [incoming_bindings], self._namespace)
             self.addChild(subjob)
             # Conditionals don't really make a namespace, just kind of a scope?
             # TODO: Let stuff leave scope!
@@ -1340,6 +1344,14 @@ class WDLSectionJob(WDLBaseJob):
     """
     Job that can create more graph for a section of the wrokflow.
     """
+
+    def __init__(self, namespace: str, **kwargs: Any) -> None:
+        """
+        Make a WDLSectionJob where the interior runs in the given namespace,
+        starting with the root workflow.
+        """
+        super().__init__(**kwargs)
+        self._namespace = namespace
 
     def create_subgraph(self, nodes: Sequence[WDL.Tree.WorkflowNode], gather_nodes: Sequence[WDL.Tree.Gather], environment: WDLBindings, local_environment: Optional[WDLBindings] = None) -> Job:
         """
@@ -1447,7 +1459,7 @@ class WDLSectionJob(WDLBaseJob):
             rvs.append(environment)
 
             # Use them to make a new job
-            job = WDLWorkflowNodeJob(wdl_id_to_wdl_node[node_id], rvs)
+            job = WDLWorkflowNodeJob(wdl_id_to_wdl_node[node_id], rvs, self._namespace)
             for prev_job in prev_jobs:
                 # Connect up the happens-after relationships to make sure the
                 # return values are available.
@@ -1544,11 +1556,11 @@ class WDLScatterJob(WDLSectionJob):
     instance of the body. If an instance of the body doesn't create a binding,
     it gets a null value in the corresponding array.
     """
-    def __init__(self, scatter: WDL.Tree.Scatter, prev_node_results: Sequence[Promised[WDLBindings]], **kwargs: Any) -> None:
+    def __init__(self, scatter: WDL.Tree.Scatter, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, **kwargs: Any) -> None:
         """
-        Create a subtree that will run a WDL scatter.
+        Create a subtree that will run a WDL scatter. The scatter itself and the contents live in the given namespace.
         """
-        super().__init__(**kwargs, unitName=scatter.workflow_node_id, displayName=scatter.workflow_node_id)
+        super().__init__(namespace, **kwargs, unitName=scatter.workflow_node_id, displayName=scatter.workflow_node_id)
 
         # Because we need to return the return value of the workflow, we need
         # to return a Toil promise for the last/sink job in the workflow's
@@ -1678,11 +1690,11 @@ class WDLConditionalJob(WDLSectionJob):
     """
     Job that evaluates a conditional in a WDL workflow.
     """
-    def __init__(self, conditional: WDL.Tree.Conditional, prev_node_results: Sequence[Promised[WDLBindings]], **kwargs: Any) -> None:
+    def __init__(self, conditional: WDL.Tree.Conditional, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, **kwargs: Any) -> None:
         """
-        Create a subtree that will run a WDL conditional.
+        Create a subtree that will run a WDL conditional. The conditional itself and its contents live in the given namespace.
         """
-        super().__init__(**kwargs, unitName=conditional.workflow_node_id, displayName=conditional.workflow_node_id)
+        super().__init__(namespace, **kwargs, unitName=conditional.workflow_node_id, displayName=conditional.workflow_node_id)
 
         # Once again we need to ship the whole body template to be instantiated
         # into Toil jobs only if it will actually run.
@@ -1727,12 +1739,15 @@ class WDLWorkflowJob(WDLSectionJob):
     Job that evaluates an entire WDL workflow.
     """
 
-    def __init__(self, workflow: WDL.Tree.Workflow, prev_node_results: Sequence[Promised[WDLBindings]], workflow_id: List[str], called_as: str, **kwargs: Any) -> None:
+    def __init__(self, workflow: WDL.Tree.Workflow, prev_node_results: Sequence[Promised[WDLBindings]], workflow_id: List[str], namespace: str, **kwargs: Any) -> None:
         """
         Create a subtree that will run a WDL workflow. The job returns the
         return value of the workflow.
+
+        :param namespace: the namespace that the workflow's *contents* will be
+               in. Caller has already added the workflow's own name.
         """
-        super().__init__(**kwargs)
+        super().__init__(namespace, **kwargs)
 
         # Because we need to return the return value of the workflow, we need
         # to return a Toil promise for the last/sink job in the workflow's
@@ -1747,7 +1762,7 @@ class WDLWorkflowJob(WDLSectionJob):
         self._workflow = workflow
         self._prev_node_results = prev_node_results
         self._workflow_id = workflow_id
-        self._called_as = called_as
+        self._namespace = namespace
 
     def run(self, file_store: AbstractFileStore) -> Promised[WDLBindings]:
         """
@@ -1755,7 +1770,7 @@ class WDLWorkflowJob(WDLSectionJob):
         """
         super().run(file_store)
 
-        logger.info("Running workflow %s (%s) called as %s", self._workflow.name, self._workflow_id, self._called_as)
+        logger.info("Running workflow %s (%s) called as %s", self._workflow.name, self._workflow_id, self._namespace)
 
         # Combine the bindings we get from previous jobs.
         # For a task we only see the insode-the-task namespace.
@@ -1822,7 +1837,9 @@ class WDLRootJob(WDLSectionJob):
         """
         Create a subtree to run the workflow and namespace the outputs.
         """
-        super().__init__(**kwargs)
+
+        # The root workflow names the root namespace
+        super().__init__(workflow.name, **kwargs)
 
         self._workflow = workflow
         self._inputs = inputs
@@ -1835,11 +1852,11 @@ class WDLRootJob(WDLSectionJob):
 
         # Run the workflow. We rely in this to handle entering the input
         # namespace if needed, or handling free-floating inputs.
-        workflow_job = WDLWorkflowJob(self._workflow, [self._inputs], [self._workflow.name], self._workflow.name)
+        workflow_job = WDLWorkflowJob(self._workflow, [self._inputs], [self._workflow.name], self._namespace)
         self.addChild(workflow_job)
 
         # And namespace its outputs
-        namespace_job = WDLNamespaceBindingsJob(self._workflow.name, [workflow_job.rv()])
+        namespace_job = WDLNamespaceBindingsJob(self._namespace, [workflow_job.rv()])
         workflow_job.addFollowOn(namespace_job)
 
         return namespace_job.rv()

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -572,8 +572,8 @@ def evaluate_defaultable_decl(node: WDL.Tree.Decl, environment: WDLBindings, std
     If the name of the declaration is already defined in the environment, return its value. Otherwise, return the evaluated expression.
     """
 
-    if node.name in environment:
-        logger.debug('Name %s is already defined, not using default', node.name)
+    if node.name in environment and not isinstance(environment[node.name], WDL.Value.Null):
+        logger.debug('Name %s is already defined with a non-null value, not using default', node.name)
         return environment[node.name]
     else:
         logger.info('Defaulting %s to %s', node.name, node.expr)

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -1010,17 +1010,21 @@ class WDLTaskJob(WDLBaseJob):
 
         if shutil.which('singularity'):
 
-            # Prepare to use Singularity. Make sure that we have plenty of space to
+            # Prepare to use Singularity. We will need plenty of space to
             # download images.
             if 'SINGULARITY_CACHEDIR' not in os.environ:
                 # Cache Singularity's layers somehwere known to have space, not in home
                 os.environ['SINGULARITY_CACHEDIR'] = os.path.join(file_store.workflow_dir, 'singularity_cache')
+            # Make sure it exists.
+            os.makedirs(os.environ['SINGULARITY_CACHEDIR'], exist_ok=True)
 
             if 'MINIWDL__SINGULARITY__IMAGE_CACHE' not in os.environ:
                 # Cache Singularity images for the workflow on this machine.
                 # Since MiniWDL does only within-process synchronization for pulls,
                 # we also will need to pre-pull one image into here at a time.
                 os.environ['MINIWDL__SINGULARITY__IMAGE_CACHE'] = os.path.join(file_store.workflow_dir, 'miniwdl_sif_cache')
+            # Make sure it exists.
+            os.makedirs(os.environ['MINIWDL__SINGULARITY__IMAGE_CACHE'], exist_ok=True)
 
             # Run containers with Singularity
             TaskContainerImplementation: Type[TaskContainer]  = SingularityContainer

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -169,7 +169,7 @@ def combine_bindings(all_bindings: Sequence[WDLBindings]) -> WDLBindings:
     Combine variable bindings from multiple predecessor tasks into one set for
     the current task.
     """
-    
+
     # We can't just use WDL.Env.merge, because if a value is shadowed in a
     # binding, WDL.Env.merge can resurrect it to haunt us and become the
     # winning value in the merge result. See
@@ -181,14 +181,14 @@ def combine_bindings(all_bindings: Sequence[WDLBindings]) -> WDLBindings:
     # environment together to propagate one or zero new values.
     #
     # So we do the merge manually.
-    
+
     if len(all_bindings) == 0:
         # Combine nothing
         return WDL.Env.Bindings()
     else:
         # Sort, largest first
         all_bindings = sorted(all_bindings, key=lambda x: -len(x))
-        
+
         merged = all_bindings[0]
         for bindings in all_bindings[1:]:
             for binding in bindings:
@@ -201,7 +201,7 @@ def combine_bindings(all_bindings: Sequence[WDLBindings]) -> WDLBindings:
                         logger.debug('Drop duplicate binding for %s', binding.name)
                 else:
                     merged = merged.bind(binding.name, binding.value, binding.info)
-    
+
     return merged
 
 def log_bindings(all_bindings: Sequence[Promised[WDLBindings]]) -> None:
@@ -844,7 +844,7 @@ class WDLTaskJob(WDLBaseJob):
         """
 
         super().__init__(unitName=namespace, displayName=namespace, **kwargs)
-        
+
         logger.info("Preparing to run task %s as %s", task.name, namespace)
 
         self._task = task
@@ -1152,7 +1152,7 @@ class WDLTaskJob(WDLBaseJob):
             # become typed.
             host_stdout_txt: str = task_container.host_stdout_txt() #  type: ignore
             host_stderr_txt: str = task_container.host_stderr_txt() #  type: ignore
-            
+
             if isinstance(task_container, SingularityContainer):
                 # Before running the command, we need to make sure the container's
                 # image is already pulled, so MiniWDL doesn't try and pull it.
@@ -1220,7 +1220,7 @@ class WDLWorkflowNodeJob(WDLBaseJob):
         self._node = node
         self._prev_node_results = prev_node_results
         self._namespace = namespace
-        
+
         if isinstance(self._node, WDL.Tree.Call):
             logger.debug("Preparing job for call node %s", self._node.workflow_node_id)
 
@@ -1763,7 +1763,7 @@ class WDLWorkflowJob(WDLSectionJob):
         # workflow in run().
 
         logger.debug("Preparing to run workflow %s", workflow.name)
-       
+
 
         self._workflow = workflow
         self._prev_node_results = prev_node_results

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -511,6 +511,9 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
             failure_exit_code = CWL_UNSUPPORTED_REQUIREMENT_EXIT_CODE
         AbstractFileStore._terminateEvent.set()
     finally:
+        # Get rid of our deferred function manager now so we can't mistake it
+        # for someone else's if we do worker cleanup.
+        del deferredFunctionManager
         try:
             import cwltool.main
 

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -306,7 +306,6 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
         sys.stdout.flush()
 
         logProcessContext(config)
-        logger.debug('Environment: %s', os.environ)
 
         ##########################################
         # Connect to the deferred function system

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -198,7 +198,13 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
         "LOGNAME",
         "USER",
         "DISPLAY",
-        "JAVA_HOME"
+        "JAVA_HOME",
+        "XDG_SESSION_TYPE",
+        "XDG_SESSION_CLASS",
+        "XDG_SESSION_ID",
+        "XDG_RUNTIME_DIR",
+        "XDG_DATA_DIRS",
+        "DBUS_SESSION_BUS_ADDRESS"
     }
     for i in environment:
         if i == "PATH":
@@ -300,6 +306,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
         sys.stdout.flush()
 
         logProcessContext(config)
+        logger.debug('Environment: %s', os.environ)
 
         ##########################################
         # Connect to the deferred function system


### PR DESCRIPTION
This lets you use TOil to run the HPRS casembly workflows on our new Slurm cluster.

I ran this:

```
rm -Rf logdump && rm -Rf ./trash/tree && mkdir logdump && time SINGULARITY_CACHEDIR=`pwd`/trash/cache/.singularity/cache MINIWDL__SINGULARITY__IMAGE_CACHE=`pwd`/trash/cache/.cache/miniwdl toil-wdl-runner -e SINGULARITY_CACHEDIR -e MINIWDL__SINGULARITY__IMAGE_CACHE --disableProgress --logDebug --retryCount 0 --jobStore ./trash/tree --outputDirectory ./trash/assembly-out --outputFile ./trash/assembly-out.json --batchSystem slurm --batchLogsDir `pwd`/logdump ../hpp_production_workflows/assembly/wdl/workflows/trio_hifiasm_assembly_yak_input_cutadapt_multistep.wdl ./trash/assembly-inputs.json 2>&1 | tee log.txt
```

This was against https://github.com/adamnovak/hpp_production_workflows commit e46d12a8672a87ca8fe5c7f7b217edcf0a6f4908.

I got these times:

```
    real    84m38.579s
    user    35m29.374s
    sys     0m23.457s
```

Useful Tips:
* Set `--batchLogsDir` to get Slurm's collected logs, otherwise they never leave the nodes because the temp directory is not shared.
* Set the `SINGULARITY_CACHEDIR` and `MINIWDL__SINGULARITY__IMAGE_CACHE` environment variables to shared storage, or the images will need to be re-downloaded for every node for every workflow execution. You may not need the `-e` option because it turns out Toil automatically propagates the whole environment before running user jobs. 

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Toil can (as of https://github.com/human-pangenomics/hpp_production_workflows/pull/18) run the HPRC assembly WDL workflows (fixes #4435).
 * Toil no longer trusts XDG_RUNTIME_DIR under Slurm (fixes some of the issues behind #4395 when Slurm is configured not to follow the XDG spec)
 * Toil now puts it lock files for Singularity cache directories for WDL in those directories.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

