### PR TITLE
Limit reading/mounting from shared filesystem JobStore

### DIFF
--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -286,7 +286,7 @@ Allows configuring Toil's data storage.
                         to use a batch system that does not support
                         cleanup. Set to "true" if caching
                         is desired.
- --symlinkJobStoreReads BOOL
+  --symlinkJobStoreReads BOOL
                         Allow reads and container mounts from a JobStore's
                         shared filesystem directly via symlink. Can be turned
                         off if the shared filesystem can't support the IO load

--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -286,6 +286,13 @@ Allows configuring Toil's data storage.
                         to use a batch system that does not support
                         cleanup. Set to "true" if caching
                         is desired.
+ --symlinkJobStoreReads BOOL
+                        Allow reads and container mounts from a JobStore's
+                        shared filesystem directly via symlink. Can be turned
+                        off if the shared filesystem can't support the IO load
+                        of all the jobs reading from it at once, and you want
+                        to use ``--caching=True`` to make jobs on each node
+                        read from node-local cache storage. (Default=True)
 
 **Autoscaling Options**
 Allows the specification of the minimum and maximum number of nodes in an

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -169,6 +169,7 @@ class Config:
     caching: Optional[bool]
     symlinkImports: bool
     moveOutputs: bool
+    symlink_job_store_reads: bool
 
     # Autoscaling options
     provisioner: Optional[str]
@@ -338,6 +339,7 @@ class Config:
         set_option("symlinkImports", old_names=["linkImports"])
         set_option("moveOutputs", old_names=["moveExports"])
         set_option("caching", old_names=["enableCaching"])
+        set_option("symlink_job_store_reads")
 
         # Autoscaling options
         set_option("provisioner")

--- a/src/toil/options/common.py
+++ b/src/toil/options/common.py
@@ -349,7 +349,7 @@ def add_base_toil_options(parser: ArgumentParser, jobstore_as_flag: bool = False
     link_imports_help = ("When using a filesystem based job store, CWL input files are by default symlinked in.  "
                          "Setting this option to True instead copies the files into the job store, which may protect "
                          "them from being modified externally.  When set to False, as long as caching is enabled, "
-                         "Toil will protect the file automatically by changing the permissions to read-only."
+                         "Toil will protect the file automatically by changing the permissions to read-only. "
                          "default=%(default)s")
     link_imports.add_argument("--symlinkImports", dest="symlinkImports", type=strtobool, default=True,
                               metavar="BOOL", help=link_imports_help)
@@ -357,7 +357,7 @@ def add_base_toil_options(parser: ArgumentParser, jobstore_as_flag: bool = False
     move_exports_help = ('When using a filesystem based job store, output files are by default moved to the '
                          'output directory, and a symlink to the moved exported file is created at the initial '
                          'location.  Setting this option to True instead copies the files into the output directory.  '
-                         'Applies to filesystem-based job stores only.'
+                         'Applies to filesystem-based job stores only. '
                          'default=%(default)s')
     move_exports.add_argument("--moveOutputs", dest="moveOutputs", type=strtobool, default=False, metavar="BOOL",
                               help=move_exports_help)
@@ -367,6 +367,11 @@ def add_base_toil_options(parser: ArgumentParser, jobstore_as_flag: bool = False
     caching.add_argument('--caching', dest='caching', type=opt_strtobool, default=None, metavar="BOOL",
                          help=caching_help)
     # default is None according to PR 4299, seems to be generated at runtime
+
+    file_store_options.add_argument("--symlinkJobStoreReads", dest="symlink_job_store_reads", type=strtobool, default=True,
+                                    metavar="BOOL",
+                                    help="Allow reads and container mounts from a JobStore's shared filesystem directly "
+                                         "via symlink. default=%(default)s")
 
     # Auto scaling options
     autoscaling_options = parser.add_argument_group(


### PR DESCRIPTION
This fixes #4673 by adding a `--symlinkJobStoreReads` option.

If you set `--symlinkJobStoreReads=False`, we won't create symlinks pointing into a FileJobStore when jobs go to read from it. We will instead make copies or hardlinks (within a filesystem). So if you have a workload that does more I/O on a file mounted into a container than a single full copy would do, you can use this to make a copy happen instead of having everyone mount straight from the shared filesystem.

If you have caching enabled, you can make the cache actually cache a copy per node instead of symlinking all the way through just because it can.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * New `--symlinkJobStoreReads=False` option lets you force local-node copies (possibly in the cache) even when reading directly from a FileJobStore is possible, potentially reducing shared filesystem IO.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklist.rst -->

* [ ] Make sure the PR passes tests.
* [ ] Make sure the PR has been reviewed **since its last modification**. If not, review it.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

