### PR TITLE
Stop deleting chained-to jobs which fail as orphaned jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ clean_sdist:
 # Setting SET_OWNER_TAG will tag cloud resources so that UCSC's cloud murder bot won't kill them.
 test: check_venv check_build_reqs
 	TOIL_OWNER_TAG="shared" \
-	    python -m pytest --durations=0 --strict-markers --log-level DEBUG --log-cli-level INFO -r s $(cov) -n auto --dist loadscope $(tests) -m "$(marker)"
+	    python -m pytest --durations=0 --strict-markers --log-level DEBUG --log-cli-level DEBUG -s -r s $(cov) -n auto --dist loadscope $(tests) -m "$(marker)"
 
 
 # This target will skip building docker and all docker based tests

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ clean_sdist:
 # Setting SET_OWNER_TAG will tag cloud resources so that UCSC's cloud murder bot won't kill them.
 test: check_venv check_build_reqs
 	TOIL_OWNER_TAG="shared" \
-	    python -m pytest --durations=0 --strict-markers --log-level DEBUG --log-cli-level DEBUG -s -r s $(cov) -n auto --dist loadscope $(tests) -m "$(marker)"
+	    python -m pytest --durations=0 --strict-markers --log-level DEBUG --log-cli-level INFO -r s $(cov) -n auto --dist loadscope $(tests) -m "$(marker)"
 
 
 # This target will skip building docker and all docker based tests

--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -120,10 +120,6 @@ class AbstractFileStore(ABC):
         # job is re-run it will need to be able to re-delete these files.
         # This is a set of str objects, not FileIDs.
         self.filesToDelete: Set[str] = set()
-        # Records IDs of jobs that need to be deleted when the currently
-        # running job is cleaned up.
-        # May be modified by the worker to actually delete jobs!
-        self.jobsToDelete: Set[str] = set()
         # Holds records of file ID, or file ID and local path, for reporting
         # the accessed files of failed jobs.
         self._accessLog: List[Tuple[str, ...]] = []

--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -602,7 +602,13 @@ class AbstractFileStore(ABC):
         """
         Update the status of the job on the disk.
 
-        May start an asynchronous process. Call waitForCommit() to wait on that process.
+        May bump the version number of the job.
+
+        May start an asynchronous process. Call waitForCommit() to wait on that
+        process. You must waitForCommit() before committing any further updates
+        to the job. During the asynchronous process, it is safe to modify the
+        job; modifications after this call will not be committed until the next
+        call.
 
         :param jobState: If True, commit the state of the FileStore's job,
                     and file deletes. Otherwise, commit only file creates/updates.

--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -1828,12 +1828,14 @@ class CachingFileStore(AbstractFileStore):
 
                 logger.debug('Committing file deletes and job state changes asynchronously')
 
-                # Indicate any files that should be deleted once the update of
-                # the job wrapper is completed.
+                # Indicate any files that should be seen as deleted once the
+                # update of the job description is visible.
+                if len(self.jobDesc.filesToDelete) > 0:
+                    raise RuntimeError("Job is already in the process of being committed!")
                 self.jobDesc.filesToDelete = list(self.filesToDelete)
                 # Complete the job
                 self.jobStore.update_job(self.jobDesc)
-                # Delete any remnant files
+                # Delete the files
                 list(map(self.jobStore.delete_file, self.filesToDelete))
                 # Remove the files to delete list, having successfully removed the files
                 if len(self.filesToDelete) > 0:

--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import errno
 import hashlib
 import logging
@@ -1802,7 +1803,7 @@ class CachingFileStore(AbstractFileStore):
             raise RuntimeError("Job is already in the process of being committed!")
 
         state_to_commit: Optional[JobSescription] = None
-        
+
         if jobState:
             # Clone the current job description, so that further updates to it
             # (such as new successors being added when it runs) occur after the
@@ -1826,7 +1827,7 @@ class CachingFileStore(AbstractFileStore):
         # Start the commit thread
         self.commitThread = threading.Thread(target=self.startCommitThread, args=(state_to_commit,))
         self.commitThread.start()
-       
+
     def startCommitThread(self, state_to_commit: Optional[JobDescription]):
         """
         Run in a thread to actually commit the current job.
@@ -1854,7 +1855,7 @@ class CachingFileStore(AbstractFileStore):
                 # Do all the things that make this job not redoable
 
                 logger.debug('Committing file deletes and job state changes asynchronously')
-                
+
                 # Complete the job
                 self.jobStore.update_job(state_to_commit)
                 logger.debug('Job committed asynchronously')
@@ -1878,14 +1879,14 @@ class CachingFileStore(AbstractFileStore):
     def shutdown(cls, shutdown_info: Tuple[str, str]) -> None:
         """
         :param shutdown_info: Tuple of the coordination directory (where the
-               cache database is) and the cache directory (where the cached data is). 
-                     
+               cache database is) and the cache directory (where the cached data is).
+
         Job local temp directories will be removed due to their appearance in
         the database.
         """
-        
+
         coordination_dir, cache_dir = shutdown_info
-        
+
         if os.path.isdir(cache_dir):
             # There is a directory to clean up
 
@@ -1903,7 +1904,7 @@ class CachingFileStore(AbstractFileStore):
             # and use that.
             dbFilename = None
             dbAttempt = float('-inf')
-            
+
             # We also need to remember all the plausible database files and
             # journals
             all_db_files = []
@@ -1955,7 +1956,7 @@ class CachingFileStore(AbstractFileStore):
             for filename in all_db_files:
                 # And delete everything related to the caching database
                 robust_rmtree(filename)
-                
+
     def __del__(self):
         """
         Cleanup function that is run when destroying the class instance that ensures that all the

--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -1833,8 +1833,6 @@ class CachingFileStore(AbstractFileStore):
                 self.jobDesc.filesToDelete = list(self.filesToDelete)
                 # Complete the job
                 self.jobStore.update_job(self.jobDesc)
-                # Delete any remnant jobs
-                list(map(self.jobStore.delete_job, self.jobsToDelete))
                 # Delete any remnant files
                 list(map(self.jobStore.delete_file, self.filesToDelete))
                 # Remove the files to delete list, having successfully removed the files

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -194,23 +194,22 @@ class NonCachingFileStore(AbstractFileStore):
         if self.waitForPreviousCommit is not None:
             self.waitForPreviousCommit()
 
-        if not jobState:
-            # All our operations that need committing are job state related
-            return
-
         try:
-            # Indicate any files that should be deleted once the update of
-            # the job wrapper is completed.
-            self.jobDesc.filesToDelete = list(self.filesToDelete)
-            # Complete the job
-            self.jobStore.update_job(self.jobDesc)
-            # Delete any remnant files
-            list(map(self.jobStore.delete_file, self.filesToDelete))
-            # Remove the files to delete list, having successfully removed the files
-            if len(self.filesToDelete) > 0:
-                self.jobDesc.filesToDelete = []
-                # Update, removing emptying files to delete
+            if jobState:
+                # Indicate any files that should be seen as deleted once the
+                # update of the job description is visible.
+                if len(self.jobDesc.filesToDelete) > 0:
+                    raise RuntimeError("Job is already in the process of being committed!")
+                self.jobDesc.filesToDelete = list(self.filesToDelete)
+                # Complete the job
                 self.jobStore.update_job(self.jobDesc)
+                # Delete any remnant files
+                list(map(self.jobStore.delete_file, self.filesToDelete))
+                # Remove the files to delete list, having successfully removed the files
+                if len(self.filesToDelete) > 0:
+                    self.jobDesc.filesToDelete = []
+                    # Update, removing emptying files to delete
+                    self.jobStore.update_job(self.jobDesc)
         except:
             self._terminateEvent.set()
             raise

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -204,8 +204,6 @@ class NonCachingFileStore(AbstractFileStore):
             self.jobDesc.filesToDelete = list(self.filesToDelete)
             # Complete the job
             self.jobStore.update_job(self.jobDesc)
-            # Delete any remnant jobs
-            list(map(self.jobStore.delete_job, self.jobsToDelete))
             # Delete any remnant files
             list(map(self.jobStore.delete_file, self.filesToDelete))
             # Remove the files to delete list, having successfully removed the files

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1229,6 +1229,13 @@ class JobDescription(Requirer):
     def __repr__(self):
         return f'{self.__class__.__name__}( **{self.__dict__!r} )'
 
+    def reserve_versions(self, count: int) -> None:
+        """
+        Reserve a job version number for later, for journaling asynchronously.
+        """
+        self._job_version += count
+        logger.debug("Skip ahead to job version: %s", self)
+
     def pre_update_hook(self) -> None:
         """
         Run before pickling and saving a created or updated version of this job.

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -824,13 +824,14 @@ class AbstractJobStore(ABC):
 
         # Cleanup jobs that are not reachable from the root, and therefore orphaned
         # TODO: Avoid reiterating reachable_from_root (which may be very large)
-        jobsToDelete = [x for x in getJobDescriptions() if x.jobStoreID not in reachable_from_root]
-        for jobDescription in jobsToDelete:
+        unreachable = [x for x in getJobDescriptions() if x.jobStoreID not in reachable_from_root]
+        for jobDescription in unreachable:
             # clean up any associated files before deletion
             for fileID in jobDescription.filesToDelete:
                 # Delete any files that should already be deleted
                 logger.warning(f"Deleting file '{fileID}'. It is marked for deletion but has not yet been removed.")
                 self.delete_file(fileID)
+            # TODO: Should we also delete the jobs marked in these as jobsToDetete?
             # Delete the job from us and the cache
             deleteJob(str(jobDescription.jobStoreID))
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -794,6 +794,10 @@ class AbstractJobStore(ABC):
             for service_jobstore_id in root_job_description.services:
                 if haveJob(service_jobstore_id):
                     reachable_from_root.add(service_jobstore_id)
+            for merged_jobstore_id in root_job_description.merged_jobs:
+                # Keep merged-in jobs around themselves, but don't bother
+                # exploring them, since we took their successors.
+                reachable_from_root.add(merged_jobstore_id)
 
             # Unprocessed means it might have successor jobs we need to add.
             unprocessed_job_descriptions = [root_job_description]
@@ -815,6 +819,10 @@ class AbstractJobStore(ABC):
                                     reachable_from_root.add(service_jobstore_id)
 
                             new_job_descriptions_to_process.append(successor_job_description)
+                    for merged_jobstore_id in job_description.merged_jobs:
+                        # Keep merged-in jobs around themselves, but don't bother
+                        # exploring them, since we took their successors.
+                        reachable_from_root.add(merged_jobstore_id)
                 unprocessed_job_descriptions = new_job_descriptions_to_process
 
             logger.debug(f"{len(reachable_from_root)} jobs reachable from root.")

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -839,7 +839,6 @@ class AbstractJobStore(ABC):
                 # Delete any files that should already be deleted
                 logger.warning(f"Deleting file '{fileID}'. It is marked for deletion but has not yet been removed.")
                 self.delete_file(fileID)
-            # TODO: Should we also delete the jobs marked in these as jobsToDetete?
             # Delete the job from us and the cache
             deleteJob(str(jobDescription.jobStoreID))
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -797,8 +797,7 @@ class AbstractJobStore(ABC):
             for merged_jobstore_id in root_job_description.merged_jobs:
                 # Keep merged-in jobs around themselves, but don't bother
                 # exploring them, since we took their successors.
-                #reachable_from_root.add(merged_jobstore_id)
-                pass
+                reachable_from_root.add(merged_jobstore_id)
 
             # Unprocessed means it might have successor jobs we need to add.
             unprocessed_job_descriptions = [root_job_description]
@@ -823,8 +822,7 @@ class AbstractJobStore(ABC):
                     for merged_jobstore_id in job_description.merged_jobs:
                         # Keep merged-in jobs around themselves, but don't bother
                         # exploring them, since we took their successors.
-                        #reachable_from_root.add(merged_jobstore_id)
-                        pass
+                        reachable_from_root.add(merged_jobstore_id)
                 unprocessed_job_descriptions = new_job_descriptions_to_process
 
             logger.debug(f"{len(reachable_from_root)} jobs reachable from root.")

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -797,7 +797,8 @@ class AbstractJobStore(ABC):
             for merged_jobstore_id in root_job_description.merged_jobs:
                 # Keep merged-in jobs around themselves, but don't bother
                 # exploring them, since we took their successors.
-                reachable_from_root.add(merged_jobstore_id)
+                #reachable_from_root.add(merged_jobstore_id)
+                pass
 
             # Unprocessed means it might have successor jobs we need to add.
             unprocessed_job_descriptions = [root_job_description]
@@ -822,7 +823,8 @@ class AbstractJobStore(ABC):
                     for merged_jobstore_id in job_description.merged_jobs:
                         # Keep merged-in jobs around themselves, but don't bother
                         # exploring them, since we took their successors.
-                        reachable_from_root.add(merged_jobstore_id)
+                        #reachable_from_root.add(merged_jobstore_id)
+                        pass
                 unprocessed_job_descriptions = new_job_descriptions_to_process
 
             logger.debug(f"{len(reachable_from_root)} jobs reachable from root.")

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -224,11 +224,14 @@ class AbstractJobStoreTest:
 
         def testPersistantFilesToDelete(self):
             """
-            Make sure that updating a job carries over filesToDelete.
+            Make sure that updating a job persists filesToDelete.
 
-            The following demonstrates the job update pattern, where files to be deleted are referenced in
-            "filesToDelete" array, which is persisted to disk first. If things go wrong during the update, this list of
-            files to delete is used to remove the unneeded files.
+            The following demonstrates the job update pattern, where files to
+            be deleted atomically with a job update are referenced in
+            "filesToDelete" array, which is persisted to disk first. If things
+            go wrong during the update, this list of files to delete is used to
+            ensure that the updated job and the files are never both visible at
+            the same time.
             """
 
             # Create a job.

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -633,6 +633,8 @@ class hidden:
 
             Attempting to get the file from the jobstore should not fail.
             """
+            print("Testing")
+            logger.debug("Testing testing 123")
             self.options.retryCount = 0
             self.options.logLevel = 'DEBUG'
             A = Job.wrapJobFn(self._adjustCacheLimit, newTotalMB=1024, disk='1G')

--- a/src/toil/test/src/resumabilityTest.py
+++ b/src/toil/test/src/resumabilityTest.py
@@ -74,7 +74,7 @@ class ResumabilityTest(ToilTest):
             log_content = f.read()
             # Make sure we actually did do chaining
             assert "Chaining from" in log_content
-        
+
         # Because of the chaining, the problem we are looking for is the job
         # with the root ID not being able to load the body of a job with a
         # different ID. That doesn't look like a job deleted despite failure.

--- a/src/toil/test/src/resumabilityTest.py
+++ b/src/toil/test/src/resumabilityTest.py
@@ -20,11 +20,11 @@ from toil.exceptions import FailedJobsException
 from toil.test import ToilTest, slow
 
 
-@slow
 class ResumabilityTest(ToilTest):
     """
     https://github.com/BD2KGenomics/toil/issues/808
     """
+    @slow
     def test(self):
         """
         Tests that a toil workflow that fails once can be resumed without a NoSuchJobException.
@@ -53,6 +53,34 @@ class ResumabilityTest(ToilTest):
             # store ID: n/t/jobwbijqL failed with exit value 1"
             self.assertTrue("failed with exit value" not in logString)
 
+    def test_chaining(self):
+        """
+        Tests that a job which is chained to and fails can resume and succeed.
+        """
+
+        options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
+        options.logLevel = "DEBUG"
+        options.retryCount = 0
+        tempDir = self._createTempDir()
+        options.logFile = os.path.join(tempDir, "log.txt")
+
+        root = Job.wrapJobFn(chaining_parent)
+
+        with self.assertRaises(FailedJobsException):
+            # This one is intended to fail.
+            Job.Runner.startToil(root, options)
+
+        with open(options.logFile, 'r') as f:
+            log_content = f.read()
+            # Make sure we actually did do chaining
+            assert "Chaining from" in log_content
+        
+        # Because of the chaining, the problem we are looking for is the job
+        # with the root ID not being able to load the body of a job with a
+        # different ID. That doesn't look like a job deleted despite failure.
+        options.restart = True
+        Job.Runner.startToil(root, options)
+
 def parent(job):
     """
     Set up a bunch of dummy child jobs, and a bad job that needs to be
@@ -60,6 +88,12 @@ def parent(job):
     """
     for _ in range(5):
         job.addChildJobFn(goodChild)
+    job.addFollowOnJobFn(badChild)
+
+def chaining_parent(job):
+    """
+    Set up a failing job to chain to.
+    """
     job.addFollowOnJobFn(badChild)
 
 def goodChild(job):

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -430,7 +430,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
 
                 logger.info("Not chaining from job %s", jobDesc)
 
-                # TODO: Somehow the commit happens even if we don't start it here.
+                # No need to commit because the _executor context manager did it.
 
                 break
 
@@ -472,15 +472,6 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
 
             # This will update the job once the previous job is done updating
             fileStore.startCommit(jobState=True)
-
-            # Clone the current job description again, so that further updates
-            # to it (such as new successors being added when it runs) occur
-            # after the commit process we just kicked off, and aren't committed
-            # early or partially.
-            jobDesc = copy.deepcopy(jobDesc)
-            # Bump its version since saving will do that too and we don't want duplicate versions.
-            jobDesc.pre_update_hook()
-
 
             logger.debug("Starting the next job")
 

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -405,6 +405,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
                             # When the executor for the job finishes it will
                             # kick off a commit with the command link to the
                             # job body cut.
+                            assert jobDesc.command == None
 
                 # Accumulate messages from this job & any subsequent chained jobs
                 statsDict.workers.logsToMaster += fileStore.loggingMessages
@@ -489,6 +490,9 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
             logger.info("Worker log can be found at %s. Set --cleanWorkDir to retain this log", localWorkerTempDir)
 
         logger.info("Finished running the chain of jobs on this node, we ran for a total of %f seconds", time.time() - startTime)
+        logger.debug("Final job: %s", jobDesc)
+        if not jobDesc.is_subtree_done():
+           logger.debug("Final job still has command %s and subtree %s", jobDesc.command, list(jobDesc.successorsAndServiceHosts())) 
 
     ##########################################
     #Trapping where worker goes wrong

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -405,7 +405,6 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
                             # When the executor for the job finishes it will
                             # kick off a commit with the command link to the
                             # job body cut.
-                            assert jobDesc.command == None
 
                 # Accumulate messages from this job & any subsequent chained jobs
                 statsDict.workers.logsToMaster += fileStore.loggingMessages
@@ -490,9 +489,6 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
             logger.info("Worker log can be found at %s. Set --cleanWorkDir to retain this log", localWorkerTempDir)
 
         logger.info("Finished running the chain of jobs on this node, we ran for a total of %f seconds", time.time() - startTime)
-        logger.debug("Final job: %s", jobDesc)
-        if not jobDesc.is_subtree_done():
-           logger.debug("Final job still has command %s and subtree %s", jobDesc.command, list(jobDesc.successorsAndServiceHosts())) 
 
     ##########################################
     #Trapping where worker goes wrong

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -402,6 +402,10 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
                             # versions of Cactus.
                             job._runner(jobGraph=None, jobStore=jobStore, fileStore=fileStore, defer=defer)
 
+                            # When the executor for the job finishes it will
+                            # kick off a commit with the command link to the
+                            # job body cut.
+
                 # Accumulate messages from this job & any subsequent chained jobs
                 statsDict.workers.logsToMaster += fileStore.loggingMessages
 
@@ -436,8 +440,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
             # We have a single successor job that is not a checkpoint job. We
             # reassign the ID of the current JobDescription to the successor.
             # We can then delete the successor JobDescription (under its old
-            # ID) in the jobStore, as it is wholly incorporated into the
-            # current one.
+            # ID) in the jobStore, when we delete this job.
             ##########################################
 
             # Make sure nothing has gone wrong and we can really chain


### PR DESCRIPTION
This will fix #4504 by improving the semantics of `jobsToDelete` (which is now `merged_jobs`, to make it clear that it has very different semantics than `filesToDelete`, which journals file deletions).

Previously, when a job was chained to, we would put it in `jobsToDelete` on the chaining-from job, and then delete it when that job finished successfully.

But we also at some point started cutting the successor relationship to the chained-to job, which meant that if the chained-to job failed, when we went through the job tree during the restart, we would find the chained-to job's original job description under its original ID as an orphaned job and delete it.

This adds code to treat the original chained-to job as more properly merged into the chained-from job, and so still reachable from the root.

I'm also making the `filesToDelete` system more sure about what it is actually supposed to be used for.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Chained-to jobs which fail should no longer be deleted as orphans upon workflow restart (#4504)

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

