### PR TITLE
Use streams to make the status sentinel shared files

### DIFF
--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -349,14 +349,9 @@ class Leader:
     def create_status_sentinel_file(self, fail: bool) -> None:
         """Create a file in the jobstore indicating failure or success."""
         logName = "failed.log" if fail else "succeeded.log"
-        localLog = os.path.join(os.getcwd(), logName)
-        open(localLog, "w").close()
-        self.jobStore.import_file("file://" + localLog, logName, hardlink=True)
-
-        if os.path.exists(
-            localLog
-        ):  # Bandaid for Jenkins tests failing stochastically and unexplainably.
-            os.remove(localLog)
+        with self.jobStore.write_shared_file_stream(logName) as file_handle:
+            # We just need an empty file, so don't write any content
+            pass
 
     def _handledFailedSuccessor(self, successor_id: str, predecessor_id: str) -> bool:
         """


### PR DESCRIPTION
For some reason we were creating and deleting files with particular names in the current directory to create filestore shared files with particular names.

We shouldn't need to do that, because we have the filestore streaming functions, so now we don't.

This should fix #5086.

I don't have a test for this, because "doesn't delete `succeeded.log`" seemed like a weirdly specific property to test, and a test for "no race conditions for many workflows at once in one directory" seemed expensive to run.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Toil workflows will no longer touch and then delete (or race each other to use) `succeeded.log` or `failed.log` in the current directory on completion.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

