### PR TITLE
Revert ensurepip to get-pip to fix Python 3.10 ARM CI appliance builds

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -179,7 +179,7 @@ print(heredoc('''
     RUN chmod 777 /usr/bin/waitForKey.sh && chmod 777 /usr/bin/customDockerInit.sh && chmod 777 /usr/bin/singularity
 
     # The stock pip is too old and can't install from sdist with extras
-    RUN {python} -m ensurepip --upgrade
+    RUN curl -sS https://bootstrap.pypa.io/get-pip.py | {python}
 
     # Include virtualenv, as it is still the recommended way to deploy pipelines
     RUN {pip} install --upgrade virtualenv==20.25.1


### PR DESCRIPTION
Related to Dockerfile changes I made in #4824

For some reason, when I replaced the `get-pip` script with `ensurepip`, which should have been [included in the default python installation](https://docs.python.org/3/library/ensurepip.html), CI breaks on Python 3.10 on ARM:
```
 > [linux/amd64 15/26] RUN python3.10 -m ensurepip --upgrade:
#28 0.622 
#28 0.622 Python modules for the system python are usually handled by dpkg and apt-get.
#28 0.622 
#28 0.622     apt install python3-<module name>
#28 0.622 
#28 0.622 Install the python3-pip package to use pip itself.  Using pip together
#28 0.622 with the system python might have unexpected results for any system installed
#28 0.622 module, so use it on your own risk, or make sure to only use it in virtual
#28 0.622 environments.
#28 0.622 
```

I'm unsure of why this happens and how to create a fix around ensurepip, and my QEMU is unable to emulate ARM without segfaulting so I can't test this locally, so this just reverts it to what worked before (or at least should be).

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

No changelog entry as this is a CI maintenance PR

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

