### PR TITLE
Anonymous AWS Access

### DIFF
--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -128,6 +128,8 @@ There are several environment variables that affect the way Toil runs.
 |                                  | access to S3 and SimpleDB, the AWS job store will  |
 |                                  | not be usable.                                     |
 +----------------------------------+----------------------------------------------------+
+| TOIL_AWS_ANONYMOUS_URL_ACCESS    | Whether to access s3:// URLs anonymously.          |
++----------------------------------+----------------------------------------------------+
 | TOIL_GOOGLE_PROJECTID            | The Google project ID to use when generating       |
 |                                  | Google job store names for tests or CWL workflows. |
 +----------------------------------+----------------------------------------------------+

--- a/docs/running/cliOptions.rst
+++ b/docs/running/cliOptions.rst
@@ -311,6 +311,10 @@ Allows configuring Toil's data storage.
                         of all the jobs reading from it at once, and you want
                         to use ``--caching=True`` to make jobs on each node
                         read from node-local cache storage. (Default=True)
+  --awsAnonymousUrlAccess BOOL
+                        Whether to access AWS S3 URLs anonymously. Useful for
+                        skipping multi-factor authentication when MFA is
+                        configured but unnecessary.
 
 **Autoscaling Options**
 Allows the specification of the minimum and maximum number of nodes in an

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 from threading import Condition
 from typing import Any, ContextManager, NamedTuple, Optional, Union, cast
 
-from toil.batchSystems.options import OptionSetter
+from toil.options import OptionSetter
 from toil.bus import MessageBus, MessageOutbox
 from toil.common import Config, Toil, cacheDirName
 from toil.deferred import DeferredFunctionManager
@@ -282,16 +282,17 @@ class AbstractBatchSystem(ABC):
         """
         If this batch system provides any command line options, add them to the given parser.
         """
+        pass
 
     @classmethod
     def setOptions(cls, setOption: OptionSetter) -> None:
         """
         Process command line or configuration options relevant to this batch system.
 
-        :param setOption: A function with signature
-            setOption(option_name, parsing_function=None, check_function=None, default=None, env=None)
-            returning nothing, used to update run configuration as a side effect.
+        :param setOption: A function taking an option name and returning
+            nothing, used to update run configuration as a side effect.
         """
+        pass
 
     def getWorkerContexts(self) -> list[ContextManager[Any]]:
         """

--- a/src/toil/batchSystems/awsBatch.py
+++ b/src/toil/batchSystems/awsBatch.py
@@ -48,7 +48,7 @@ from toil.batchSystems.abstractBatchSystem import (
 )
 from toil.batchSystems.cleanup_support import BatchSystemCleanupSupport
 from toil.batchSystems.contained_executor import pack_job
-from toil.batchSystems.options import OptionSetter
+from toil.options import OptionSetter
 from toil.bus import ExternalBatchIdMessage
 from toil.common import Config, Toil
 from toil.job import JobDescription, Requirer

--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -100,7 +100,7 @@ from toil.batchSystems.abstractBatchSystem import (
 )
 from toil.batchSystems.cleanup_support import BatchSystemCleanupSupport
 from toil.batchSystems.contained_executor import pack_job
-from toil.batchSystems.options import OptionSetter
+from toil.options import OptionSetter
 from toil.common import Config, Toil
 from toil.job import JobDescription, Requirer
 from toil.lib.conversions import human2bytes

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -39,7 +39,7 @@ from toil.batchSystems.abstractBatchSystem import (
 )
 from toil.batchSystems.local_support import BatchSystemLocalSupport
 from toil.batchSystems.mesos import JobQueue, MesosShape, TaskData, ToilJob
-from toil.batchSystems.options import OptionSetter
+from toil.options import OptionSetter
 from toil.job import JobDescription
 from toil.lib.conversions import b_to_mib, mib_to_b
 from toil.lib.memoize import strict_bool

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -13,7 +13,7 @@
 
 import logging
 from argparse import ArgumentParser, _ArgumentGroup
-from typing import Any, Callable, Optional, Protocol, TypeVar, Union
+from typing import Optional, Union
 
 from toil.batchSystems.registry import (
     DEFAULT_BATCH_SYSTEM,
@@ -21,32 +21,12 @@ from toil.batchSystems.registry import (
     get_batch_systems,
 )
 from toil.lib.threading import cpu_count
+# Need to re-export from here for compatibility with old batch system plugins
+from toil.options import OptionSetter as OptionSetter
 
 logger = logging.getLogger(__name__)
 
-
-class OptionSetter(Protocol):
-    """
-    Protocol for the setOption function we get to let us set up CLI options for
-    each batch system.
-
-    Actual functionality is defined in the Config class.
-    """
-
-    OptionType = TypeVar("OptionType")
-
-    def __call__(
-        self,
-        option_name: str,
-        parsing_function: Optional[Callable[[Any], OptionType]] = None,
-        check_function: Optional[Callable[[OptionType], Union[None, bool]]] = None,
-        default: Optional[OptionType] = None,
-        env: Optional[list[str]] = None,
-        old_names: Optional[list[str]] = None,
-    ) -> bool: ...
-
-
-def set_batchsystem_options(
+def set_batch_system_options(
     batch_system: Optional[str], set_option: OptionSetter
 ) -> None:
     """
@@ -80,7 +60,7 @@ def set_batchsystem_options(
     set_option("batch_logs_dir")
 
 
-def add_all_batchsystem_options(parser: Union[ArgumentParser, _ArgumentGroup]) -> None:
+def add_all_batch_system_options(parser: Union[ArgumentParser, _ArgumentGroup]) -> None:
     from toil.options.common import SYS_MAX_SIZE
 
     # Do the global cross-batch-system arguments

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -35,7 +35,7 @@ from toil.batchSystems.abstractBatchSystem import (
     ResourceSet,
     UpdatedBatchJobInfo,
 )
-from toil.batchSystems.options import OptionSetter
+from toil.options import OptionSetter
 from toil.bus import ExternalBatchIdMessage
 from toil.common import Config, Toil
 from toil.job import (

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -29,7 +29,7 @@ from toil.batchSystems.abstractBatchSystem import (
 from toil.batchSystems.abstractGridEngineBatchSystem import (
     AbstractGridEngineBatchSystem,
 )
-from toil.batchSystems.options import OptionSetter
+from toil.options import OptionSetter
 from toil.bus import get_job_kind
 from toil.common import Config
 from toil.job import JobDescription, Requirer

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -2255,8 +2255,12 @@ def pack_runtime_context(local_context: cwltool.context.RuntimeContext) -> cwlto
     # Drop the FS access hook
     stored_context.make_fs_access = StdFsAccess
 
-    # Make sure it pickles
-    pickle.dumps(stored_context)
+    if hasattr(stored_context, "toil_get_file"):
+        # Drop the toil_get_file hook
+        delattr(stored_context, "toil_get_file")
+
+    # Drop the path mapper hook
+    stored_context.path_mapper = PathMapper
 
     return stored_context
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -3809,7 +3809,7 @@ class CWLImportWrapper(CWLNamedJob):
             initialized_job_order=self.initialized_job_order,
             tool=self.tool,
             basedir=self.basedir,
-            skip_remote=self.reference_inputs,
+            skip_remote=self.skip_remote,
             bypass_file_store=self.bypass_file_store,
             import_data=imports_job.rv(0),
         )

--- a/src/toil/cwl/utils.py
+++ b/src/toil/cwl/utils.py
@@ -164,7 +164,7 @@ def download_structure(
 
     Guaranteed to fill the structure with real files, and not symlinks out of
     it to elsewhere. File URIs may be toilfile: URIs or any other URI that
-    Toil's job store system can read.
+    Toil can read.
 
     :param file_store: The Toil file store to download from.
 
@@ -178,6 +178,10 @@ def download_structure(
     :param into_dir: The directory to download the top-level dict's files
         into.
     """
+
+    # TODO: Have a good way to get a URL access straight from a FileStore
+    # without dealing with the internal JobStore.
+
     logger.debug("Downloading directory with %s items", len(dir_dict))
 
     for name, value in dir_dict.items():
@@ -208,7 +212,7 @@ def download_structure(
                 )
             else:
                 # We need to download from some other kind of URL.
-                size, executable = AbstractJobStore.read_from_url(
+                size, executable = file_store.jobStore.read_from_url(
                     value, open(dest_path, "wb")
                 )
                 if executable:

--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -131,6 +131,12 @@ class AbstractFileStore(ABC):
         # Holds total bytes of observed disk usage for the last job run under open()
         self._job_disk_used: Optional[int] = None
 
+    def __getstate__(self) -> None:
+        """
+        Make sure file stores cannot themselves be pickled.
+        """
+        raise RuntimeError("Attempted to pickle file store implementation") 
+
     @staticmethod
     def createFileStore(
         jobStore: AbstractJobStore,

--- a/src/toil/fileStores/abstractFileStore.py
+++ b/src/toil/fileStores/abstractFileStore.py
@@ -135,7 +135,7 @@ class AbstractFileStore(ABC):
         """
         Make sure file stores cannot themselves be pickled.
         """
-        raise RuntimeError("Attempted to pickle file store implementation") 
+        raise TypeError("Attempted to pickle file store implementation") 
 
     @staticmethod
     def createFileStore(

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -3025,10 +3025,16 @@ class Job:
                         serviceJob = self._registry[serviceID]
                         logger.debug("Saving service %s", serviceJob.description)
                         # Pickle the service body, which triggers all the promise stuff
-                        serviceJob.saveBody(jobStore)
+                        try:
+                            serviceJob.saveBody(jobStore)
+                        except TypeError as e:
+                            raise RuntimeError("Could not save body of service " + str(serviceJob.description)) from e
             if job != self or saveSelf:
                 # Now pickle the job itself
-                job.saveBody(jobStore)
+                try:
+                    job.saveBody(jobStore)
+                except TypeError as e:
+                    raise RuntimeError("Could not save body of " + str(job.description)) from e
 
         # Now that the job data is on disk, commit the JobDescriptions in
         # reverse execution order, in a batch if supported.

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -3027,13 +3027,13 @@ class Job:
                         # Pickle the service body, which triggers all the promise stuff
                         try:
                             serviceJob.saveBody(jobStore)
-                        except TypeError as e:
+                        except Exception as e:
                             raise RuntimeError("Could not save body of service " + str(serviceJob.description)) from e
             if job != self or saveSelf:
                 # Now pickle the job itself
                 try:
                     job.saveBody(jobStore)
-                except TypeError as e:
+                except Exception as e:
                     raise RuntimeError("Could not save body of " + str(job.description)) from e
 
         # Now that the job data is on disk, commit the JobDescriptions in

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -48,8 +48,8 @@ from toil.job import (
     ServiceJobDescription,
 )
 from toil.lib.ftp_utils import FtpFsAccess
+from toil.lib.url import URLAccess, AbstractURLProtocolImplementation 
 from toil.lib.compatibility import deprecated
-from toil.lib.exceptions import UnimplementedURLException
 from toil.lib.io import WriteWatchingStream
 from toil.lib.memoize import memoize
 from toil.lib.retry import ErrorCondition, retry
@@ -162,281 +162,7 @@ class JobStoreExistsException(LocatorException):
             prefix,
         )
 
-class URLAccess:
-    """
-    Widget for accessing external storage (URLs).
 
-    Can be instantiated.
-    """
-
-    def __init__(self, config: Config) -> None:
-        """
-        Make a new widget for accessing URLs.
-        """
-        self._config = config
-
-    def url_exists(self, src_uri: str) -> bool:
-        """
-        Return True if the file at the given URI exists, and False otherwise.
-
-        May raise an error if file existence cannot be determined.
-
-        :param src_uri: URL that points to a file or object in the storage
-               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
-
-        """
-        parseResult = urlparse(src_uri)
-        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
-        return otherCls._url_exists(parseResult, self._config)
-
-    def get_size(self, src_uri: str) -> Optional[int]:
-        """
-        Get the size in bytes of the file at the given URL, or None if it cannot be obtained.
-
-        :param src_uri: URL that points to a file or object in the storage
-               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
-        """
-        parseResult = urlparse(src_uri)
-        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
-        return otherCls._get_size(parseResult, self._config)
-
-    def get_is_directory(self, src_uri: str) -> bool:
-        """
-        Return True if the thing at the given URL is a directory, and False if
-        it is a file. The URL may or may not end in '/'.
-        """
-        parseResult = urlparse(src_uri)
-        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
-        return otherCls._get_is_directory(parseResult, self._config)
-
-    def list_url(self, src_uri: str) -> list[str]:
-        """
-        List the directory at the given URL. Returned path components can be
-        joined with '/' onto the passed URL to form new URLs. Those that end in
-        '/' correspond to directories. The provided URL may or may not end with
-        '/'.
-
-        Currently supported schemes are:
-
-            - 's3' for objects in Amazon S3
-                e.g. s3://bucket/prefix/
-
-            - 'file' for local files
-                e.g. file:///local/dir/path/
-
-        :param str src_uri: URL that points to a directory or prefix in the storage mechanism of a
-                supported URL scheme e.g. a prefix in an AWS s3 bucket.
-
-        :return: A list of URL components in the given directory, already URL-encoded.
-        """
-        parseResult = urlparse(src_uri)
-        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
-        return otherCls._list_url(parseResult, self._config)
-
-    def read_from_url(self, src_uri: str, writable: IO[bytes]) -> tuple[int, bool]:
-        """
-        Read the given URL and write its content into the given writable stream.
-
-        Raises FileNotFoundError if the URL doesn't exist.
-
-        :param config: The current Toil configuration object.
-
-        :return: The size of the file in bytes and whether the executable permission bit is set
-        """
-        parseResult = urlparse(src_uri)
-        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
-        return otherCls._read_from_url(parseResult, writable, self._config)
-
-    def open_url(self, src_uri: str) -> IO[bytes]:
-        """
-        Read from the given URI.
-
-        Raises FileNotFoundError if the URL doesn't exist.
-
-        Has a readable stream interface, unlike :meth:`read_from_url` which
-        takes a writable stream.
-        """
-        parseResult = urlparse(src_uri)
-        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
-        return otherCls._open_url(parseResult, self._config)
-
-
-class AbstractURLProtocolImplementation(ABC):
-    """
-    Base class for URL accessor implementations. Also manages finding the
-    implementation for a URL.
-
-    Many job sotres implement this to allow access to URLs on the same kind of
-    backing storage as that kind of job store.
-    """
-
-    @classmethod
-    def find_url_implementation(
-        cls, url: ParseResult, export: bool = False
-    ) -> "AbstractURLProtocolImplementation":
-        """
-        Returns the subclass that supports the given URL.
-
-        :param ParseResult url: The given URL
-
-        :param bool export: Determines if the url is supported for exporting
-
-        :rtype: toil.jobStore.AbstractURLProtocolImplementation
-        """
-        # TODO: Make pluggable.
-
-        if StandardURLProtocolImplementation._supports_url(url, export):
-            # THis is a standard URL scheme
-            return StandardURLProtocolImplementation
-
-        for implementation in AbstractJobStore._get_job_store_classes():
-            if issubclass(implementation, cls) and implementation._supports_url(url, export):
-                # This scheme belongs to one of the available job store implementations.
-                return implementation
-        raise UnimplementedURLException(url, "export" if export else "import")
-
-    # TODO: De-private-ify these methods while allowing a class that provides
-    # this to also be an instance of URLAccess 
-
-    @classmethod
-    @abstractmethod
-    def _url_exists(cls, url: ParseResult, config: Config) -> bool:
-        """
-        Return True if the item at the given URL exists, and Flase otherwise.
-
-        May raise an error if file existence cannot be determined.
-
-        :param config: The current Toil configuration object.
-        """
-        raise NotImplementedError(f"No implementation for {url}")
-
-    @classmethod
-    @abstractmethod
-    def _get_size(cls, url: ParseResult, config: Config) -> Optional[int]:
-        """
-        Get the size of the object at the given URL, or None if it cannot be obtained.
-
-        :param config: The current Toil configuration object.
-        """
-        raise NotImplementedError(f"No implementation for {url}")
-
-    @classmethod
-    @abstractmethod
-    def _get_is_directory(cls, url: ParseResult, config: Config) -> bool:
-        """
-        Return True if the thing at the given URL is a directory, and False if
-        it is a file or it is known not to exist. The URL may or may not end in
-        '/'.
-
-        :param url: URL that points to a file or object, or directory or prefix,
-               in the storage mechanism of a supported URL scheme e.g. a blob
-               in an AWS s3 bucket.
-
-        :param config: The current Toil configuration object.
-        """
-        raise NotImplementedError(f"No implementation for {url}")
-
-    @classmethod
-    @abstractmethod
-    def _read_from_url(cls, url: ParseResult, writable: IO[bytes], config: Config) -> tuple[int, bool]:
-        """
-        Reads the contents of the object at the specified location and writes it to the given
-        writable stream.
-
-        Refer to :func:`~AbstractJobStore.importFile` documentation for currently supported URL schemes.
-
-        Raises FileNotFoundError if the thing at the URL is not found.
-
-        :param ParseResult url: URL that points to a file or object in the storage
-               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
-
-        :param IO[bytes] writable: a writable stream
-
-        :param config: The current Toil configuration object.
-
-        :return: The size of the file in bytes and whether the executable permission bit is set
-        """
-        raise NotImplementedError(f"No implementation for {url}")
-
-    @classmethod
-    @abstractmethod
-    def _list_url(cls, url: ParseResult, config: Config) -> list[str]:
-        """
-        List the contents of the given URL, which may or may not end in '/'
-
-        Returns a list of URL components. Those that end in '/' are meant to be
-        directories, while those that do not are meant to be files.
-
-        Refer to :func:`~AbstractJobStore.importFile` documentation for currently supported URL schemes.
-
-        :param ParseResult url: URL that points to a directory or prefix in the
-        storage mechanism of a supported URL scheme e.g. a prefix in an AWS s3
-        bucket.
-
-        :param config: The current Toil configuration object.
-
-        :return: The children of the given URL, already URL-encoded if
-        appropriate. (If the URL is a bare path, no encoding is done.)
-        """
-        raise NotImplementedError(f"No implementation for {url}")
-
-    @classmethod
-    @abstractmethod
-    def _open_url(cls, url: ParseResult, config: Config) -> IO[bytes]:
-        """
-        Get a stream of the object at the specified location.
-
-        Refer to :func:`~AbstractJobStore.importFile` documentation for currently supported URL schemes.
-
-        :param config: The current Toil configuration object.
-
-        :raises: FileNotFoundError if the thing at the URL is not found.
-        """
-        raise NotImplementedError(f"No implementation for {url}")
-
-    @classmethod
-    @abstractmethod
-    def _write_to_url(
-        cls,
-        readable: Union[IO[bytes], IO[str]],
-        url: ParseResult,
-        executable: bool,
-        config: Config
-    ) -> None:
-        """
-        Reads the contents of the given readable stream and writes it to the object at the
-        specified location. Raises FileNotFoundError if the URL doesn't exist..
-
-        Refer to AbstractJobStore.importFile documentation for currently supported URL schemes.
-
-        :param Union[IO[bytes], IO[str]] readable: a readable stream
-
-        :param ParseResult url: URL that points to a file or object in the storage
-               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
-
-        :param bool executable: determines if the file has executable permissions
-
-        :param config: The current Toil configuration object.
-        """
-        raise NotImplementedError(f"No implementation for {url}")
-
-    @classmethod
-    @abstractmethod
-    def _supports_url(cls, url: ParseResult, export: bool = False) -> bool:
-        """
-        Returns True if the job store supports the URL's scheme.
-
-        Refer to AbstractJobStore.importFile documentation for currently supported URL schemes.
-
-        :param ParseResult url: a parsed URL that may be supported
-
-        :param bool export: Determines if the url is supported for export
-
-        :param config: The current Toil configuration object.
-
-        :return bool: returns true if the cls supports the URL
-        """
-        raise NotImplementedError(f"No implementation for {url}")
 
 class AbstractJobStore(URLAccess, ABC):
     """
@@ -603,7 +329,7 @@ class AbstractJobStore(URLAccess, ABC):
 
     @staticmethod
     @memoize
-    def _get_job_store_classes() -> list["AbstractJobStore"]:
+    def _get_job_store_classes() -> list[type["AbstractJobStore"]]:
         """
         A list of concrete AbstractJobStore implementations whose dependencies are installed.
 
@@ -751,7 +477,7 @@ class AbstractJobStore(URLAccess, ABC):
         # optimizations that circumvent this, the _import_file method should be overridden by
         # subclasses of AbstractJobStore.
         parseResult = urlparse(src_uri)
-        otherCls = self._findJobStoreForUrl(parseResult)
+        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
         logger.info("Importing input %s...", src_uri)
         return self._import_file(
             otherCls,
@@ -763,7 +489,7 @@ class AbstractJobStore(URLAccess, ABC):
 
     def _import_file(
         self,
-        otherCls: Type[AbstractURLProtocolImplementation],
+        otherCls: type[AbstractURLProtocolImplementation],
         uri: ParseResult,
         shared_file_name: Optional[str] = None,
         hardlink: bool = False,
@@ -825,7 +551,7 @@ class AbstractJobStore(URLAccess, ABC):
         self._export_file(otherCls, file_id, parseResult)
 
     def _export_file(
-        self, otherCls: Type[AbstractURLProtocolImplementation], jobStoreFileID: FileID, url: ParseResult
+        self, otherCls: type[AbstractURLProtocolImplementation], jobStoreFileID: FileID, url: ParseResult
     ) -> None:
         """
         Refer to exportFile docstring for information about this method.
@@ -839,7 +565,7 @@ class AbstractJobStore(URLAccess, ABC):
         self._default_export_file(otherCls, jobStoreFileID, url)
 
     def _default_export_file(
-        self, otherCls: Type[AbstractURLProtocolImplementation], jobStoreFileID: FileID, url: ParseResult
+        self, otherCls: type[AbstractURLProtocolImplementation], jobStoreFileID: FileID, url: ParseResult
     ) -> None:
         """
         Refer to exportFile docstring for information about this method.

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -17,6 +17,7 @@ import pickle
 import re
 import shutil
 from abc import ABC, ABCMeta, abstractmethod
+from argparse import ArgumentParser, _ArgumentGroup
 from collections.abc import Iterator, ValuesView
 from contextlib import closing, contextmanager
 from datetime import timedelta
@@ -52,6 +53,7 @@ from toil.lib.exceptions import UnimplementedURLException
 from toil.lib.io import WriteWatchingStream
 from toil.lib.memoize import memoize
 from toil.lib.retry import ErrorCondition, retry
+from toil.options import OptionSetter
 
 if TYPE_CHECKING:
     from toil.job import TemporaryID
@@ -330,6 +332,12 @@ class AbstractJobStore(ABC):
 
         :rtype: List[AbstractJobStore]
         """
+        # TODO: Although this method is private from users of job stores, it is
+        # shared with jobStores/options.py.
+        
+        # TODO: Replace with a real plugin/registry system like for batch
+        # systems.
+
         jobStoreClassNames = (
             "toil.jobStores.fileJobStore.FileJobStore",
             "toil.jobStores.googleJobStore.GoogleJobStore",
@@ -353,6 +361,27 @@ class AbstractJobStore(ABC):
                 jobStoreClass = getattr(module, className)
                 jobStoreClasses.append(jobStoreClass)
         return jobStoreClasses
+
+    @classmethod
+    def add_options(cls, parser: Union[ArgumentParser, _ArgumentGroup]) -> None:
+        """
+        If this job store provides any command line options, add them to the given parser.
+        """
+
+        # By default, job store implementatiuons have no CLI options.
+        pass
+
+    @classmethod
+    def set_options(cls, set_option: OptionSetter) -> None:
+        """
+        Process command line or configuration options relevant to this job store.
+
+        :param set_option: A function taking an option name and returning
+            nothing, used to update run configuration as a side effect.
+        """
+
+        # By default, job store implementatiuons have no CLI options.
+        pass
 
     @classmethod
     def _findJobStoreForUrl(

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -1705,7 +1705,7 @@ class StandardURLProtocolImplementation(AbstractURLProtocolImplementation, metac
     ) -> tuple[int, bool]:
         # We can't actually retry after we start writing.
         # TODO: Implement retry with byte range requests
-        with cls._open_url(url) as readable:
+        with cls._open_url(url, config) as readable:
             # Make something to count the bytes we get
             # We need to put the actual count in a container so our
             # nested function can modify it without creating its own

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -657,17 +657,17 @@ class AWSJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
             return cls._get_is_directory(url)
 
     @classmethod
-    def _get_size(cls, url: ParseResult) -> int:
+    def _get_size(cls, url: ParseResult, config: Config) -> int:
         return get_object_for_url(url, existing=True, anonymous=config.aws_anonymous_url_access).content_length
 
     @classmethod
-    def _read_from_url(cls, url: ParseResult, writable):
+    def _read_from_url(cls, url: ParseResult, writable, config: Config):
         srcObj = get_object_for_url(url, existing=True, anonymous=config.aws_anonymous_url_access)
         srcObj.download_fileobj(writable)
         return (srcObj.content_length, False)  # executable bit is always False
 
     @classmethod
-    def _open_url(cls, url: ParseResult) -> IO[bytes]:
+    def _open_url(cls, url: ParseResult, config: Config) -> IO[bytes]:
         src_obj = get_object_for_url(url, existing=True, anonymous=config.aws_anonymous_url_access)
         response = src_obj.get()
         # We should get back a response with a stream in 'Body'
@@ -677,7 +677,7 @@ class AWSJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
 
     @classmethod
     def _write_to_url(
-        cls, readable, url: ParseResult, executable: bool = False
+        cls, readable, url: ParseResult, executable: bool, config: Config
     ) -> None:
         dstObj = get_object_for_url(url, anonymous=config.aws_anonymous_url_access)
 
@@ -692,14 +692,14 @@ class AWSJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
         )
 
     @classmethod
-    def _list_url(cls, url: ParseResult) -> list[str]:
+    def _list_url(cls, url: ParseResult, config: Config) -> list[str]:
         return list_objects_for_url(url, anonymous=config.aws_anonymous_url_access)
 
     @classmethod
-    def _get_is_directory(cls, url: ParseResult) -> bool:
+    def _get_is_directory(cls, url: ParseResult, config: Config) -> bool:
         # We consider it a directory if anything is in it.
         # TODO: Can we just get the first item and not the whole list?
-        return len(cls._list_url(url)) > 0
+        return len(cls._list_url(url, config)) > 0
 
     @classmethod
     def _supports_url(cls, url: ParseResult, export: bool = False) -> bool:

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -31,6 +31,7 @@ from urllib.parse import ParseResult, parse_qs, urlencode, urlsplit, urlunsplit
 from botocore.exceptions import ClientError
 
 import toil.lib.encryption as encryption
+from toil.common import Config
 from toil.fileStores import FileID
 from toil.job import Job, JobDescription
 from toil.jobStores.abstractJobStore import (
@@ -89,8 +90,6 @@ if TYPE_CHECKING:
         ReplaceableItemTypeDef,
         UpdateConditionTypeDef,
     )
-
-    from toil import Config
 
 boto3_session = establish_boto3_session()
 s3_boto3_resource = boto3_session.resource("s3")

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -396,15 +396,15 @@ class FileJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
             os.chmod(destPath, os.stat(destPath).st_mode | stat.S_IXUSR)
 
     @classmethod
-    def _url_exists(cls, url: ParseResult) -> bool:
+    def _url_exists(cls, url: ParseResult, config: Config) -> bool:
         return os.path.exists(cls._extract_path_from_url(url))
 
     @classmethod
-    def _get_size(cls, url):
+    def _get_size(cls, url: ParseResult, config: Config) -> int:
         return os.stat(cls._extract_path_from_url(url)).st_size
 
     @classmethod
-    def _read_from_url(cls, url, writable):
+    def _read_from_url(cls, url: ParseResult, writable: bool, config: Config) -> tuple[int, bool]:
         """
         Writes the contents of a file to a source (writes url to writable)
         using a ~10Mb buffer.
@@ -414,21 +414,21 @@ class FileJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
         """
 
         # we use a ~10Mb buffer to improve speed
-        with cls._open_url(url) as readable:
+        with cls._open_url(url, config) as readable:
             shutil.copyfileobj(readable, writable, length=cls.BUFFER_SIZE)
             # Return the number of bytes we read when we reached EOF.
             executable = os.stat(readable.name).st_mode & stat.S_IXUSR
             return readable.tell(), executable
 
     @classmethod
-    def _open_url(cls, url: ParseResult) -> IO[bytes]:
+    def _open_url(cls, url: ParseResult, config: Config) -> IO[bytes]:
         """
         Open a file URL as a binary stream.
         """
         return open(cls._extract_path_from_url(url), "rb")
 
     @classmethod
-    def _write_to_url(cls, readable, url, executable=False):
+    def _write_to_url(cls, readable: IO[bytes], url: ParseResult, executable: bool, config: Config):
         """
         Writes the contents of a file to a source (writes readable to url)
         using a ~10Mb buffer.
@@ -445,7 +445,7 @@ class FileJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
         )
 
     @classmethod
-    def _list_url(cls, url: ParseResult) -> list[str]:
+    def _list_url(cls, url: ParseResult, config: Config) -> list[str]:
         path = cls._extract_path_from_url(url)
         listing = []
         for p in os.listdir(path):
@@ -458,7 +458,7 @@ class FileJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
         return listing
 
     @classmethod
-    def _get_is_directory(cls, url: ParseResult) -> bool:
+    def _get_is_directory(cls, url: ParseResult, config: Config) -> bool:
         path = cls._extract_path_from_url(url)
         return os.path.isdir(path)
 

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -133,9 +133,9 @@ class FileJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
         os.makedirs(self.filesDir, exist_ok=True)
         os.makedirs(self.jobFilesDir, exist_ok=True)
         os.makedirs(self.sharedFilesDir, exist_ok=True)
-        self.linkImports = config.symlinkImports
-        self.moveExports = config.moveOutputs
-        self.symlink_job_store_reads = config.symlink_job_store_reads
+        self.linkImports = self.config.symlinkImports
+        self.moveExports = self.config.moveOutputs
+        self.symlink_job_store_reads = self.config.symlink_job_store_reads
         super().initialize()
 
     def resume(self):

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -441,7 +441,7 @@ class GoogleJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
         return blob
 
     @classmethod
-    def _url_exists(cls, url: ParseResult) -> bool:
+    def _url_exists(cls, url: ParseResult, config: Config) -> bool:
         try:
             cls._get_blob_from_url(url, exists=True)
             return True
@@ -449,17 +449,17 @@ class GoogleJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
             return False
 
     @classmethod
-    def _get_size(cls, url):
+    def _get_size(cls, url, config: Config):
         return cls._get_blob_from_url(url, exists=True).size
 
     @classmethod
-    def _read_from_url(cls, url, writable):
+    def _read_from_url(cls, url, writable, config: Config):
         blob = cls._get_blob_from_url(url, exists=True)
         blob.download_to_file(writable)
         return blob.size, False
 
     @classmethod
-    def _open_url(cls, url: ParseResult) -> IO[bytes]:
+    def _open_url(cls, url: ParseResult, config: Config) -> IO[bytes]:
         blob = cls._get_blob_from_url(url, exists=True)
         return blob.open("rb")
 
@@ -468,18 +468,18 @@ class GoogleJobStore(AbstractJobStore, AbstractURLProtocolImplementation):
         return url.scheme.lower() == "gs"
 
     @classmethod
-    def _write_to_url(cls, readable: bytes, url: str, executable: bool = False) -> None:
+    def _write_to_url(cls, readable: bytes, url: str, executable: bool, config: Config) -> None:
         blob = cls._get_blob_from_url(url)
         blob.upload_from_file(readable)
 
     @classmethod
-    def _list_url(cls, url: ParseResult) -> list[str]:
+    def _list_url(cls, url: ParseResult, config: Config) -> list[str]:
         raise NotImplementedError(
             "Listing files in Google buckets is not yet implemented!"
         )
 
     @classmethod
-    def _get_is_directory(cls, url: ParseResult) -> bool:
+    def _get_is_directory(cls, url: ParseResult, config: Config) -> bool:
         raise NotImplementedError(
             "Checking directory status in Google buckets is not yet implemented!"
         )

--- a/src/toil/jobStores/options.py
+++ b/src/toil/jobStores/options.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2015-2025 Regents of the University of California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import logging
+from argparse import ArgumentParser, _ArgumentGroup
+from typing import Optional, Union
+
+from toil.options import OptionSetter
+
+logger = logging.getLogger(__name__)
+
+def add_all_job_store_options(parser: Union[ArgumentParser, _ArgumentGroup]) -> None:
+    """
+    Add all job stores' options to the parser.
+    """
+    
+    from toil.jobStores.abstractJobStore import AbstractJobStore
+
+    for job_store_type in AbstractJobStore._get_job_store_classes():
+        logger.debug("Add options for %s job store", job_store_type)
+        job_store_type.add_options(parser)
+
+def set_job_store_options(
+    set_option: OptionSetter
+) -> None:
+    """
+    Call set_option for all job stores' options.
+
+    Unlike with batch systems, multiple job store classes can be used in one
+    workflow (for URL access), so we don't allow restrictign to jsut one
+    implementation.
+    """
+
+    from toil.jobStores.abstractJobStore import AbstractJobStore
+
+    for job_store_type in AbstractJobStore._get_job_store_classes():
+        job_store_type.set_options(set_option)
+
+
+
+    

--- a/src/toil/lib/url.py
+++ b/src/toil/lib/url.py
@@ -1,0 +1,313 @@
+# Copyright (C) 2015-2025 Regents of the University of California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+from abc import ABC, ABCMeta, abstractmethod
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ContextManager,
+    Literal,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
+from urllib.parse import ParseResult, urlparse
+
+from toil.lib.exceptions import UnimplementedURLException
+
+if TYPE_CHECKING:
+    from toil.common import Config
+
+logger = logging.getLogger(__name__)
+
+class URLAccess:
+    """
+    Widget for accessing external storage (URLs).
+
+    Can be instantiated.
+    """
+
+    def __init__(self, config: "Config") -> None:
+        """
+        Make a new widget for accessing URLs.
+        """
+        self._config = config
+        super().__init__()
+
+    def url_exists(self, src_uri: str) -> bool:
+        """
+        Return True if the file at the given URI exists, and False otherwise.
+
+        May raise an error if file existence cannot be determined.
+
+        :param src_uri: URL that points to a file or object in the storage
+               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
+
+        """
+        parseResult = urlparse(src_uri)
+        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
+        return otherCls._url_exists(parseResult, self._config)
+
+    def get_size(self, src_uri: str) -> Optional[int]:
+        """
+        Get the size in bytes of the file at the given URL, or None if it cannot be obtained.
+
+        :param src_uri: URL that points to a file or object in the storage
+               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
+        """
+        parseResult = urlparse(src_uri)
+        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
+        return otherCls._get_size(parseResult, self._config)
+
+    def get_is_directory(self, src_uri: str) -> bool:
+        """
+        Return True if the thing at the given URL is a directory, and False if
+        it is a file. The URL may or may not end in '/'.
+        """
+        parseResult = urlparse(src_uri)
+        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
+        return otherCls._get_is_directory(parseResult, self._config)
+
+    def list_url(self, src_uri: str) -> list[str]:
+        """
+        List the directory at the given URL. Returned path components can be
+        joined with '/' onto the passed URL to form new URLs. Those that end in
+        '/' correspond to directories. The provided URL may or may not end with
+        '/'.
+
+        Currently supported schemes are:
+
+            - 's3' for objects in Amazon S3
+                e.g. s3://bucket/prefix/
+
+            - 'file' for local files
+                e.g. file:///local/dir/path/
+
+        :param str src_uri: URL that points to a directory or prefix in the storage mechanism of a
+                supported URL scheme e.g. a prefix in an AWS s3 bucket.
+
+        :return: A list of URL components in the given directory, already URL-encoded.
+        """
+        parseResult = urlparse(src_uri)
+        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
+        return otherCls._list_url(parseResult, self._config)
+
+    def read_from_url(self, src_uri: str, writable: IO[bytes]) -> tuple[int, bool]:
+        """
+        Read the given URL and write its content into the given writable stream.
+
+        Raises FileNotFoundError if the URL doesn't exist.
+
+        :param config: The current Toil configuration object.
+
+        :return: The size of the file in bytes and whether the executable permission bit is set
+        """
+        parseResult = urlparse(src_uri)
+        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
+        return otherCls._read_from_url(parseResult, writable, self._config)
+
+    def open_url(self, src_uri: str) -> IO[bytes]:
+        """
+        Read from the given URI.
+
+        Raises FileNotFoundError if the URL doesn't exist.
+
+        Has a readable stream interface, unlike :meth:`read_from_url` which
+        takes a writable stream.
+        """
+        parseResult = urlparse(src_uri)
+        otherCls = AbstractURLProtocolImplementation.find_url_implementation(parseResult)
+        return otherCls._open_url(parseResult, self._config)
+
+
+class AbstractURLProtocolImplementation(ABC):
+    """
+    Base class for URL accessor implementations. Also manages finding the
+    implementation for a URL.
+
+    Many job stores implement this to allow access to URLs on the same kind of
+    backing storage as that kind of job store.
+    """
+
+    @classmethod
+    def find_url_implementation(
+        cls, url: ParseResult, export: bool = False
+    ) -> type["AbstractURLProtocolImplementation"]:
+        """
+        Returns the subclass that supports the given URL.
+
+        :param ParseResult url: The given URL
+
+        :param bool export: Determines if the url is supported for exporting
+        """
+        # TODO: Make pluggable.
+
+        from toil.jobStores.abstractJobStore import AbstractJobStore, StandardURLProtocolImplementation
+
+        if StandardURLProtocolImplementation._supports_url(url, export):
+            # This is a standard URL scheme
+            return StandardURLProtocolImplementation
+
+        for implementation in AbstractJobStore._get_job_store_classes():
+            if issubclass(implementation, AbstractURLProtocolImplementation) and implementation._supports_url(url, export):
+                # This scheme belongs to one of the available job store implementations.
+                return implementation
+        raise UnimplementedURLException(url, "export" if export else "import")
+
+    # TODO: De-private-ify these methods while allowing a class that provides
+    # this to also be an instance of URLAccess 
+
+    @classmethod
+    @abstractmethod
+    def _url_exists(cls, url: ParseResult, config: "Config") -> bool:
+        """
+        Return True if the item at the given URL exists, and Flase otherwise.
+
+        May raise an error if file existence cannot be determined.
+
+        :param config: The current Toil configuration object.
+        """
+        raise NotImplementedError(f"No implementation for {url}")
+
+    @classmethod
+    @abstractmethod
+    def _get_size(cls, url: ParseResult, config: "Config") -> Optional[int]:
+        """
+        Get the size of the object at the given URL, or None if it cannot be obtained.
+
+        :param config: The current Toil configuration object.
+        """
+        raise NotImplementedError(f"No implementation for {url}")
+
+    @classmethod
+    @abstractmethod
+    def _get_is_directory(cls, url: ParseResult, config: "Config") -> bool:
+        """
+        Return True if the thing at the given URL is a directory, and False if
+        it is a file or it is known not to exist. The URL may or may not end in
+        '/'.
+
+        :param url: URL that points to a file or object, or directory or prefix,
+               in the storage mechanism of a supported URL scheme e.g. a blob
+               in an AWS s3 bucket.
+
+        :param config: The current Toil configuration object.
+        """
+        raise NotImplementedError(f"No implementation for {url}")
+
+    @classmethod
+    @abstractmethod
+    def _read_from_url(cls, url: ParseResult, writable: IO[bytes], config: "Config") -> tuple[int, bool]:
+        """
+        Reads the contents of the object at the specified location and writes it to the given
+        writable stream.
+
+        Refer to :func:`~AbstractJobStore.importFile` documentation for currently supported URL schemes.
+
+        Raises FileNotFoundError if the thing at the URL is not found.
+
+        :param ParseResult url: URL that points to a file or object in the storage
+               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
+
+        :param IO[bytes] writable: a writable stream
+
+        :param config: The current Toil configuration object.
+
+        :return: The size of the file in bytes and whether the executable permission bit is set
+        """
+        raise NotImplementedError(f"No implementation for {url}")
+
+    @classmethod
+    @abstractmethod
+    def _list_url(cls, url: ParseResult, config: "Config") -> list[str]:
+        """
+        List the contents of the given URL, which may or may not end in '/'
+
+        Returns a list of URL components. Those that end in '/' are meant to be
+        directories, while those that do not are meant to be files.
+
+        Refer to :func:`~AbstractJobStore.importFile` documentation for currently supported URL schemes.
+
+        :param ParseResult url: URL that points to a directory or prefix in the
+        storage mechanism of a supported URL scheme e.g. a prefix in an AWS s3
+        bucket.
+
+        :param config: The current Toil configuration object.
+
+        :return: The children of the given URL, already URL-encoded if
+        appropriate. (If the URL is a bare path, no encoding is done.)
+        """
+        raise NotImplementedError(f"No implementation for {url}")
+
+    @classmethod
+    @abstractmethod
+    def _open_url(cls, url: ParseResult, config: "Config") -> IO[bytes]:
+        """
+        Get a stream of the object at the specified location.
+
+        Refer to :func:`~AbstractJobStore.importFile` documentation for currently supported URL schemes.
+
+        :param config: The current Toil configuration object.
+
+        :raises: FileNotFoundError if the thing at the URL is not found.
+        """
+        raise NotImplementedError(f"No implementation for {url}")
+
+    @classmethod
+    @abstractmethod
+    def _write_to_url(
+        cls,
+        readable: Union[IO[bytes], IO[str]],
+        url: ParseResult,
+        executable: bool,
+        config: "Config"
+    ) -> None:
+        """
+        Reads the contents of the given readable stream and writes it to the object at the
+        specified location. Raises FileNotFoundError if the URL doesn't exist..
+
+        Refer to AbstractJobStore.importFile documentation for currently supported URL schemes.
+
+        :param Union[IO[bytes], IO[str]] readable: a readable stream
+
+        :param ParseResult url: URL that points to a file or object in the storage
+               mechanism of a supported URL scheme e.g. a blob in an AWS s3 bucket.
+
+        :param bool executable: determines if the file has executable permissions
+
+        :param config: The current Toil configuration object.
+        """
+        raise NotImplementedError(f"No implementation for {url}")
+
+    @classmethod
+    @abstractmethod
+    def _supports_url(cls, url: ParseResult, export: bool = False) -> bool:
+        """
+        Returns True if the job store supports the URL's scheme.
+
+        Refer to AbstractJobStore.importFile documentation for currently supported URL schemes.
+
+        :param ParseResult url: a parsed URL that may be supported
+
+        :param bool export: Determines if the url is supported for export
+
+        :param config: The current Toil configuration object.
+
+        :return bool: returns true if the cls supports the URL
+        """
+        raise NotImplementedError(f"No implementation for {url}")

--- a/src/toil/options/__init__.py
+++ b/src/toil/options/__init__.py
@@ -24,12 +24,10 @@ class OptionSetter(Protocol):
     Actual functionality is defined in the Config class.
     
     Looks first at option_name and then at old_names to find the namespace key for the option.
-
-    Returns the option's value, or None if not found.
     """
 
     def __call__(
         self,
         option_name: str,
         old_names: Optional[list[str]] = None,
-    ) -> Optional[Any]: ...
+    ) -> None: ...

--- a/src/toil/options/__init__.py
+++ b/src/toil/options/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2015-2025 Regents of the University of California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+from typing import Any, Optional, Protocol
+
+class OptionSetter(Protocol):
+    """
+    Protocol for the setOption function we get to let us set up CLI options for
+    each batch system or job store.
+
+    Used to have more parameters for managing defaults and environment
+    variables, but now that's all done by the parser.
+
+    Actual functionality is defined in the Config class.
+    
+    Looks first at option_name and then at old_names to find the namespace key for the option.
+
+    Returns the option's value, or None if not found.
+    """
+
+    def __call__(
+        self,
+        option_name: str,
+        old_names: Optional[list[str]] = None,
+    ) -> Optional[Any]: ...

--- a/src/toil/options/common.py
+++ b/src/toil/options/common.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from configargparse import SUPPRESS
 from ruamel.yaml import YAML
 
-from toil.batchSystems.options import add_all_batchsystem_options
+from toil.batchSystems.options import add_all_batch_system_options
+from toil.jobStores.options import add_all_job_store_options
 from toil.lib.conversions import bytes2human, human2bytes, opt_strtobool, strtobool
 from toil.provisioners import parse_node_types
 from toil.statsAndLogging import add_logging_options
@@ -421,18 +422,18 @@ def add_base_toil_options(
     )
 
     # Batch system options
-    batchsystem_options = parser.add_argument_group(
-        title="Toil options for specifying the batch system",
-        description="Allows the specification of the batch system.",
+    batch_system_options = parser.add_argument_group(
+        title="Toil options for the batch system",
+        description="Allows specifying and configuring batch system.",
     )
-    add_all_batchsystem_options(batchsystem_options)
+    add_all_batch_system_options(batch_system_options)
 
     # File store options
-    file_store_options = parser.add_argument_group(
+    storage_options = parser.add_argument_group(
         title="Toil options for configuring storage",
         description="Allows configuring Toil's data storage.",
     )
-    link_imports = file_store_options.add_mutually_exclusive_group()
+    link_imports = storage_options.add_mutually_exclusive_group()
     link_imports_help = (
         "When using a filesystem based job store, CWL input files are by default symlinked in.  "
         "Setting this option to True instead copies the files into the job store, which may protect "
@@ -448,7 +449,7 @@ def add_base_toil_options(
         metavar="BOOL",
         help=link_imports_help,
     )
-    move_exports = file_store_options.add_mutually_exclusive_group()
+    move_exports = storage_options.add_mutually_exclusive_group()
     move_exports_help = (
         "When using a filesystem based job store, output files are by default moved to the "
         "output directory, and a symlink to the moved exported file is created at the initial "
@@ -465,7 +466,7 @@ def add_base_toil_options(
         help=move_exports_help,
     )
 
-    caching = file_store_options.add_mutually_exclusive_group()
+    caching = storage_options.add_mutually_exclusive_group()
     caching_help = "Enable or disable caching for your workflow, specifying this overrides default from job store"
     caching.add_argument(
         "--caching",
@@ -477,7 +478,7 @@ def add_base_toil_options(
     )
     # default is None according to PR 4299, seems to be generated at runtime
 
-    file_store_options.add_argument(
+    storage_options.add_argument(
         "--symlinkJobStoreReads",
         dest="symlink_job_store_reads",
         type=strtobool,
@@ -486,6 +487,10 @@ def add_base_toil_options(
         help="Allow reads and container mounts from a JobStore's shared filesystem directly "
         "via symlink. default=%(default)s",
     )
+
+    # Add job store pluggable options to storage section
+    add_all_job_store_options(storage_options)
+
 
     # Auto scaling options
     autoscaling_options = parser.add_argument_group(

--- a/src/toil/test/batchSystems/batch_system_plugin_test.py
+++ b/src/toil/test/batchSystems/batch_system_plugin_test.py
@@ -87,4 +87,4 @@ class BatchSystemPluginTest(ToilTest):
         # try to install a batchsystem plugin with some arguments
         # if the arguments exists, the values should also exist in the config
         with Toil(options) as toil:
-            self.assertEqual(toil.config.fake_argument == "exists", True)
+            self.assertEqual(toil._config.fake_argument == "exists", True)

--- a/src/toil/test/batchSystems/batch_system_plugin_test.py
+++ b/src/toil/test/batchSystems/batch_system_plugin_test.py
@@ -21,7 +21,7 @@ from toil.batchSystems.abstractBatchSystem import (
     UpdatedBatchJobInfo,
 )
 from toil.batchSystems.cleanup_support import BatchSystemCleanupSupport
-from toil.batchSystems.options import OptionSetter
+from toil.options import OptionSetter
 from toil.batchSystems.registry import add_batch_system_factory
 from toil.common import Toil, addOptions
 from toil.job import JobDescription

--- a/src/toil/test/options/options.py
+++ b/src/toil/test/options/options.py
@@ -1,3 +1,5 @@
+import os
+
 from configargparse import ArgParser
 
 from toil.common import Toil, addOptions
@@ -14,12 +16,13 @@ class OptionsTest(ToilTest):
         Test to ensure that caching will be set to false when running on Slurm
         :return:
         """
+        job_store = os.path.join(self._createTempDir(), "tree")
         parser = ArgParser()
         addOptions(parser, jobstore_as_flag=True, wdl=False, cwl=False)
-        test_args = ["--jobstore=example-jobstore", "--batchSystem=slurm"]
+        test_args = ["--jobstore", job_store, "--batchSystem=slurm"]
         options = parser.parse_args(test_args)
         with Toil(options) as toil:
-            caching_value = toil.config.caching
+            caching_value = toil._config.caching
         self.assertEqual(caching_value, False)
 
     def test_caching_option_priority(self):
@@ -27,16 +30,18 @@ class OptionsTest(ToilTest):
         Test to ensure that the --caching option takes priority over the default_caching() return value
         :return:
         """
+        job_store = os.path.join(self._createTempDir(), "tree")
         parser = ArgParser()
         addOptions(parser, jobstore_as_flag=True, wdl=False, cwl=False)
         # the kubernetes batchsystem (and I think all batchsystems including singlemachine) return False
         # for default_caching
         test_args = [
-            "--jobstore=example-jobstore",
+            "--jobstore",
+            job_store,
             "--batchSystem=kubernetes",
             "--caching=True",
         ]
         options = parser.parse_args(test_args)
         with Toil(options) as toil:
-            caching_value = toil.config.caching
+            caching_value = toil._config.caching
         self.assertEqual(caching_value, True)

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -661,7 +661,7 @@ class PreemptibleDeficitCompensationTest(AbstractAWSAutoscaleTest):
             if __name__ == "__main__":
                 options = Job.Runner.getDefaultArgumentParser().parse_args()
                 with Toil(options) as toil:
-                    if toil.config.restart:
+                    if options.restart:
                         toil.restart()
                     else:
                         toil.start(Job.wrapJobFn(job))

--- a/src/toil/test/src/autoDeploymentTest.py
+++ b/src/toil/test/src/autoDeploymentTest.py
@@ -66,7 +66,7 @@ class AutoDeploymentTest(ApplianceTestSupport):
                 if __name__ == "__main__":
                     options = Job.Runner.getDefaultArgumentParser().parse_args()
                     with Toil(options) as toil:
-                        if toil.config.restart:
+                        if options.restart:
                             toil.restart()
                         else:
                             toil.start(Job.wrapJobFn(job))
@@ -139,7 +139,7 @@ class AutoDeploymentTest(ApplianceTestSupport):
                 if __name__ == "__main__":
                     options = Job.Runner.getDefaultArgumentParser().parse_args()
                     with Toil(options) as toil:
-                        if toil.config.restart:
+                        if options.restart:
                             toil.restart()
                         else:
                             toil.start(Job.wrapJobFn(job))

--- a/src/toil/test/src/workerTest.py
+++ b/src/toil/test/src/workerTest.py
@@ -27,10 +27,10 @@ class WorkerTests(ToilTest):
     def setUp(self):
         super().setUp()
         path = self._getTestJobStorePath()
-        self.jobStore = FileJobStore(path)
         self.config = Config()
         self.config.jobStore = "file:%s" % path
-        self.jobStore.initialize(self.config)
+        self.jobStore = FileJobStore(path, self.config)
+        self.jobStore.initialize()
         self.jobNumber = 0
 
     def testNextChainable(self):

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -1221,7 +1221,10 @@ class NonDownloadingSize(WDL.StdLib._Size):
                 else:
                     # This is some other kind of remote file.
                     # We need to get its size from the URI.
-                    item_size = AbstractJobStore.get_size(uri)
+                    # To access the URI we need to reach inside the stdlib to get a URLAccess.
+                    # TODO: Maybe the stdlib should be one???
+                    assert isinstance(self.stdlib, ToilWDLStdLibBase)
+                    item_size = self.stdlib._file_store.jobStore.get_size(uri)
                     if item_size is None:
                         # User asked for the size and we can't figure it out efficiently, so bail out.
                         raise RuntimeError(f"Attempt to check the size of {uri} failed")
@@ -1659,7 +1662,7 @@ class ToilWDLStdLibBase(WDL.StdLib.Base):
                 )
                 file_uri = Toil.normalize_uri(abs_filepath)
 
-            if not AbstractJobStore.url_exists(file_uri):
+            if not self._file_store.jobStore.url_exists(file_uri):
                 logger.debug("File appears nonexistent so marking it nonexistent")
                 return set_file_nonexistent(file, True)
         virtualized_filename = self._virtualize_filename(file.value)
@@ -1746,7 +1749,8 @@ class ToilWDLStdLibBase(WDL.StdLib.Base):
             # Open it exclusively
             with open(dest_path, "xb") as dest_file:
                 # And save to it
-                size, executable = AbstractJobStore.read_from_url(filename, dest_file)
+                url_access = file_source if isinstance(file_source, Toil) else file_source.jobStore
+                size, executable = url_access.read_from_url(filename, dest_file)
                 if executable:
                     # Set the execute bit in the file's permissions
                     os.chmod(dest_path, os.stat(dest_path).st_mode | stat.S_IXUSR)
@@ -2611,7 +2615,7 @@ def drop_if_missing(
 
     if filename is not None and is_any_url(filename):
         try:
-            if filename.startswith(TOIL_URI_SCHEME) or AbstractJobStore.url_exists(
+            if filename.startswith(TOIL_URI_SCHEME) or standard_library._file_store.jobStore.url_exists(
                 filename
             ):
                 # We assume anything in the filestore actually exists.
@@ -5453,7 +5457,7 @@ def main() -> None:
                 document: WDL.Tree.Document = WDL.load(
                     resolve_workflow(options.wdl_uri, supported_languages={"WDL"}),
                     # Smuggle the job store in so we can read URLs according to the config
-                    read_source=functools.partial(toil_read_source, job_store=toil._jobStore),
+                    read_source=partial(toil_read_source, job_store=toil._jobStore),
                 )
 
                 # See if we're going to run a workflow or a task
@@ -5521,7 +5525,7 @@ def main() -> None:
 
                         # We need the absolute path or URL to raise the error
                         if input_source_uri is not None:
-                            # If this is a local fike, use that as the abspath.
+                            # If this is a local file, use that as the abspath.
                             # Otherwise just pass through a URL.
                             inputs_abspath = (
                                 input_source_uri

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -518,10 +518,13 @@ async def toil_read_source(
             # TODO: this is probably sync work that would be better as async work here
             job_store.read_from_url(candidate_uri, destination_buffer)
         except Exception as e:
-            # TODO: we need to assume any error is just a not-found,
+            # We need to assume any arbitrary error is just a not-found,
             # because the exceptions thrown by read_from_url()
             # implementations are not specified.
-            logger.debug("Tried to fetch %s from %s but got %s", uri, candidate_uri, e)
+            logger.debug("Tried to fetch %s from %s but got %s: %s", uri, candidate_uri, type(e), e)
+            if isinstance(e, TypeError):
+                # This is probably actually a bug
+                raise
             continue
         # If we get here, we got it probably.
         try:


### PR DESCRIPTION
This should fix #5203 by adding a flag and environment variable for doing `s3://` URL accesses anonymously.

I implemented the ability for job stores to provide command-line options to make this work. (Though with my later refactoring maybe I really need to move that to URL scheme implementations???)

To do this I needed to give URL accesses access to the Toil config, so I refactored them out of the AbstractJobStore. I also moved the implementations out of the AbstractJobStore and to their own interface (though the job store implementations still implement the various URL schemes by also implementing that interface).

I also had to adjust the CWL runner to prepare the RuntimeContext carefully for pickling, since now it needs a URL accessing widget, which might be the `Toil` object or the whole JobStore and shouldn't be moved from machine to machine. Now that's wrapped in a couple of functions that handle setting and clearing all the file access hooks, but to avoid thinking about different levels of context set-up-ness now every CWL job that uses a RuntimeContext sets up and tears down the while file streaming thread system. That code could probably be consolidated.

And I needed access to the config early on in the CWL runner to use it to access URLs, so I changed how the `Toil` object sets up the config so you can get it after construction and don't need to go into the context manager.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Added `--awsAnonymousUrlAccess`/`TOIL_AWS_ANONYMOUS_URL_ACCESS` to allow accessing public data in S3 without logging in with an account that might need MFA or not grant access to it through IAM.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

