### PR TITLE
Virtualize filenames as in-container paths from point of view of WDL command

### DIFF
--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -523,6 +523,10 @@ class ToilWDLStdLibTaskCommand(ToilWDLStdLibBase):
         # use the out-of-container equivalent.
         result = self.container.host_path(filename)
 
+        if result is None:
+            # We really shouldn't have files in here that we didn't virtualize.
+            raise RuntimeError(f"File {filename} in container is not mounted from the host and can't be opened form the host")
+
         logger.debug('Devirtualized %s as out-of-container file %s', filename, result)
         return result
 
@@ -534,8 +538,8 @@ class ToilWDLStdLibTaskCommand(ToilWDLStdLibBase):
         """
 
         if filename not in self.container.input_path_map:
-            # Mount the file
-            task_container.add_paths([filename])
+            # Mount the file.
+            self.container.add_paths([filename])
 
         result = self.container.input_path_map[filename]
         

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -525,7 +525,7 @@ class ToilWDLStdLibTaskCommand(ToilWDLStdLibBase):
 
         if result is None:
             # We really shouldn't have files in here that we didn't virtualize.
-            raise RuntimeError(f"File {filename} in container is not mounted from the host and can't be opened form the host")
+            raise RuntimeError(f"File {filename} in container is not mounted from the host and can't be opened from the host")
 
         logger.debug('Devirtualized %s as out-of-container file %s', filename, result)
         return result


### PR DESCRIPTION
This should fix problems with WDL file manipulation functions not working right when called from command placeholder substitutions.

Now we have the "virtual" file name space be the inside of the container path space during WDL task commands, while the devirtualized path space is always the host side path space.

This should fix #4514 for files that aren't just converted from strings where that isn't really allowed, and should also fix #4515.

It doesn't really do anything for #4516, but is sort of relevant. With this, you *only* get the in-container path insode the command itself. If you go File to String elsewhere in the task, you get a URI.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * WDL commands now see in-container paths for files but devirtualize to out-of-container paths

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

