### PR TITLE
Create necessary file staging conflicts

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -85,6 +85,7 @@ from cwltool.software_requirements import (
 )
 from cwltool.stdfsaccess import StdFsAccess, abspath
 from cwltool.utils import (
+    DirectoryType,
     CWLObjectType,
     CWLOutputType,
     adjustDirObjs,
@@ -202,7 +203,7 @@ def _filter_skip_null(value: Any, err_flag: List[bool]) -> Any:
         return {k: _filter_skip_null(v, err_flag) for k, v in value.items()}
     return value
 
-def ensure_no_collisions(directory: CWLObjectType, dir_description: Optional[str] = None):
+def ensure_no_collisions(directory: DirectoryType, dir_description: Optional[str] = None) -> None:
     """
     Make sure no items in the given CWL Directory have the same name.
 
@@ -761,7 +762,7 @@ class ToilPathMapper(PathMapper):
 
             # We want to check the directory to make sure it is not
             # self-contradictory in its immediate children and their names.
-            ensure_no_collisions(obj)
+            ensure_no_collisions(cast(DirectoryType, obj))
 
             # We may need to copy this directory even if we don't copy things inside it.
             copy_here = False
@@ -1642,7 +1643,7 @@ def import_files(
             return None
         elif rec.get("class", None) == "Directory":
             # Check the original listing for collisions
-            ensure_no_collisions(rec)
+            ensure_no_collisions(cast(DirectoryType, rec))
 
             # Pull out the old listing, if any
             old_listing = cast(Optional[List[CWLObjectType]], rec.get("listing", None))
@@ -1660,7 +1661,7 @@ def import_files(
                 # its original File objects that we need to process)
 
                 # Check the new listing for collisions
-                ensure_no_collisions(rec)
+                ensure_no_collisions(cast(DirectoryType, rec))
 
             return old_listing
         return None

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -1121,6 +1121,52 @@ def test_filename_conflict_resolution(tmp_path: Path):
     assert b"Finished toil run successfully" in stderr
     assert p.returncode == 0
 
+@needs_cwl
+@needs_docker
+@pytest.mark.cwl_small_log_dir
+def test_filename_conflict_detection(tmp_path: Path):
+    """
+    Make sure we don't just stage files over each other when using a container.
+    """
+    out_dir = tmp_path / "cwl-out-dir"
+    toil = "toil-cwl-runner"
+    options = [
+        f"--outdir={out_dir}",
+        "--clean=always",
+    ]
+    cwl = os.path.join(
+        os.path.dirname(__file__), "test_filename_conflict_detection.cwl"
+    )
+    cmd = [toil] + options + [cwl]
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    assert b"File staging conflict" in stderr
+    assert p.returncode != 0
+
+@needs_cwl
+@needs_docker
+@pytest.mark.cwl_small_log_dir
+def test_filename_conflict_detection_at_root(tmp_path: Path):
+    """
+    Make sure we don't just stage files over each other.
+
+    Specifically, when using a container and the files are at the root of the work dir.
+    """
+    out_dir = tmp_path / "cwl-out-dir"
+    toil = "toil-cwl-runner"
+    options = [
+        f"--outdir={out_dir}",
+        "--clean=always",
+    ]
+    cwl = os.path.join(
+        os.path.dirname(__file__), "test_filename_conflict_detection_at_root.cwl"
+    )
+    cmd = [toil] + options + [cwl]
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    assert b"File staging conflict" in stderr
+    assert p.returncode != 0
+
 
 @needs_cwl
 @pytest.mark.cwl_small

--- a/src/toil/test/cwl/test_filename_conflict_detection.cwl
+++ b/src/toil/test/cwl/test_filename_conflict_detection.cwl
@@ -1,0 +1,36 @@
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand:
+  - ls
+
+requirements:
+  DockerRequirement:
+    dockerPull: ubuntu:20.04
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing:
+      # https://github.com/DataBiosphere/toil/issues/3449 is specifically about
+      # a directory with a conflict in it so test that.
+      - basename: subdir
+        class: Directory
+        listing:
+          - basename: innderdupe.txt
+            class: File
+            contents: |
+              Stuff
+          - basename: innderdupe.txt
+            class: File
+            contents: |
+              Other stuff
+
+inputs: {}
+
+stdout: stdout.txt
+
+outputs:
+  standard_out:
+    type: stdout
+
+
+
+

--- a/src/toil/test/cwl/test_filename_conflict_detection_at_root.cwl
+++ b/src/toil/test/cwl/test_filename_conflict_detection_at_root.cwl
@@ -1,0 +1,35 @@
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand:
+  - ls
+
+requirements:
+  DockerRequirement:
+    dockerPull: ubuntu:20.04
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: duplicate.txt
+        writable: true # Unless writable we catch the problem due to overwriting a read-only file
+        entry: |
+          This is one file
+      - entryname: unique.txt
+        writable: true
+        entry: |
+          This is a different file
+      - entryname: duplicate.txt
+        writable: true
+        entry: |
+          This is another file pretending to be the first one
+
+inputs: {}
+
+stdout: stdout.txt
+
+outputs:
+  standard_out:
+    type: stdout
+
+
+
+

--- a/src/toil/test/cwl/test_filename_conflict_resolution.cwl
+++ b/src/toil/test/cwl/test_filename_conflict_resolution.cwl
@@ -16,7 +16,7 @@ requirements:
           for i in range(2):
             msout = f"{root}_{i}"
             print(f"Copying: {msin} -> {msout}")
-            subprocess.check_call(['cp', '-r', '-L', '--no-preserve=mode', msin, msout])
+            subprocess.check_call(['cp', '-R', '-L', msin, msout])
 
 inputs:
   - id: msin


### PR DESCRIPTION
This will fix #3449 by failing the workflow if it asks for a `Directory` where two things are supposed to be at the same path. This includes the initial work directory from `InitialWorkDirRequirement`.

As far as I understand it, this is what the runner is always supposed to do. If `File` objects passed as inputs share a name we are supposed to rename them apart, but if the user is putting them together into a `Directory`, the user is supposed to guarantee that they have unique names. We are supposed to make sure that that is the case, not rename them apart, and not clobber one with another, because either of those would be too astonishing.

Previously we would sometimes catch this for non-workdir-root `Directory`s for uncontained jobs, but not for Docker-contained jobs because the `ToilPathMapper` would rename them apart.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Toil will now more consistently fail CWL workflows if it encounters a `Directory` or `InitialWorkDirRequirement` where the workflow requests two sibling files or directories with the same name (#3449).

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

