### PR TITLE
Report errors in WDL using MiniWDL's error location printer

### DIFF
--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -104,7 +104,7 @@ def report_wdl_errors(task: str, exit: bool = False, log: Callable[[str], None] 
             Run the decoratee and handle WDL errors.
             """
             with wdl_error_reporter(task, exit=exit, log=log):
-                return decoratee(*args, **kwargs) #  type: ignore
+                return decoratee(*args, **kwargs)
         return cast(F, decorated)
     return decorator
 


### PR DESCRIPTION
This improves WDL error reporting for #4608 by calling into MiniWDL to report errors.

Now if you run:
```
toil-wdl-runner https://raw.githubusercontent.com/human-pangenomics/hpp_production_workflows/655cbcdb659b38ab8c8472a14e97fea41dab0ca9/QC/wdl/workflows/comparison_qc.wdl
```

You will get a nice message calling out the chain of errors, formatted by MiniWDL:

```
[2023-10-19T09:38:37-0700] [MainThread] [C] [toil.wdl.wdltoil] Could not run workflow
(https://raw.githubusercontent.com/human-pangenomics/hpp_production_workflows/655cbcdb659b38ab8c8472a14e97fea41dab0ca9/QC/wdl/workflows/comparison_qc.wdl Ln 7 Col 1) Failed to import https://raw.githubusercontent.com/biomonika/HPP/main/assembly/wdl/workflows/findAssemblyBreakpoints.wdl
(https://raw.githubusercontent.com/biomonika/HPP/main/assembly/wdl/workflows/findAssemblyBreakpoints.wdl Ln 487 Col 30) Expected Array[Any] instead of File; command placeholder has 'sep' option for non-Array expression
            R --no-save --args ~{sep=" " mashmap} <<Rscript
                                 ^^^^^^^^^^^^^^^
```

I don't plug a workaround CLI option for this particular error, like MiniWDL does, because `toil-wdl-runner` doesn't support it (yet?).

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * WDL parsing error messages now use MiniWDL's pretty-printer

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

