### PR TITLE
Allow debugging jobs by name (and status improvements)

### DIFF
--- a/docs/running/debugging.rst
+++ b/docs/running/debugging.rst
@@ -47,24 +47,23 @@ But it will fail.
 
 If you want to reproduce the failure later, or on another machine, you can first find out what jobs failed with ``toil status``::
 
-    toil status --failed ./store
+    toil status --failed --noAggStats ./store
 
 This will produce something like:
 
     [2024-03-14T17:45:15-0400] [MainThread] [I] [toil.utils.toilStatus] Traversing the job graph gathering jobs. This may take a couple of minutes.
     Failed jobs:
     'WDLTaskJob' test.hello.command kind-WDLTaskJob/instance-r9u6_dcs v6
-    Of the 3 jobs considered, there are 1 completely failed jobs, 1 jobs with children, 2 jobs ready to run, 0 zombie jobs, 0 jobs with services, 0 services, and 1 jobs with log files currently in FileJobStore(/Users/anovak/workspace/toil/store).
 
-And we can see a failed job with the display name ``test.hello.command``, which describes the job's location in the WDL workflow (the command section of the ``hello`` task called from the ``test`` workflow). We can then run that job again locally by name with::
+And we can see a failed job with the display name ``test.hello.command``, which describes the job's location in the WDL workflow as the command section of the ``hello`` task called from the ``test`` workflow. (If you are writing a Toil Python script, this is the job's ``displayName``.) We can then run that job again locally by name with::
 
     toil debug-job ./store test.hello.command
 
-If there were multiple failed jobs with that name, we would need to select one by Toil job ID instead::
+If there were multiple failed jobs with that name (perhaps because of a WDL scatter), we would need to select one by Toil job ID instead::
 
     toil debug-job ./store kind-WDLTaskJob/instance-r9u6_dcs
 
-And if we know there's only one failed WDL task, we can just tell Toil to rerun the failed ``WDLTaskJob`` by class name::
+And if we know there's only one failed WDL task, we can just tell Toil to rerun the failed ``WDLTaskJob`` by Python class name::
 
     toil debug-job ./store WDLTaskJob
 

--- a/docs/running/debugging.rst
+++ b/docs/running/debugging.rst
@@ -5,8 +5,74 @@ Toil Debugging
 
 Toil has a number of tools to assist in debugging.  Here we provide help in working through potential problems that a user might encounter in attempting to run a workflow.
 
-Introspecting the Jobstore
---------------------------
+Reading the Log
+---------------
+
+Usually, at the end of a failed Toil worklfow, Toil will reproduce the job logs for the jobs that failed. You can look at the end of your workflow log and use the job logs to identify which jobs are failing and why.
+
+Finding Failed Jobs in the Jobstore 
+-----------------------------------
+
+The ``toil status`` command (:ref:`cli_status`) can be used with the ``--failed`` option to list all failed jobs in a Toil job store.
+
+You can also use it with the ``--logs`` option to retrieve per-job logs from the job store, for failed jobs that left them. These logs might be useful for diagnosing and fixing the problem.
+
+Running a Job Locally
+---------------------
+
+If you have a failing job's ID or name, you can reproduce its failure on your local machine with ``toil debug-job``. See :ref:`cli_debug_job`.
+
+For example, say you have this WDL workflow in ``test.wdl``. This workflow **cannot succeed**, due to the typo in the echo command::
+
+    version 1.0
+    workflow test {
+      call hello
+    }
+    task hello {
+      input {
+      }
+      command <<<
+        set -e
+        echoo "Hello"
+      >>>
+      output {
+      }
+    }
+
+You could try to run it with::
+
+    toil-wdl-runner --jobStore ./store test.wdl
+
+But it will fail.
+
+If you want to reproduce the failure later, or on another machine, you can first find out what jobs failed with ``toil status``::
+
+    toil status --failed ./store
+
+This will produce something like:
+
+    [2024-03-14T17:45:15-0400] [MainThread] [I] [toil.utils.toilStatus] Traversing the job graph gathering jobs. This may take a couple of minutes.
+    Failed jobs:
+    'WDLTaskJob' test.hello.command kind-WDLTaskJob/instance-r9u6_dcs v6
+    Of the 3 jobs considered, there are 1 completely failed jobs, 1 jobs with children, 2 jobs ready to run, 0 zombie jobs, 0 jobs with services, 0 services, and 1 jobs with log files currently in FileJobStore(/Users/anovak/workspace/toil/store).
+
+And we can see a failed job with the display name ``test.hello.command``, which describes the job's location in the WDL workflow (the command section of the ``hello`` task called from the ``test`` workflow). We can then run that job again locally by name with::
+
+    toil debug-job ./store test.hello.command
+
+If there were multiple failed jobs with that name, we would need to select one by Toil job ID instead::
+
+    toil debug-job ./store kind-WDLTaskJob/instance-r9u6_dcs
+
+And if we know there's only one failed WDL task, we can just tell Toil to rerun the failed ``WDLTaskJob`` by class name::
+
+    toil debug-job ./store WDLTaskJob
+
+Any of these will run the job (including any containers) on the local machine, where its execution can be observed live or monitored with a debugger.
+    
+
+Introspecting the Job Store
+---------------------------
 
 Note: Currently these features are only implemented for use locally (single machine) with the fileJobStore.
 
@@ -31,11 +97,11 @@ into the jobStore.
 
 Stats and Status
 ----------------
-See :ref:`cli_status` for more about gathering statistics about job success, runtime, and resource usage from workflows.
+See :ref:`cli_stats` and :ref:`cli_status` for more about gathering statistics about job success, runtime, and resource usage from workflows.
 
 Using a Python debugger
 -----------------------
 
-If you execute a workflow using the :code:`--debugWorker` flag, Toil will not fork in order to run jobs, which means
-you can either use `pdb <https://docs.python.org/3/library/pdb.html>`_, or an `IDE that supports debugging Python <https://wiki.python.org/moin/PythonDebuggingTools#IDEs_with_Debug_Capabilities>`_ as you would normally. Note that the :code:`--debugWorker` flag will
+If you execute a workflow using the :code:`--debugWorker` flag, or if you use ``toil debug-job``, Toil will run the job in the process you started from the command line. This means
+you can either use `pdb <https://docs.python.org/3/library/pdb.html>`_, or an `IDE that supports debugging Python <https://wiki.python.org/moin/PythonDebuggingTools#IDEs_with_Debug_Capabilities>`_ to interact with the Python process as it runs your job. Note that the :code:`--debugWorker` flag will
 only work with the :code:`single_machine` batch system (the default), and not any of the custom job schedulers.

--- a/docs/running/utils.rst
+++ b/docs/running/utils.rst
@@ -11,6 +11,8 @@ The generic ``toil`` subcommand utilities are:
 
     ``status`` --- Inspects a job store to see which jobs have failed, run successfully, etc.
 
+    ``debug-job`` --- Runs a failing job on your local machine.
+
     ``clean`` --- Delete the job store used by a previous Toil workflow invocation.
 
     ``kill`` --- Kills any running jobs in a rogue toil.
@@ -221,6 +223,8 @@ Otherwise, the ``toil status`` command will return something like the following:
 
 The ``toil status`` command supports several useful flags, including ``--perJob`` to get per-job status information, ``--logs`` to print stored worker logs, and ``--failed`` to list all failed jobs in the workflow. For more information, run ``toil status --help``.
 
+.. _cli_clean:
+
 Clean Command
 -------------
 
@@ -234,6 +238,22 @@ The deletion of the job store can be modified by the ``--clean`` argument, and m
 Temporary directories where jobs are running can also be saved from deletion using the ``--cleanWorkDir``, which has
 the same options as ``--clean``.  This option should only be run when debugging, as intermediate jobs will fill up
 disk space.
+
+.. _cli_debug_job:
+
+Debug Job Command
+-----------------
+
+If a Toil worklfow fails, and it wasn't run with ``--clean=always``, the failing job will be waiting in the job store to be debugged. (With WDL or CWL workflows, you may have needed to manually set a ``--jobStore`` location you can find again.)
+
+You can use ``toil debug-job`` on a job in the job store to run it on your local machine, to locally reproduce any error that may have happened during a remote workflow.
+
+The ``toil debug-job`` command takes a job store, and the ID or a name of a job in it. If multiple jobs match a job name, and only one seems to have run out of retries and completely failed, it will run that one.
+
+You can also pass the ``--printJobInfo`` flag to dump information about the job instead of running it.
+
+
+.. _cli_kill:
 
 Kill Command
 ------------

--- a/docs/running/utils.rst
+++ b/docs/running/utils.rst
@@ -33,9 +33,9 @@ Running an Example
 
 We can run an example workflow and record stats::
 
-    python3 discoverfiles.py file:my-jobstore --stats
+    python3 workflow.py file:my-jobstore --stats
 
-Where ``discoverfiles.py`` is the following:
+Where ``workflow.py`` is the following:
 
 .. literalinclude:: ../../src/toil/test/docs/scripts/tutorial_stats.py
 
@@ -202,7 +202,7 @@ Status Command
 
 Continuing the example from the stats section above, if we ran our workflow with the command ::
 
-    python3 discoverfiles.py file:my-jobstore --stats
+    python3 workflow.py file:my-jobstore --stats
 
 We could interrogate our jobstore with the status command, for example::
 
@@ -215,9 +215,11 @@ If the run was successful, this would not return much valuable information, some
     2018-01-11 19:31:29,740 - toil.utils.toilStatus - INFO - Checking if we have files for Toil
     The root job of the job store is absent, the workflow completed successfully.
 
-Otherwise, the ``status`` command should return the following:
+Otherwise, the ``toil status`` command will return something like the following:
 
-    There are ``x`` unfinished jobs, ``y`` parent jobs with children, ``z`` jobs with services, ``a`` services, and ``b`` totally failed jobs currently in  ``c``.
+    Of the 3 jobs considered, there are 1 completely failed jobs, 1 jobs with children, 2 jobs ready to run, 0 zombie jobs, 0 jobs with services, 0 services, and 0 jobs with log files currently in FileJobStore(/Users/anovak/workspace/toil/tree).
+
+The ``toil status`` command supports several useful flags, including ``--perJob`` to get per-job status information, ``--logs`` to print stored worker logs, and ``--failed`` to list all failed jobs in the workflow. For more information, run ``toil status --help``.
 
 Clean Command
 -------------

--- a/src/toil/test/docs/scripts/example_alwaysfail.py
+++ b/src/toil/test/docs/scripts/example_alwaysfail.py
@@ -16,7 +16,7 @@ def main():
 
     Then you can inspect the job store with tools like `toil status`:
 
-        toil status --printLogs ./jobstore
+        toil status --logs ./jobstore
 
     """
     parser = ArgumentParser(description=main.__doc__)

--- a/src/toil/utils/toilDebugJob.py
+++ b/src/toil/utils/toilDebugJob.py
@@ -21,6 +21,7 @@ from toil.common import Config, Toil, parser_with_common_options
 from toil.jobStores.fileJobStore import FileJobStore
 from toil.statsAndLogging import set_logging_from_options
 from toil.utils.toilDebugFile import printContentsOfJobStore
+from toil.utils.toilStatus import ToilStatus
 from toil.worker import workerScript
 
 logger = logging.getLogger(__name__)
@@ -28,10 +29,10 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     parser = parser_with_common_options(jobstore_option=True, prog="toil debug-job")
-    parser.add_argument("jobID", type=str, nargs='?', default=None,
-                        help="The job store id of a job within the provided jobstore to run by itself.")
-    parser.add_argument("--printJobInfo", type=str,
-                        help="Dump debugging info about this job ID")
+    parser.add_argument("job", type=str,
+                        help="The job store id or job name of a job within the provided jobstore")
+    parser.add_argument("--printJobInfo", action="store_true",
+                        help="Dump debugging info about the job instead of runnign it")
 
     options = parser.parse_args()
     set_logging_from_options(options)
@@ -42,36 +43,67 @@ def main() -> None:
     # But override its options
     config.setOptions(options)
 
-    did_something = False
+    # Find the job
+
+    if jobStore.job_exists(options.job):
+        # The user asked for a particular job and it exists
+        job_id = options.job
+    else:
+        # Go search by name and fill in job_id
+
+        # TODO: break out job store scan logic so it doesn't need to re-connect
+        # to the job store.
+        status = ToilStatus(options.jobStore)
+        hits = []
+        suggestion = None
+        for job in status.jobsToReport:
+            if options.job in (job.jobName, job.unitName, job.displayName):
+                # Find all the jobs that sort of match
+                hits.append(job)
+            if suggestion is None and job.remainingTryCount == 0:
+                # How about this nice failing job instead?
+                suggestion = job
+        if len(hits) == 0:
+            # No hits
+            if suggestion is None:
+                logger.critical("No job found with ID or name \"%s\". No jobs are completely failed.", options.job)
+            else:
+                logger.critical("No job found with ID or name \"%s\". How about the failed job %s instead?", options.job, suggestion)
+            sys.exit(1)
+        elif len(hits) > 1:
+            # Several hits, maybe only one has failed
+            completely_failed_hits = [job for job in hits if job.remainingTryCount == 0]
+            if len(completely_failed_hits) == 0:
+                logger.critical("Multiple jobs match \"%s\" but none are completely failed: %s", options.job, hits)
+                sys.exit(1)
+            elif len(completely_failed_hits) > 0:
+                logger.critical("Multiple jobs matching \"%s\" are completely failed: %s", options.job, completely_failed_hits)
+                sys.exit(1)
+            else:
+                # We found one completely failed job, they probably mean that one.
+                logger.info("There are %s jobs matching \"%s\"; assuming you mean the failed one: %s", options.job, completely_failed_hits[0])
+                job_id = completely_failed_hits[0].jobStoreID
+        else:
+            # We found one job with this name, so they must mean that one
+            logger.info("Looked up job named \"%s\": %s", options.job, hits[0])
+            job_id = hits[0].jobStoreID
 
     if options.printJobInfo:
+        # Report on the job
+
         if isinstance(jobStore, FileJobStore):
             # List all its files if we can
-            printContentsOfJobStore(job_store=jobStore, job_id=options.printJobInfo)
+            printContentsOfJobStore(job_store=jobStore, job_id=job_id)
         # Print the job description itself
-        job_desc = jobStore.load_job(options.printJobInfo)
+        job_desc = jobStore.load_job(job_id)
         print(f"Job: {job_desc}")
         pprint.pprint(job_desc.__dict__)
-
-        did_something = True
+    else:
+        # Run the job
+        logger.debug(f"Running the following job locally: {job_id}")
+        workerScript(jobStore, config, job_id, job_id, redirectOutputToLogFile=False)
+        logger.debug(f"Finished running: {job_id}")
 
     # TODO: Option to print list of successor jobs
     # TODO: Option to run job within python debugger, allowing step through of arguments
     # idea would be to have option to import pdb and set breakpoint at the start of the user's code
-
-    if options.jobID is not None:
-        # We actually want to run a job.
-
-        jobID = options.jobID
-        logger.debug(f"Running the following job locally: {jobID}")
-        workerScript(jobStore, config, jobID, jobID, redirectOutputToLogFile=False)
-        logger.debug(f"Finished running: {jobID}")
-        # Even if the job fails, the worker script succeeds unless something goes wrong with it internally.
-
-        did_something = True
-
-    if not did_something:
-        # Somebody forgot to tell us to do anything.
-        # Show the usage instructions.
-        parser.print_help()
-        sys.exit(1)

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -31,7 +31,11 @@ logger = logging.getLogger(__name__)
 def create_tags_dict(tags: List[str]) -> Dict[str, str]:
     tags_dict = dict()
     for tag in tags:
-        key, value = tag.split('=')
+        try:
+            key, value = tag.split('=')
+        except ValueError:
+            logger.error("Tag specification '%s' must contain '='", tag)
+            raise
         tags_dict[key] = value
     return tags_dict
 

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -345,7 +345,7 @@ def main() -> None:
                         help="Do not print overall, aggregate status of workflow.",
                         default=True)
 
-    parser.add_argument("--printDot", action="store_true",
+    parser.add_argument("--dot", "--printDot", dest="print_dot", action="store_true",
                         help="Print dot formatted description of the graph. If using --jobs will "
                              "restrict to subgraph including only those jobs. default=%(default)s",
                         default=False)
@@ -354,19 +354,19 @@ def main() -> None:
                         help="Restrict reporting to the following jobs (allows subsetting of the report).",
                         default=None)
 
-    parser.add_argument("--printPerJobStats", action="store_true",
+    parser.add_argument("--perJob", "--printPerJobStats", dest="print_per_job_stats", action="store_true",
                         help="Print info about each job. default=%(default)s",
                         default=False)
 
-    parser.add_argument("--printLogs", action="store_true",
+    parser.add_argument("--logs", "--printLogs", dest="print_logs", action="store_true",
                         help="Print the log files of jobs (if they exist). default=%(default)s",
                         default=False)
 
-    parser.add_argument("--printChildren", action="store_true",
+    parser.add_argument("--children", "--printChildren", dest="print_children", action="store_true",
                         help="Print children of each job. default=%(default)s",
                         default=False)
 
-    parser.add_argument("--printStatus", action="store_true",
+    parser.add_argument("--status", "--printStatus", dest="print_status", action="store_true",
                         help="Determine which jobs are currently running and the associated batch system ID")
     options = parser.parse_args()
     set_logging_from_options(options)
@@ -400,13 +400,13 @@ def main() -> None:
     properties = jobStats['properties']
     childNumber = jobStats['childNumber']
 
-    if options.printPerJobStats:
+    if options.print_per_job_stats:
         status.printAggregateJobStats(properties, childNumber)
-    if options.printLogs:
+    if options.print_logs:
         status.printJobLog()
-    if options.printChildren:
+    if options.print_children:
         status.printJobChildren()
-    if options.printDot:
+    if options.print_dot:
         status.print_dot_chart()
     if options.stats:
         print('Of the %i jobs considered, '
@@ -418,7 +418,7 @@ def main() -> None:
               'and %i jobs with log files currently in %s.' %
               (len(status.jobsToReport), len(hasChildren), len(readyToRun), len(zombies),
                len(hasServices), len(services), len(hasLogFile), status.jobStore))
-    if options.printStatus:
+    if options.print_status:
         status.print_bus_messages()
     if len(status.jobsToReport) > 0 and options.failIfNotComplete:
         # Upon workflow completion, all jobs will have been removed from job store

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -118,7 +118,7 @@ class ToilStatus:
                 parts.append(f"TRYS_REMAINING:{job.remainingTryCount}")
             if job_child_number > 0:
                 parts.append(f"CHILD_NUMBER:{job_child_number}")
-            
+
             print("\t".join(parts))
 
     def report_on_jobs(self) -> Dict[str, Any]:
@@ -383,6 +383,10 @@ def main() -> None:
 
     parser.add_argument("--status", "--printStatus", dest="print_status", action="store_true",
                         help="Determine which jobs are currently running and the associated batch system ID")
+
+    parser.add_argument("--failed", "--printFailed", dest="print_failed", action="store_true",
+                        help="List jobs which seem to have failed to run")
+
     options = parser.parse_args()
     set_logging_from_options(options)
 
@@ -424,6 +428,10 @@ def main() -> None:
         status.printJobChildren()
     if options.print_dot:
         status.print_dot_chart()
+    if options.print_failed:
+        print("Failed jobs:")
+        for job in completely_failed:
+            print(job)
     if options.stats:
         print('Of the %i jobs considered, '
               'there are '

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -394,11 +394,8 @@ def main() -> None:
         parser.print_help()
         sys.exit(0)
 
-    config = Config()
-    config.setOptions(options)
-
     try:
-        status = ToilStatus(config.jobStore, options.jobs)
+        status = ToilStatus(options.jobStore, options.jobs)
     except NoSuchJobStoreException:
         print('No job store found.')
         return


### PR DESCRIPTION
This will fix #4814 by pulling in some job store scanning logic from `toil status`. It also includes some fixes to `toil status`, which kind of didn't work.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * `toil status --printPerJobStats` actually reports per-job stats and not merged mega-stats.
 *  `toil status --printPerJobStats` uses a new more-readable format and notes completely failed jobs (those with 0 tries left)
 * `toil status` now has shorter flag names you can use
 * `toil status --failed` now exists and can print all the completely failed jobs (those with 0 tries left)
 * `toil debug-job` can now look up jobs by name and run them
 * Documentation now exists showing how to use `toil status` and `toil debug-job` to reproduce problems

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

