### PR TITLE
Support relaxing quant checks in WDL

### DIFF
--- a/src/toil/options/wdl.py
+++ b/src/toil/options/wdl.py
@@ -97,3 +97,14 @@ def add_wdl_options(parser: ArgumentParser, suppress: bool = True) -> None:
         default=False,
         help=suppress_help or "Exit runner if workflow has any lint warnings"
     )
+
+    quant_check_arguments = ["--wdlQuantCheck"] + (
+        ["--quantCheck"] if not suppress else []
+    )
+    parser.add_argument(
+        *quant_check_arguments,
+        dest="quant_check",
+        type=strtobool,
+        default=True,
+        help=suppress_help or "Whether to relax quantifier validation rules"
+    )

--- a/src/toil/test/wdl/md5sum/md5sum-gs.json
+++ b/src/toil/test/wdl/md5sum/md5sum-gs.json
@@ -1,1 +1,1 @@
-{"ga4ghMd5.inputFile": "gs://broad-public-datasets/NA12878/NA12878.cram.crai"}
+{"ga4ghMd5.inputFile": "gs://gcp-public-data-landsat/LT04/01/003/027/LT04_L1TP_003027_19830202_20170220_01_T1/README.GTF"}

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -5662,6 +5662,7 @@ def main() -> None:
             document: WDL.Tree.Document = WDL.load(
                 wdl_uri,
                 read_source=toil_read_source,
+                check_quant=options.quant_check
             )
 
             # See if we're going to run a workflow or a task


### PR DESCRIPTION
This will give us MiniWDL relaxed quant check parity.

The only place we use MiniWDL's type checking seems to be in the initial document load, which is where any type errors will result in the workflow crashing. We don't actually use MiniWDL's type checking for evaluation since we have our own evaluation logic, so our existing code seems to be fairly robust to coercing from optional types, ex:

```wdl
workflow testWorkflow {
    input {
      String? in
    }
    call testTask {input: test=in}
    output {
      String out = testTask.out
    }
}

task testTask {
  input {
    String test
  }
  command <<<
  >>>

  output {
    String out = test
  }
}
```

A downside to this seems to be that even with relaxed type checking, we don't have full behavioral parity with MiniWDL as MiniWDL seems to coerce any nonexistent optional type (at least string) to the empty string:

```
$ miniwdl run test.wdl --no-quant-check
...
{
  "dir": "/home/heaucques/Documents/toil/20250507_123426_testWorkflow",
  "outputs": {
    "testWorkflow.out": ""
  }
}
```
For Toil, we always expect something, so it will just crash:
```
$ toil-wdl-runner test.wdl --quantCheck=False
...
[2025-05-07T12:35:15-0700] [MainThread] [C] [toil.wdl.wdltoil] Could not evaluate task code because:
	
	🚨🚨🚨
	(test.wdl Ln 13 Col 5) Value for test was not provided and no default value is available
	🚨🚨🚨
```

Since this isn't really in the spec (I think?), it might be some type of behavior up to the runner.


Another thing to note is that I don't know how easy it is to "get a fully-working flag" (see https://github.com/chanzuckerberg/miniwdl/issues/752). We currently depend on MiniWDL's type checking system, so short of monkeypatching or writing our own type checker, there isn't a very easy way.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Allow relaxing quantifier checks with `--quantCheck`
 
## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

