### PR TITLE
Ship User Logs to Leader

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ before_script:
   # a service account bearer token for auth and triggers https://github.com/docker/buildx/issues/267
   # where buildx can't use a bearer token from a kube config and falls back to anonymous instead
   # of using the system's service account.
-  - if [[ "${CI_BUILDKIT_DRIVER}" == "kubernetes" ]] ; then KUBECONFIG=/dev/null docker buildx create --use --name=buildkit --platform=linux/amd64,linux/arm64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64" ; else docker buildx create --use --name=container-builder --driver=docker-container --config ./buildkitd.toml ; fi
+  - if [[ "${CI_BUILDKIT_DRIVER}" == "kubernetes" ]] ; then KUBECONFIG=/dev/null docker buildx create --use --name=buildkit --platform=linux/amd64,linux/arm64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64" ; else cat buildkitd.toml ; docker buildx create --use --name=container-builder --driver=docker-container --config ./buildkitd.toml ; fi
   # Report on the builders, and make sure they exist.
   - docker buildx inspect --bootstrap || (echo "Docker builder deployment can't be found! Are we on the right Gitlab runner?" && exit 1)
   # This will hang if we can't talk to the builder

--- a/docs/appendices/architecture.rst
+++ b/docs/appendices/architecture.rst
@@ -104,7 +104,7 @@ Toil's statistics and logging system is implemented in a joint class
 and run as a thread on the leader, where it polls for new log files in the job
 store with the
 :meth:`~toil.jobStores.abstractJobStore.AbstractJobStore.read_logs` method.
-These are JSON files, which contain strucutred data. Structured log messages
+These are JSON files, which contain structured data. Structured log messages
 from user Python code, stored under ``workers.logs_to_leader``, from the file
 store's
 :meth:`~toil.fileStores.abstractFileStore.AbstractFileStore.log_to_leader`
@@ -122,6 +122,13 @@ to the file store, and the log file is made available through
 :meth:`toil.job.JobDescription.getLogFileHandle`. The leader thread retrieves
 these logs and calls back into :class:`~toil.statsAndLogging.StatsAndLogging`
 to print or locally save them as appropriate.
+
+The CWL and WDL interpreters use
+:meth:`~toil.fileStores.abstractFileStore.AbstractFileStore.log_user_stream` to
+inject CWL and WDL task-level logs into the stats and logging logging system.
+The full text of those logs gets stored in the JSON stats files, and when the
+StatsAndLogging thread sees them it reports and saves them, similarly to how it
+treats Toil job logs.
 
 To ship the statistics and the non-failed-job logs around, the job store has a
 logs mailbox system: the

--- a/docs/appendices/architecture.rst
+++ b/docs/appendices/architecture.rst
@@ -84,15 +84,16 @@ several human-readable names that are useful for logging and identification:
 | unitName         | Name of this *instance* of this kind of job. If set by the user,   |
 |                  | it will appear with the jobName in logging.                        |
 |                  |                                                                    |
-|                  | For a CWL workflow, the unitName is set to a descriptive name that |
-|                  | includes the CWL file name and the ID in the file if set.          |
+|                  | For a CWL workflow, the unitName is the dotted path from the       |
+|                  | workflow down to the task being run, including numbers for scatter |
+|                  | steps.                                                             |
 +------------------+--------------------------------------------------------------------+
 | displayName      | A human-readable name to identify this particular job instance.    |
 |                  | Used as an identifier of the job class in the stats report.        |
 |                  | Defaults to the job class's name if no real user-defined name is   |
 |                  | available.                                                         |
 |                  |                                                                    |
-|                  | For a CWL workflow, the displayName is the absolute workflow URI.  |
+|                  | For CWL workflows, this includes the jobName and the unitName.     |
 +------------------+--------------------------------------------------------------------+
 
 Statistics and Logging

--- a/docs/cwl/running.rst
+++ b/docs/cwl/running.rst
@@ -80,9 +80,9 @@ reference ``$(runtime.tmpdir)`` in CWL tools and workflows.
 written. References to these and other output types will be in the JSON object
 printed to the stdout stream after workflow execution.
 
-``--logFile``: Path to the main logfile with logs from all jobs.
+``--logFile``: Path to the main logfile.
 
-``--writeLogs``: Directory where all job logs will be stored.
+``--writeLogs``: Directory where job logs will be stored. At ``DEBUG`` log level, this will contain logs for each Toil job run, as well as ``stdout``/``stderr`` logs for each CWL job, for output the workflow didn't capture.
 
 ``--retryCount``: How many times to retry each Toil job.
 
@@ -181,7 +181,7 @@ You can get run statistics broken down by CWL file. This only works once the wor
 
     $ toil stats /path/to/jobstore
 
-The output will contain CPU, memory, and walltime information for all CWL job types:
+The output will contain CPU, memory, and walltime information for all CWL job types. Note that the job names you get will look different from those in this old example run.
 ::
 
     <hostname> 2018-10-15 12:06:19,003 MainThread INFO toil.lib.bioio: Root logger is at level 'INFO', 'toil' logger at level 'INFO'.
@@ -233,13 +233,16 @@ The output will contain CPU, memory, and walltime information for all CWL job ty
 
 **Understanding toil log files**
 
-There is a `worker_log.txt` file for each job, this file is written to while the job is running, and deleted after the job finishes. The contents are printed to the main log file and transferred to a log file in the `--logDir` folder once the job is completed successfully.
+There is a `worker_log.txt` file for each Toil job. This file is written to while the job is running, and uploaded at the end if the job finishes or if running at debug log level. If uploaded, the contents are printed to the main log file and transferred to a log file in the `--logDir` folder.
 
 The new log file will be named something like:
 ::
 
-    file:<path to cwl tool>.cwl_<job ID>.log
+    CWLJob_<name of the CWL job>_<attempt number>.log
 
-    file:---home-johnsoni-pipeline_1.1.14-ACCESS--Pipeline-cwl_tools-marianas-ProcessLoopUMIFastq.cwl_I-O-jobfGsQQw000.log
+Standard output/error files will be named like:
+::
 
-This is the toil job command with spaces replaced by dashes.
+    <name of the CWL job>.stdout_<attempt number>.log
+
+If you have a workflow ``revsort.cwl`` which has a step ``rev`` which calls the tool ``revtool.cwl``, the CWL job name ends up being all those parts strung together with ``.``: ``revsort.cwl.rev.revtool.cwl``.

--- a/docs/cwl/running.rst
+++ b/docs/cwl/running.rst
@@ -82,7 +82,7 @@ printed to the stdout stream after workflow execution.
 
 ``--logFile``: Path to the main logfile.
 
-``--writeLogs``: Directory where job logs will be stored. At ``DEBUG`` log level, this will contain logs for each Toil job run, as well as ``stdout``/``stderr`` logs for each CWL job, for output the workflow didn't capture.
+``--writeLogs``: Directory where job logs will be stored. At ``DEBUG`` log level, this will contain logs for each Toil job run, as well as ``stdout``/``stderr`` logs for each CWL ``CommandLineTool`` that didn't use the ``stdout``/``stderr`` directives to redirect output.
 
 ``--retryCount``: How many times to retry each Toil job.
 

--- a/docs/wdl/running.rst
+++ b/docs/wdl/running.rst
@@ -68,6 +68,38 @@ to nest that under an ``outputs`` key and includes a ``dir`` key.
 Any number of other Toil options may also be specified. For defined Toil options,
 see :ref:`commandRef`.
 
+Managing Workflow Logs
+----------------------
+
+At the default settings, if a WDL task succeeds, the standard output and
+standard error will be printed in the ``toil-wdl-runner`` output, unless they
+are captured by the workflow (with the ``stdout()`` and ``stderr()`` WDL
+built-in functions). If a WDL task fails, they will be printed whether they
+were meant to be captured or not. Complete logs from Toil for failed jobs will
+also be printed.
+
+If you would like to save the logs organized by WDL task, you can use the
+``--writeLogs`` or ``--writeLogsGzip`` options to specify a directory where the
+log files should be saved. Log files will be named after the same dotted,
+hierarchical workflow and task names used to set values from the input JSON,
+except that scatters will add an additional numerical component. In addition
+to the logs for WDL tasks, Toil job logs for failed jobs will also appear here
+when running at the default log level.
+
+For example, if you run::
+
+    toil-wdl-runner --writeLogs logs https://raw.githubusercontent.com/DataBiosphere/toil/36b54c45e8554ded5093bcdd03edb2f6b0d93887/src/toil/test/wdl/miniwdl_self_test/self_test.wdl https://raw.githubusercontent.com/DataBiosphere/toil/36b54c45e8554ded5093bcdd03edb2f6b0d93887/src/toil/test/wdl/miniwdl_self_test/inputs.json
+
+You will end up with a ``logs/`` directory containing::
+
+    hello_caller.0.hello.stderr_000.log
+    hello_caller.1.hello.stderr_000.log
+    hello_caller.2.hello.stderr_000.log
+
+The final number is a sequential counter: if a step has to be retried, or if
+you run the workflow multiple times without clearing out the logs directory, it
+will increment.
+
 
 
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -34,7 +34,7 @@ import stat
 import sys
 import textwrap
 import uuid
-from tempfile import NamedTemporaryFile, gettempdir
+from tempfile import NamedTemporaryFile, TemporaryFile, gettempdir
 from threading import Thread
 from typing import (
     IO,
@@ -1987,7 +1987,7 @@ def upload_file(
 
     Uploads local files to the Toil file store, and sets their location to a
     reference to the toil file store.
-    
+
     Unless skip_remote is set, downloads remote files into the file store and
     sets their locations to references into the file store as well.
     """
@@ -2614,6 +2614,13 @@ class CWLJob(CWLNamedJob):
                 streaming_allowed=runtime_context.streaming_allowed,
             )
 
+        # Collect standard output and standard error somewhere if they don't go to files.
+        # We need to keep two FDs to these because cwltool will close what we give it.
+        default_stdout = TemporaryFile()
+        runtime_context.default_stdout = os.fdopen(os.dup(default_stdout.fileno()), 'wb')
+        default_stderr = TemporaryFile()
+        runtime_context.default_stderr = os.fdopen(os.dup(default_stderr.fileno()), 'wb')
+
         process_uuid = uuid.uuid4()  # noqa F841
         started_at = datetime.datetime.now()  # noqa F841
 
@@ -2635,6 +2642,16 @@ class CWLJob(CWLNamedJob):
         for t, fd in pipe_threads:
             os.close(fd)
             t.join()
+
+        # Log any output/error data
+        default_stdout.seek(0, os.SEEK_END)
+        if default_stdout.tell() > 0:
+            default_stdout.seek(0)
+            file_store.log_user_stream(self.description.unitName + '.stdout', default_stdout)
+        default_stderr.seek(0, os.SEEK_END)
+        if default_stderr.tell():
+            default_stderr.seek(0)
+            file_store.log_user_stream(self.description.unitName + '.stderr', default_stderr)
 
         # Get ahold of the filesystem
         fs_access = runtime_context.make_fs_access(runtime_context.basedir)
@@ -3352,12 +3369,12 @@ def determine_load_listing(
 
     1. no_listing: DIRECTORY_NAME.listing will be undefined.
         e.g.
-            
+
             inputs.DIRECTORY_NAME.listing == unspecified
 
     2. shallow_listing: DIRECTORY_NAME.listing will return a list one level
         deep of DIRECTORY_NAME's contents.
-        e.g. 
+        e.g.
 
             inputs.DIRECTORY_NAME.listing == [items in directory]
              inputs.DIRECTORY_NAME.listing[0].listing == undefined
@@ -3789,7 +3806,7 @@ def main(args: Optional[List[str]] = None, stdout: TextIO = sys.stdout) -> int:
                 Callable[[str], FileID],
                 functools.partial(toil.import_file, symlink=True),
             )
-            
+
             # Import all the input files, some of which may be missing optional
             # files.
             logger.info("Importing input files...")

--- a/src/toil/exceptions.py
+++ b/src/toil/exceptions.py
@@ -36,7 +36,7 @@ class FailedJobsException(Exception):
             for job_desc in failed_jobs:
                 if job_desc.logJobStoreFileID:
                     with job_desc.getLogFileHandle(job_store) as f:
-                        self.msg += "\n" + StatsAndLogging.formatLogStream(f, job_desc)
+                        self.msg += "\n" + StatsAndLogging.formatLogStream(f, f'Log from job "{job_desc}"')
         # catch failures to prepare more complex details and only return the basics
         except Exception:
             logger.exception("Exception when compiling information about failed jobs")

--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -628,7 +628,7 @@ class AbstractFileStore(ABC):
         log information.
 
         :param name: A hierarchical, .-delimited string.
-        :param stream: A stream of encoded text. Encodign errirs will be
+        :param stream: A stream of encoded text. Encoding errors will be
             tolerated.
         """
 

--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -619,7 +619,7 @@ class AbstractFileStore(ABC):
     def logToMaster(self, text: str, level: int = logging.INFO) -> None:
         self.log_to_leader(text, level)
 
-    def log_user_stream(self, name: str, stream: IO[bytes]):
+    def log_user_stream(self, name: str, stream: IO[bytes]) -> None:
         """
         Send a stream of UTF-8 text to the leader as a named log stream.
 

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -874,7 +874,7 @@ class JobDescription(Requirer):
         """
         Get the names and ID of this job as a named tuple.
         """
-        return Names(self.jobName, self.unitName, self.displayName, str(self), str(self.jobStoreID))
+        return Names(self.jobName, self.unitName, self.displayName, self.displayName, str(self.jobStoreID))
 
     def get_chain(self) -> List[Names]:
         """

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -1208,7 +1208,7 @@ class Leader:
                     # more memory efficient than read().striplines() while leaving off the
                     # trailing \n left when using readlines()
                     # http://stackoverflow.com/a/15233739
-                    StatsAndLogging.logWithFormatting(job_store_id, log_stream, method=logger.warning,
+                    StatsAndLogging.logWithFormatting(f'Log from job "{job_store_id}"', log_stream, method=logger.warning,
                                                       message='The job seems to have left a log file, indicating failure: %s' % replacement_job)
                 if self.config.writeLogs or self.config.writeLogsGzip:
                     with replacement_job.getLogFileHandle(self.jobStore) as log_stream:
@@ -1236,7 +1236,7 @@ class Leader:
                         else:
                             with log_stream:
                                 if os.path.getsize(log_file) > 0:
-                                    StatsAndLogging.logWithFormatting(job_store_id, log_stream, method=logger.warning,
+                                    StatsAndLogging.logWithFormatting(f'Log from job "{job_store_id}"', log_stream, method=logger.warning,
                                                                       message='The batch system left a non-empty file %s:' % log_file)
                                     if self.config.writeLogs or self.config.writeLogsGzip:
                                         file_root, _ = os.path.splitext(os.path.basename(log_file))

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gzip
+import io
 import json
 import logging
 import os
@@ -49,7 +50,7 @@ class StatsAndLogging:
         self._worker.start()
 
     @classmethod
-    def formatLogStream(cls, stream: Union[IO[str], IO[bytes]], job_name: Optional[str] = None) -> str:
+    def formatLogStream(cls, stream: Union[IO[str], IO[bytes]], stream_name: str) -> str:
         """
         Given a stream of text or bytes, and the job name, job itself, or some
         other optional stringifyable identity info for the job, return a big
@@ -62,7 +63,7 @@ class StatsAndLogging:
 
         :param stream: The stream of text or bytes to print for the user.
         """
-        lines = [f'Log from job "{job_name}" follows:', '=========>']
+        lines = [f'{stream_name} follows:', '=========>']
 
         for line in stream:
             if isinstance(line, bytes):
@@ -75,13 +76,13 @@ class StatsAndLogging:
 
 
     @classmethod
-    def logWithFormatting(cls, jobStoreID: str, jobLogs: Union[IO[str], IO[bytes]], method: Callable[[str], None] = logger.debug,
+    def logWithFormatting(cls, stream_name: str, jobLogs: Union[IO[str], IO[bytes]], method: Callable[[str], None] = logger.debug,
                             message: Optional[str] = None) -> None:
         if message is not None:
             method(message)
 
-        # Format and log the logs, identifying the job with its job store ID.
-        method(cls.formatLogStream(jobLogs, jobStoreID))
+        # Format and log the logs, identifying the stream with the given name.
+        method(cls.formatLogStream(jobLogs, stream_name))
 
     @classmethod
     def writeLogFiles(cls, jobNames: List[str], jobLogList: List[str], config: 'Config', failed: bool = False) -> None:
@@ -118,6 +119,9 @@ class StatsAndLogging:
             # we don't have anywhere to write the logs, return now
             return
 
+        # Make sure the destination exists
+        os.makedirs(path, exist_ok=True)
+
         fullName = createName(path, mainFileName, extension, failed)
         with writeFn(fullName, 'wb') as f:
             for l in jobLogList:
@@ -150,7 +154,9 @@ class StatsAndLogging:
             stats = json.loads(statsStr, object_hook=Expando)
             if not stats:
                 return
+            
             try:
+                # Handle all the log_to_leader messages
                 logs = stats.workers.logs_to_leader
             except AttributeError:
                 # To be expected if there were no calls to log_to_leader()
@@ -160,6 +166,28 @@ class StatsAndLogging:
                     logger.log(int(message.level),
                                'Got message from job at time %s: %s',
                                time.strftime('%m-%d-%Y %H:%M:%S'), message.text)
+
+            try:
+                # Handle all the user-level text streams reported back (command output, etc.)
+                user_logs = stats.workers.logging_user_streams
+            except AttributeError:
+                # To be expected if there were no calls to log_user_stream()
+                pass
+            else:
+                for stream_entry in user_logs:
+                    try:
+                        # Unpack the stream name and text.
+                        name, text = stream_entry.name, stream_entry.text
+                    except AttributeError:
+                        # Doesn't have a user-provided stream name and stream
+                        # text, so skip it.
+                        continue
+                    # Since this is sent as inline text we need to pretend to stream it.
+                    # TODO: Save these as individual files if they start to get too big?
+                    cls.logWithFormatting(name, io.StringIO(text), logger.info)
+                    # Save it as a log file, as if it were a Toil-level job.
+                    cls.writeLogFiles([name], [text], config=config)
+
             try:
                 logs = stats.logs
             except AttributeError:
@@ -168,7 +196,7 @@ class StatsAndLogging:
                 # we may have multiple jobs per worker
                 jobNames = logs.names
                 messages = logs.messages
-                cls.logWithFormatting(jobNames[0], messages,
+                cls.logWithFormatting(f'Log from job "{jobNames[0]}"', messages,
                                       message='Received Toil worker log. Disable debug level logging to hide this output')
                 cls.writeLogFiles(jobNames, messages, config=config)
 

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -96,7 +96,7 @@ class StatsAndLogging:
             logName = ('failed_' if failed else '') + logName
             counter = 0
             while True:
-                suffix = str(counter).zfill(3) + logExtension
+                suffix = '_' + str(counter).zfill(3) + logExtension
                 fullName = os.path.join(logPath, logName + suffix)
                 #  The maximum file name size in the default HFS+ file system is 255 UTF-16 encoding units, so basically 255 characters
                 if len(fullName) >= 255:

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -154,7 +154,7 @@ class StatsAndLogging:
             stats = json.loads(statsStr, object_hook=Expando)
             if not stats:
                 return
-            
+
             try:
                 # Handle all the log_to_leader messages
                 logs = stats.workers.logs_to_leader

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -151,7 +151,7 @@ class StatsAndLogging:
             if not stats:
                 return
             try:
-                logs = stats.workers.logsToMaster
+                logs = stats.workers.logs_to_leader
             except AttributeError:
                 # To be expected if there were no calls to log_to_leader()
                 pass

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -548,14 +548,16 @@ class AbstractJobStoreTest:
             jobNames = ['testStatsAndLogging_writeLogFiles']
             jobLogList = ['string', b'bytes', '', b'newline\n']
             config = self._createConfig()
-            setattr(config, 'writeLogs', '.')
+            setattr(config, 'writeLogs', self._createTempDir())
             setattr(config, 'writeLogsGzip', None)
             StatsAndLogging.writeLogFiles(jobNames, jobLogList, config)
-            jobLogFile = os.path.join(config.writeLogs, jobNames[0] + '000.log')
+            jobLogFile = os.path.join(config.writeLogs, jobNames[0] + '_000.log')
+            # The log directory should get exactly one file, names after this
+            # easy job name with no replacements needed.
+            self.assertEqual(os.listdir(config.writeLogs), [os.path.basename(jobLogFile)])
             self.assertTrue(os.path.isfile(jobLogFile))
             with open(jobLogFile) as f:
                 self.assertEqual(f.read(), 'string\nbytes\n\nnewline\n')
-            os.remove(jobLogFile)
 
         def testBatchCreate(self):
             """Test creation of many jobs."""

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -82,7 +82,7 @@ class ToilStatus:
                 with job.getLogFileHandle(self.jobStore) as fH:
                     # TODO: This looks intended to be machine-readable, but the format is
                     #  unspecified and no escaping is done. But keep these tags around.
-                    print(StatsAndLogging.formatLogStream(fH, job_name=f"LOG_FILE_OF_JOB:{job} LOG:"))
+                    print(StatsAndLogging.formatLogStream(fH, stream_name=f"LOG_FILE_OF_JOB:{job} LOG:"))
             else:
                 print(f"LOG_FILE_OF_JOB: {job} LOG: Job has no log file")
 

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -1670,9 +1670,15 @@ class WDLTaskJob(WDLBaseJob):
                 task_container.run(miniwdl_logger, command_string)
             finally:
                 if os.path.exists(host_stderr_txt):
-                    logger.info('Standard error at %s: %s', host_stderr_txt, open(host_stderr_txt).read())
+                    logger.info('Standard error at %s', host_stderr_txt)
+                    # Save the whole error stream.
+                    file_store.log_user_stream(self._namespace + '.stderr', open(host_stderr_txt, 'rb'))
+
                 if os.path.exists(host_stdout_txt):
-                    logger.info('Standard output at %s: %s', host_stdout_txt, open(host_stdout_txt).read())
+                    logger.info('Standard output at %s', host_stdout_txt)
+                    # Save the whole output stream.
+                    file_store.log_user_stream(self._namespace + '.stdout', open(host_stdout_txt, 'rb'))
+
 
         else:
             # We need to fake stdout and stderr, since nothing ran but the

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -1202,6 +1202,8 @@ class WDLBaseJob(Job):
     null values for things not defined in a section. Post-processing operations
     can be added onto any job before it is saved, and will be applied as long
     as the job's run method calls postprocess().
+
+    Also responsible for remembering the execution directory.
     """
 
     def __init__(self, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
@@ -1337,18 +1339,21 @@ class WDLTaskJob(WDLBaseJob):
     All bindings are in terms of task-internal names.
     """
 
-    def __init__(self, task: WDL.Tree.Task, prev_node_results: Sequence[Promised[WDLBindings]], task_id: List[str], namespace: str, **kwargs: Any) -> None:
+    def __init__(self, task: WDL.Tree.Task, prev_node_results: Sequence[Promised[WDLBindings]], task_id: List[str], namespace: str, task_path: str, **kwargs: Any) -> None:
         """
         Make a new job to run a task.
 
         :param namespace: The namespace that the task's *contents* exist in.
                The caller has alredy added the task's own name.
+
+        :param task_path: Like the namespace, but including subscript numbers
+               for scatters.
         """
 
         # This job should not be local because it represents a real workflow task.
         # TODO: Instead of re-scheduling with more resources, add a local
         # "wrapper" job like CWL uses to determine the actual requirements.
-        super().__init__(unitName=namespace, displayName=namespace, local=False, **kwargs)
+        super().__init__(unitName=task_path, displayName=task_path, local=False, **kwargs)
 
         logger.info("Preparing to run task %s as %s", task.name, namespace)
 
@@ -1356,6 +1361,7 @@ class WDLTaskJob(WDLBaseJob):
         self._prev_node_results = prev_node_results
         self._task_id = task_id
         self._namespace = namespace
+        self._task_path = task_path
 
     def can_fake_root(self) -> bool:
         """
@@ -1507,7 +1513,7 @@ class WDLTaskJob(WDLBaseJob):
             # resources.
             # TODO: What if the runtime section says we need a lot of disk to
             # hold the large files that the inputs section is going to write???
-            rescheduled = WDLTaskJob(self._task, self._prev_node_results, self._task_id, self._namespace, cores=runtime_cores or self.cores, memory=runtime_memory or self.memory, disk=runtime_disk or self.disk, accelerators=runtime_accelerators or self.accelerators)
+            rescheduled = WDLTaskJob(self._task, self._prev_node_results, self._task_id, self._namespace, self._task_path, cores=runtime_cores or self.cores, memory=runtime_memory or self.memory, disk=runtime_disk or self.disk, accelerators=runtime_accelerators or self.accelerators)
             # Run that as a child
             self.addChild(rescheduled)
 
@@ -1692,7 +1698,7 @@ class WDLTaskJob(WDLBaseJob):
                     logger.error('Failed task left standard error at %s of %d bytes', host_stderr_txt, size)
                     if size > 0:
                         # Send the whole error stream.
-                        file_store.log_user_stream(self._namespace + '.stderr', open(host_stderr_txt, 'rb'))
+                        file_store.log_user_stream(self.description.displayName + '.stderr', open(host_stderr_txt, 'rb'))
 
                 if os.path.exists(host_stdout_txt):
                     size = os.path.getsize(host_stdout_txt)
@@ -1701,7 +1707,7 @@ class WDLTaskJob(WDLBaseJob):
                         # Save the whole output stream.
                         # TODO: We can't tell if this was supposed to be
                         # captured. It might really be huge binary data.
-                        file_store.log_user_stream(self._namespace + '.stdout', open(host_stdout_txt, 'rb'))
+                        file_store.log_user_stream(self.description.displayName + '.stdout', open(host_stdout_txt, 'rb'))
 
                 # Keep crashing
                 raise
@@ -1732,14 +1738,14 @@ class WDLTaskJob(WDLBaseJob):
             logger.info('Unused standard error at %s of %d bytes', host_stderr_txt, size)
             if size > 0:
                 # Save the whole error stream because the workflow didn't capture it.
-                file_store.log_user_stream(self._namespace + '.stderr', open(host_stderr_txt, 'rb'))
+                file_store.log_user_stream(self.description.displayName + '.stderr', open(host_stderr_txt, 'rb'))
 
         if not outputs_library.stdout_used() and os.path.exists(host_stdout_txt):
             size = os.path.getsize(host_stdout_txt)
             logger.info('Unused standard output at %s of %d bytes', host_stdout_txt, size)
             if size > 0:
                 # Save the whole output stream because the workflow didn't capture it.
-                file_store.log_user_stream(self._namespace + '.stdout', open(host_stdout_txt, 'rb'))
+                file_store.log_user_stream(self.description.displayName + '.stdout', open(host_stdout_txt, 'rb'))
 
         # TODO: Check the output bindings against the types of the decls so we
         # can tell if we have a null in a value that is supposed to not be
@@ -1759,7 +1765,7 @@ class WDLWorkflowNodeJob(WDLBaseJob):
     Job that evaluates a WDL workflow node.
     """
 
-    def __init__(self, node: WDL.Tree.WorkflowNode, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, node: WDL.Tree.WorkflowNode, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, task_path: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
         """
         Make a new job to run a workflow node to completion.
         """
@@ -1768,6 +1774,7 @@ class WDLWorkflowNodeJob(WDLBaseJob):
         self._node = node
         self._prev_node_results = prev_node_results
         self._namespace = namespace
+        self._task_path = task_path
 
         if isinstance(self._node, WDL.Tree.Call):
             logger.debug("Preparing job for call node %s", self._node.workflow_node_id)
@@ -1811,11 +1818,11 @@ class WDLWorkflowNodeJob(WDLBaseJob):
 
                 if isinstance(self._node.callee, WDL.Tree.Workflow):
                     # This is a call of a workflow
-                    subjob: WDLBaseJob = WDLWorkflowJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, f'{self._namespace}.{self._node.name}', self._execution_dir)
+                    subjob: WDLBaseJob = WDLWorkflowJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, f'{self._namespace}.{self._node.name}', f'{self._task_path}.{self._node.name}', self._execution_dir)
                     self.addChild(subjob)
                 elif isinstance(self._node.callee, WDL.Tree.Task):
                     # This is a call of a task
-                    subjob = WDLTaskJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, f'{self._namespace}.{self._node.name}')
+                    subjob = WDLTaskJob(self._node.callee, [input_bindings, passed_down_bindings], self._node.callee_id, f'{self._namespace}.{self._node.name}', f'{self._task_path}.{self._node.name}')
                     self.addChild(subjob)
                 else:
                     raise WDL.Error.InvalidType(self._node, "Cannot call a " + str(type(self._node.callee)))
@@ -1826,14 +1833,14 @@ class WDLWorkflowNodeJob(WDLBaseJob):
                 self.defer_postprocessing(subjob)
                 return subjob.rv()
             elif isinstance(self._node, WDL.Tree.Scatter):
-                subjob = WDLScatterJob(self._node, [incoming_bindings], self._namespace, self._execution_dir)
+                subjob = WDLScatterJob(self._node, [incoming_bindings], self._namespace, self._task_path, self._execution_dir)
                 self.addChild(subjob)
                 # Scatters don't really make a namespace, just kind of a scope?
                 # TODO: Let stuff leave scope!
                 self.defer_postprocessing(subjob)
                 return subjob.rv()
             elif isinstance(self._node, WDL.Tree.Conditional):
-                subjob = WDLConditionalJob(self._node, [incoming_bindings], self._namespace, self._execution_dir)
+                subjob = WDLConditionalJob(self._node, [incoming_bindings], self._namespace, self._task_path, self._execution_dir)
                 self.addChild(subjob)
                 # Conditionals don't really make a namespace, just kind of a scope?
                 # TODO: Let stuff leave scope!
@@ -2053,13 +2060,14 @@ class WDLSectionJob(WDLBaseJob):
     Job that can create more graph for a section of the wrokflow.
     """
 
-    def __init__(self, namespace: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, namespace: str, task_path: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
         """
         Make a WDLSectionJob where the interior runs in the given namespace,
         starting with the root workflow.
         """
         super().__init__(execution_dir, **kwargs)
         self._namespace = namespace
+        self._task_path = task_path
 
     @staticmethod
     def coalesce_nodes(order: List[str], section_graph: WDLWorkflowGraph) -> List[List[str]]:
@@ -2127,7 +2135,7 @@ class WDLSectionJob(WDLBaseJob):
 
 
 
-    def create_subgraph(self, nodes: Sequence[WDL.Tree.WorkflowNode], gather_nodes: Sequence[WDL.Tree.Gather], environment: WDLBindings, local_environment: Optional[WDLBindings] = None) -> WDLBaseJob:
+    def create_subgraph(self, nodes: Sequence[WDL.Tree.WorkflowNode], gather_nodes: Sequence[WDL.Tree.Gather], environment: WDLBindings, local_environment: Optional[WDLBindings] = None, subscript: Optional[int] = None) -> WDLBaseJob:
         """
         Make a Toil job to evaluate a subgraph inside a workflow or workflow
         section.
@@ -2143,7 +2151,15 @@ class WDLSectionJob(WDLBaseJob):
         :param local_environment: Bindings in this environment will be
                used to evaluate the subgraph but will go out of scope
                at the end of the section.
+        :param subscript: If the subgraph is being evaluated multiple times,
+               this should be a disambiguating integer for logging.
         """
+
+        # Work out what to call what we are working on
+        task_path = self._task_path
+        if subscript is not None:
+            # We need to include a scatter loop number.
+            task_path += f'.{subscript}'
 
         if local_environment is not None:
             # Bring local environment into scope
@@ -2204,7 +2220,7 @@ class WDLSectionJob(WDLBaseJob):
 
             if len(node_ids) == 1:
                 # Make a one-node job
-                job: WDLBaseJob = WDLWorkflowNodeJob(section_graph.get(node_ids[0]), rvs, self._namespace, self._execution_dir)
+                job: WDLBaseJob = WDLWorkflowNodeJob(section_graph.get(node_ids[0]), rvs, self._namespace, task_path, self._execution_dir)
             else:
                 # Make a multi-node job
                 job = WDLWorkflowNodeListJob([section_graph.get(node_id) for node_id in node_ids], rvs, self._namespace, self._execution_dir)
@@ -2304,11 +2320,11 @@ class WDLScatterJob(WDLSectionJob):
     instance of the body. If an instance of the body doesn't create a binding,
     it gets a null value in the corresponding array.
     """
-    def __init__(self, scatter: WDL.Tree.Scatter, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, scatter: WDL.Tree.Scatter, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, task_path: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
         """
         Create a subtree that will run a WDL scatter. The scatter itself and the contents live in the given namespace.
         """
-        super().__init__(namespace, **kwargs, unitName=scatter.workflow_node_id, displayName=scatter.workflow_node_id, execution_dir=execution_dir)
+        super().__init__(namespace, task_path, **kwargs, unitName=scatter.workflow_node_id, displayName=scatter.workflow_node_id, execution_dir=execution_dir)
 
         # Because we need to return the return value of the workflow, we need
         # to return a Toil promise for the last/sink job in the workflow's
@@ -2345,7 +2361,7 @@ class WDLScatterJob(WDLSectionJob):
             raise RuntimeError("The returned value from a scatter is not an Array type.")
 
         scatter_jobs = []
-        for item in scatter_value.value:
+        for subscript, item in enumerate(scatter_value.value):
             # Make an instantiation of our subgraph for each possible value of
             # the variable. Make sure the variable is bound only for the
             # duration of the body.
@@ -2354,7 +2370,7 @@ class WDLScatterJob(WDLSectionJob):
             # TODO: We need to turn values() into a list because MyPy seems to
             # think a dict_values isn't a Sequence. This is a waste of time to
             # appease MyPy but probably better than a cast?
-            scatter_jobs.append(self.create_subgraph(self._scatter.body, list(self._scatter.gathers.values()), bindings, local_bindings))
+            scatter_jobs.append(self.create_subgraph(self._scatter.body, list(self._scatter.gathers.values()), bindings, local_bindings, subscript=subscript))
 
         if len(scatter_jobs) == 0:
             # No scattering is needed. We just need to bind all the names.
@@ -2443,11 +2459,11 @@ class WDLConditionalJob(WDLSectionJob):
     """
     Job that evaluates a conditional in a WDL workflow.
     """
-    def __init__(self, conditional: WDL.Tree.Conditional, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, conditional: WDL.Tree.Conditional, prev_node_results: Sequence[Promised[WDLBindings]], namespace: str, task_path: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
         """
         Create a subtree that will run a WDL conditional. The conditional itself and its contents live in the given namespace.
         """
-        super().__init__(namespace, **kwargs, unitName=conditional.workflow_node_id, displayName=conditional.workflow_node_id, execution_dir=execution_dir)
+        super().__init__(namespace, task_path, **kwargs, unitName=conditional.workflow_node_id, displayName=conditional.workflow_node_id, execution_dir=execution_dir)
 
         # Once again we need to ship the whole body template to be instantiated
         # into Toil jobs only if it will actually run.
@@ -2495,7 +2511,7 @@ class WDLWorkflowJob(WDLSectionJob):
     Job that evaluates an entire WDL workflow.
     """
 
-    def __init__(self, workflow: WDL.Tree.Workflow, prev_node_results: Sequence[Promised[WDLBindings]], workflow_id: List[str], namespace: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, workflow: WDL.Tree.Workflow, prev_node_results: Sequence[Promised[WDLBindings]], workflow_id: List[str], namespace: str, task_path: str, execution_dir: Optional[str] = None, **kwargs: Any) -> None:
         """
         Create a subtree that will run a WDL workflow. The job returns the
         return value of the workflow.
@@ -2503,7 +2519,7 @@ class WDLWorkflowJob(WDLSectionJob):
         :param namespace: the namespace that the workflow's *contents* will be
                in. Caller has already added the workflow's own name.
         """
-        super().__init__(namespace, execution_dir, **kwargs)
+        super().__init__(namespace, task_path, execution_dir, **kwargs)
 
         # Because we need to return the return value of the workflow, we need
         # to return a Toil promise for the last/sink job in the workflow's
@@ -2613,8 +2629,8 @@ class WDLRootJob(WDLSectionJob):
         Create a subtree to run the workflow and namespace the outputs.
         """
 
-        # The root workflow names the root namespace
-        super().__init__(workflow.name, execution_dir, **kwargs)
+        # The root workflow names the root namespace and task path.
+        super().__init__(workflow.name, workflow.name, execution_dir, **kwargs)
 
         self._workflow = workflow
         self._inputs = inputs
@@ -2628,7 +2644,7 @@ class WDLRootJob(WDLSectionJob):
 
         # Run the workflow. We rely in this to handle entering the input
         # namespace if needed, or handling free-floating inputs.
-        workflow_job = WDLWorkflowJob(self._workflow, [self._inputs], [self._workflow.name], self._namespace, self._execution_dir)
+        workflow_job = WDLWorkflowJob(self._workflow, [self._inputs], [self._workflow.name], self._namespace, self._task_path, self._execution_dir)
         workflow_job.then_namespace(self._namespace)
         self.addChild(workflow_job)
         self.defer_postprocessing(workflow_job)

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -289,7 +289,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
     failure_exit_code = 1
     statsDict = StatsDict()  # type: ignore[no-untyped-call]
     statsDict.jobs = []
-    statsDict.workers.logsToMaster = []
+    statsDict.workers.logs_to_leader = []
 
     def blockFn() -> bool:
         return True
@@ -411,7 +411,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
                             # job body cut.
 
                 # Accumulate messages from this job & any subsequent chained jobs
-                statsDict.workers.logsToMaster += fileStore.loggingMessages
+                statsDict.workers.logs_to_leader += fileStore.loggingMessages
 
                 logger.info("Completed body for %s", jobDesc)
 
@@ -608,7 +608,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
         statsDict.logs.names = listOfJobs
         statsDict.logs.messages = logMessages
 
-    if (debugging or config.stats or statsDict.workers.logsToMaster) and not jobAttemptFailed:  # We have stats/logging to report back
+    if (debugging or config.stats or statsDict.workers.logs_to_leader) and not jobAttemptFailed:  # We have stats/logging to report back
         jobStore.write_logs(json.dumps(statsDict, ensure_ascii=True))
 
     # Remove the temp dir

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -314,7 +314,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
         ##########################################
 
         jobDesc = jobStore.load_job(jobStoreID)
-        listOfJobs[0] = str(jobDesc)
+        listOfJobs[0] = jobDesc.displayName
         logger.debug("Parsed job description")
 
         ##########################################
@@ -460,7 +460,7 @@ def workerScript(jobStore: AbstractJobStore, config: Config, jobName: str, jobSt
             successorID = successor.jobStoreID
 
             # add the successor to the list of jobs run
-            listOfJobs.append(str(successor))
+            listOfJobs.append(successor.displayName)
 
             # Now we need to become that successor, under the original ID.
             successor.replace(jobDesc)


### PR DESCRIPTION
This changes CWL and WDL logging so that standard output and standard error from user commands, if they aren't captured, get thrown into the stats and logging system. Now you can see them without having to log at debug level and dig through Toil's logs.

This should fix #4657 (if you use `--writeLogs` and look in the directory, or if you don't mind *some* Toil log messages about jobs being run), and should also fix #2406 by letting you see command outputs/error logs there as well.

```
$ toil-wdl-runner --writeLogs logs https://raw.githubusercontent.com/DataBiosphere/toil/36b54c45e8554ded5093bcdd03edb2f6b0d93887/src/toil/test/wdl/miniwdl_self_test/self_test.wdl https://raw.githubusercontent.com/DataBiosphere/toil/36b54c45e8554ded5093bcdd03edb2f6b0d93887/src/toil/test/wdl/miniwdl_self_test/inputs.json

[2024-01-16T20:12:15-0500] [MainThread] [I] [toil.wdl.wdltoil] Inputs appear to come from a Github repository; adding repository root to file search path
[2024-01-16T20:12:15-0500] [MainThread] [I] [toil.wdl.wdltoil] Imported https://raw.githubusercontent.com/chanzuckerberg/miniwdl/main/tests/alyssa_ben.txt
[2024-01-16T20:12:15-0500] [MainThread] [I] [toil.wdl.wdltoil] Imported https://raw.githubusercontent.com/chanzuckerberg/miniwdl/main/tests/alyssa_ben.txt
[2024-01-16T20:12:15-0500] [MainThread] [I] [toil] Running Toil version 5.13.0a1-1125cfb27e75d3e677a7d705bedda3cf67ed6d9b-dirty on host swords.local.
[2024-01-16T20:12:15-0500] [MainThread] [I] [toil.leader] 0 jobs are running, 0 jobs are issued and waiting to run
[2024-01-16T20:12:18-0500] [Thread-3 (statsAndLoggingAggregator)] [I] [toil.statsAndLogging] hello_caller.2.hello.stderr follows:
=========>
	+ grep -qv '^#' /mnt/miniwdl_task_container/work/_miniwdl_inputs/0/tmpdjmslq4d
	++ cat /mnt/miniwdl_task_container/work/_miniwdl_inputs/0/tmpdjmslq4d
	+ name='Ben Bitdiddle'
	+ mkdir messages
	+ echo 'Hello, Ben Bitdiddle!'
	+ tee 'messages/Ben Bitdiddle.txt'
	Hello, Ben Bitdiddle!
<=========
[2024-01-16T20:12:19-0500] [Thread-3 (statsAndLoggingAggregator)] [I] [toil.statsAndLogging] hello_caller.0.hello.stderr follows:
=========>
	+ grep -qv '^#' /mnt/miniwdl_task_container/work/_miniwdl_inputs/0/tmpuj4bvb9f
<=========
[2024-01-16T20:12:19-0500] [Thread-3 (statsAndLoggingAggregator)] [I] [toil.statsAndLogging] hello_caller.1.hello.stderr follows:
=========>
	+ grep -qv '^#' /mnt/miniwdl_task_container/work/_miniwdl_inputs/0/tmpypqh6_n3
	++ cat /mnt/miniwdl_task_container/work/_miniwdl_inputs/0/tmpypqh6_n3
	+ name='Alyssa P. Hacker'
	+ mkdir messages
	+ echo 'Hello, Alyssa P. Hacker!'
	+ tee 'messages/Alyssa P. Hacker.txt'
	Hello, Alyssa P. Hacker!
<=========
[2024-01-16T20:12:26-0500] [MainThread] [I] [toil.leader] Finished toil run successfully.

Workflow Progress 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 (0 failures) [00:09<00:00, 0.64 jobs/s]
{"hello_caller.message_files": ["/Users/anovak/workspace/toil/wdl-out-44ewgj2_/Alyssa P. Hacker.txt", "/Users/anovak/workspace/toil/wdl-out-44ewgj2_/Ben Bitdiddle.txt"], "hello_caller.messages": ["Hello, Alyssa P. Hacker!", "Hello, Ben Bitdiddle!"]}
[2024-01-16T20:12:26-0500] [MainThread] [I] [toil.common] Successfully deleted the job store: FileJobStore(/var/folders/0n/4y413_9s7y70lmm3yhtt3b8m0000gq/T/tmpx0c1s5z1/tree)
```

```
$ ls logs/

hello_caller.0.hello.stderr_000.log  hello_caller.1.hello.stderr_000.log  hello_caller.2.hello.stderr_000.log
```

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Stats and logging system again uses job display name
 * WDL and CWL task standard output and standard error logs that are not captured by the workflow will now be logged at INFO level and stored in the `--writeLogs`/`--writeLogsGzip` directory.
 * WDL job names now include numbers for scatters

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

