### PR TITLE
Handle coercing file: URIs to files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import sys
 import types
 from importlib.machinery import SourceFileLoader
 from tempfile import NamedTemporaryFile
@@ -143,7 +144,6 @@ def import_version():
         # First make sure we can find it (in case we're happening during an
         # install where the source tree isn't on the path already).
         # See <https://github.com/pypa/setuptools/discussions/3909#discussioncomment-5718455>
-        import sys
         sys.path.append(os.path.dirname(__file__))
 
         import version_template

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,13 @@ def import_version():
                 cwltool_version = req[len("cwltool==") :]
                 break
         # Use the template to generate src/toil/version.py
+
+        # First make sure we can find it (in case we're happening during an
+        # install where the source tree isn't on the path already).
+        # See <https://github.com/pypa/setuptools/discussions/3909#discussioncomment-5718455>
+        import sys
+        sys.path.append(os.path.dirname(__file__))
+
         import version_template
 
         with NamedTemporaryFile(

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -403,7 +403,7 @@ class Config:
         set_option("writeLogsGzip")
         set_option("writeLogsFromAllJobs")
         set_option("write_messages")
-        
+
         # Data Publishing Options
         set_option("publish_workflow_metrics")
 
@@ -658,7 +658,7 @@ def update_config(filepath: str, key: str, new_value: Union[str, bool, int, floa
     :param key: Setting to set. Must be the command-line option name, not the
         destination variable name.
     """
-    
+
     yaml = YAML(typ="rt")
     data = yaml.load(open(filepath))
 
@@ -1505,21 +1505,33 @@ class Toil(ContextManager["Toil"]):
         self._jobStore.export_file(file_id, dst_uri)
 
     @staticmethod
-    def normalize_uri(uri: str, check_existence: bool = False) -> str:
+    def normalize_uri(uri: str, check_existence: bool = False, dir_path: Optional[str] = None) -> str:
         """
-        Given a URI, if it has no scheme, prepend "file:".
+        Given a URI, if it has no scheme, make it a properly quoted file: URI.
 
         :param check_existence: If set, raise FileNotFoundError if a URI points to
                a local file that does not exist.
+
+        :param dir_path: If specified, interpret relative paths relative to the
+            given directory path instead of the current one.
         """
-        if urlparse(uri).scheme == "file":
+
+        parsed = urlparse(uri)
+        if parsed.scheme == "file":
             uri = unquote(
-                urlparse(uri).path
+                parsed.path
             )  # this should strip off the local file scheme; it will be added back
+            parsed = urlparse(uri)
 
         # account for the scheme-less case, which should be coerced to a local absolute path
-        if urlparse(uri).scheme == "":
-            abs_path = os.path.abspath(uri)
+        if parsed.scheme == "":
+            if dir_path is not None:
+                # To support relative paths from a particular directory, join
+                # the directory on. If uri is already an abs path, join() will
+                # not do anything
+                abs_path = os.path.join(dir_path, uri)
+            else:
+                abs_path = os.path.abspath(uri)
             if not os.path.exists(abs_path) and check_existence:
                 raise FileNotFoundError(
                     f'Could not find local file "{abs_path}" when importing "{uri}".\n'

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -395,6 +395,7 @@ class FileJobStore(AbstractJobStore):
 
     @classmethod
     def _url_exists(cls, url: ParseResult) -> bool:
+        # Note that broken symlinks will not be shown to exist.
         return os.path.exists(cls._extract_path_from_url(url))
 
     @classmethod

--- a/src/toil/lib/accelerators.py
+++ b/src/toil/lib/accelerators.py
@@ -103,7 +103,9 @@ def have_working_nvidia_docker_runtime() -> bool:
                 "all",
                 "ubuntu:20.04",
                 "nvidia-smi",
-            ]
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
         )
     except (
         FileNotFoundError,

--- a/src/toil/lib/io.py
+++ b/src/toil/lib/io.py
@@ -45,6 +45,9 @@ REMOTE_SCHEMES = STANDARD_SCHEMES + [TOIL_URI_SCHEME]
 ALL_SCHEMES = REMOTE_SCHEMES + ["file:"]
 
 def is_standard_url(filename: str) -> bool:
+    """
+    Return True if the given URL is a non-Toil, non-file: URL.
+    """
     return is_url_with_scheme(filename, STANDARD_SCHEMES)
 
 def is_remote_url(filename: str) -> bool:
@@ -72,11 +75,18 @@ def is_url_with_scheme(filename: str, schemes: list[str]) -> bool:
     return False
 
 def is_toil_url(filename: str) -> bool:
+    """
+    Return True if a URL is a toilfile: URL.
+    """
     return is_url_with_scheme(filename, [TOIL_URI_SCHEME])
 
 def is_file_url(filename: str) -> bool:
-    return is_url_with_scheme(filename, ["file:"])
+    """
+    Return True if a URL is a file: URL.
 
+    Will return False for bare paths.
+    """
+    return is_url_with_scheme(filename, ["file:"])
 
 def mkdtemp(
     suffix: Optional[str] = None,

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -327,6 +327,12 @@ def _has_rsync3() -> bool:
             return False
     except subprocess.CalledProcessError:
         return False
+    except ValueError:
+        # Don't have an int where we looked
+        return False
+    except IndexError:
+        # Don't have the field to look in
+        return False
     return True
 
 

--- a/src/toil/test/wdl/testfiles/string_file_coercion.json
+++ b/src/toil/test/wdl/testfiles/string_file_coercion.json
@@ -1,0 +1,1 @@
+{"StringFileCoercion.opt_file": "empty.txt"}

--- a/src/toil/test/wdl/testfiles/string_file_coercion.wdl
+++ b/src/toil/test/wdl/testfiles/string_file_coercion.wdl
@@ -1,0 +1,35 @@
+version 1.0
+
+workflow StringFileCoercion {
+
+    input {
+        File? opt_file
+    }
+
+    if (defined(opt_file)) {
+        call UseFile {
+            input:
+                # Exciting trick from https://github.com/broadinstitute/GATK-for-Microbes/blob/51f60135abd3f61efd0dcbe1e87c9aa89f5fb91c/wdl/shortReads/MicrobialGenomePipeline.wdl#L79C35-L79C44
+                input_file = select_first([opt_file, ""])
+        }
+    }
+
+    output {
+        File? output_file = UseFile.output_file
+    }
+}
+
+
+task UseFile {
+    input {
+        File input_file
+    }
+
+    command <<<
+        cat ~{input_file} | wc -c > output.txt
+    >>>
+
+    output {
+        File output_file = "output.txt"
+    }
+}

--- a/src/toil/test/wdl/wdltoil_test.py
+++ b/src/toil/test/wdl/wdltoil_test.py
@@ -266,7 +266,7 @@ class TestWDL:
 
     def test_string_file_coercion(self, tmp_path: Path) -> None:
         """
-        Test if input Files can be coreced to string and back.
+        Test if input Files can be coerced to string and back.
         """
         with get_data("test/wdl/testfiles/string_file_coercion.wdl") as wdl:
             with get_data("test/wdl/testfiles/string_file_coercion.json") as json_file:

--- a/src/toil/test/wdl/wdltoil_test.py
+++ b/src/toil/test/wdl/wdltoil_test.py
@@ -264,6 +264,27 @@ class TestWDL:
             assert isinstance(result["url_to_file.first_line"], str)
             assert result["url_to_file.first_line"] == "chr1\t248387328"
 
+    def test_string_file_coercion(self):
+        """
+        Test if input Files can be coreced to string and back.
+        """
+        with get_data("test/wdl/testfiles/string_file_coercion.wdl") as wdl:
+            with get_data("test/wdl/testfiles/string_file_coercion.json") as json_file:
+                result_json = subprocess.check_output(
+                    self.base_command
+                    + [
+                        str(wdl),
+                        str(json_file),
+                        "-o",
+                        self.output_dir,
+                        "--logInfo",
+                        "--retryCount=0"
+                    ]
+                )
+                result = json.loads(result_json)
+
+                assert "StringFileCoercion.output_file" in result
+
     @needs_docker
     def test_wait(self, tmp_path: Path) -> None:
         """

--- a/src/toil/test/wdl/wdltoil_test.py
+++ b/src/toil/test/wdl/wdltoil_test.py
@@ -264,7 +264,7 @@ class TestWDL:
             assert isinstance(result["url_to_file.first_line"], str)
             assert result["url_to_file.first_line"] == "chr1\t248387328"
 
-    def test_string_file_coercion(self):
+    def test_string_file_coercion(self, tmp_path: Path) -> None:
         """
         Test if input Files can be coreced to string and back.
         """
@@ -276,7 +276,7 @@ class TestWDL:
                         str(wdl),
                         str(json_file),
                         "-o",
-                        self.output_dir,
+                        str(tmp_path),
                         "--logInfo",
                         "--retryCount=0"
                     ]


### PR DESCRIPTION
This should fix #5265.

Broad likes to write workflows that coerce Files to Strings and back again. Apparently when we go File to String we always include a file: URI prefix, and the String-to-FIle coercion was thinking that was a nonexistent bare path, and also the caching code was not dealing with a file: URI that didn't have a known cache path.

This fixes both of these issues at workflow scope, by revising the file URI normalization and abs-pathing code to go through one true implementation, and by making sure to find files we're making from strings at workflow scope and hook up their shared-filesystem paths.

At task scope we really shouldn't be going from String to File for anything except what's on the task's filesystem; there might still be dragons there because I'm not sure this is really allowed there.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Toil can now handle coercing input `File`s to `String`s and back in WDL workflows.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

