### PR TITLE
Improve configuration validation around autoscaling

### DIFF
--- a/src/toil/batchSystems/kubernetes.py
+++ b/src/toil/batchSystems/kubernetes.py
@@ -642,7 +642,7 @@ class KubernetesBatchSystem(BatchSystemCleanupSupport):
                         self._jobs_queue.put(jobs.get_nowait())
                     except Empty:
                         break
-                logger.debug(f"Roughly {self._jobs_queue.qsize} jobs in the queue")
+                logger.debug(f"Roughly {self._jobs_queue.qsize()} jobs in the queue")
 
     def setUserScript(self, userScript: Resource) -> None:
         logger.info(f"Setting user script for deployment: {userScript}")

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -551,8 +551,17 @@ class Config:
             batch_system = get_batch_system(self.batchSystem)
         except KeyError:
             raise RuntimeError(
-                f"Unrecognized batch system: {self.batchSystem}  "
+                f"Unrecognized batch system: {self.batchSystem} "
                 f'(choose from: {", ".join(get_batch_systems())})'
+            )
+        except ImportError as e:
+            raise RuntimeError(
+                f"The batch system \"{self.batchSystem}\" is known "
+                f"to Toil but cannot be loaded "
+                f"because \"{e.name}\" is not importable ({e}). "
+                f"Did you install Toil with the corresponding extra? "
+                f"If in doubt, use pip or pipx to install 'toil[all]' "
+                f"(with quotes) instead of just toil."
             )
 
         return batch_system

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -103,6 +103,14 @@ if TYPE_CHECKING:
 UUID_LENGTH = 32
 logger = logging.getLogger(__name__)
 
+class InconsistentConfigurationError(ValueError):
+    """
+    Class representing an error due to a Toil configuration that cannot be used.
+
+    Has an informative user-facing error message which can be logged before terminating the program.
+    """
+    pass
+
 
 @memoize
 def get_default_config_path() -> str:
@@ -460,34 +468,49 @@ class Config:
 
         self.check_configuration_consistency()
 
-        # Check for deprecated Toil built-in autoscaling
-        # --provisioner is guaranteed to be set
-        if self.provisioner is not None and self.batchSystem == "mesos":
-            logger.warning(
-                "Toil built-in autoscaling with Mesos is deprecated as Mesos is no longer active. Please use Kubernetes-based autoscaling instead."
-            )
-        
-        if self.provisioner == "gce":
-            logger.warning(
-                "Toil's GCE provisioner is deprecated and will be removed in a future release. Please use Kubernetes-based autoscaling instead."
-            )
-
     def check_configuration_consistency(self) -> None:
-        """Old checks that cannot be fit into an action class for argparse"""
+        """
+        Check whether the configuration asked for is self-consistent.
+
+        May modify the configuration to resolve automatically-resolvable
+        contraditions. Responsible for issuing warnings about the
+        configuration.
+
+        Raised exceptions will have messages in terms of command-line options,
+        suitable for showing to the user without a stack trace.
+
+        :raises InconsistentConfigurationError: when the configuration is
+            inconsistent and cannot be fixed.
+        """
+
+        # If possible, checks in here should be moved to option parsing actions
+        # for better error messages.
+
         if self.writeLogs and self.writeLogsGzip:
-            raise ValueError(
+            raise InconsistentConfigurationError(
                 "Cannot use both --writeLogs and --writeLogsGzip at the same time."
             )
         if self.writeLogsFromAllJobs and not self.writeLogs and not self.writeLogsGzip:
-            raise ValueError(
+            raise InconsistentConfigurationError(
                 "To enable --writeLogsFromAllJobs, either --writeLogs or --writeLogsGzip must be set."
             )
         for override in self.nodeStorageOverrides:
             tokens = override.split(":")
             if not any(tokens[0] in n[0] for n in self.nodeTypes):
-                raise ValueError(
+                raise InconsistentConfigurationError(
                     "Instance type in --nodeStorageOverrides must be in --nodeTypes"
                 )
+
+        from toil.batchSystems.abstractBatchSystem import AbstractScalableBatchSystem
+        if self.provisioner is not None and not issubclass(
+            self.load_batch_system_class(),
+            AbstractScalableBatchSystem
+        ):
+            raise InconsistentConfigurationError(
+                f"The {self.batchSystem} batch system is not scalable and "
+                f"cannot be used with the {self.provisioner} provisioner; change "
+                f"or remove --provisioner, or pick a different --batchSystem."
+            )
 
         if self.stats:
             if self.clean != "never" and self.clean is not None:
@@ -498,6 +521,40 @@ class Config:
                     "Setting clean to 'never'." % self.clean
                 )
             self.clean = "never"
+
+        # Check for deprecated Toil built-in autoscaling
+        # --provisioner is guaranteed to be set
+        if self.provisioner is not None and self.batchSystem == "mesos":
+            logger.warning(
+                "Toil built-in autoscaling with Mesos is deprecated as Mesos is no longer active. Please use Kubernetes-based autoscaling instead."
+            )
+
+        if self.provisioner == "gce":
+            logger.warning(
+                "Toil's GCE provisioner is deprecated and will be removed in a future release. Please use Kubernetes-based autoscaling instead."
+            )
+
+    def load_batch_system_class(self) -> type["AbstractBatchSystem"]:
+        """
+        Get the class of batch system that is configured.
+
+        :raises RuntimeError: when the configured batch system is not available.
+        """
+
+        # TODO: I'm not sure if this *really* belongs as a config method, but
+        # the config validation logic wants it.
+
+        from toil.batchSystems.registry import get_batch_system, get_batch_systems
+
+        try:
+            batch_system = get_batch_system(self.batchSystem)
+        except KeyError:
+            raise RuntimeError(
+                f"Unrecognized batch system: {self.batchSystem}  "
+                f'(choose from: {", ".join(get_batch_systems())})'
+            )
+
+        return batch_system
 
     def __eq__(self, other: object) -> bool:
         return self.__dict__ == other.__dict__
@@ -1038,6 +1095,9 @@ class Toil(ContextManager["Toil"]):
 
         Then load the job store and, on restart, consolidate the derived
         configuration with the one from the previous invocation of the workflow.
+
+        :raises InconsistentConfigurationError: When the Toil configuration is
+            inconsistent and cannot be used.
         """
         set_logging_from_options(self.options)
         config = Config()
@@ -1377,15 +1437,7 @@ class Toil(ContextManager["Toil"]):
             maxDisk=config.maxDisk,
         )
 
-        from toil.batchSystems.registry import get_batch_system, get_batch_systems
-
-        try:
-            batch_system = get_batch_system(config.batchSystem)
-        except KeyError:
-            raise RuntimeError(
-                f"Unrecognized batch system: {config.batchSystem}  "
-                f'(choose from: {", ".join(get_batch_systems())})'
-            )
+        batch_system = config.load_batch_system_class()
 
         if config.caching and not batch_system.supportsWorkerCleanup():
             raise RuntimeError(

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -914,8 +914,11 @@ def addOptions(
             sys.argv[1:], ignore_help_args=True
         )
         if len(vars(other_options)) != 0:
+            # TODO: We want to tell the user the actual option string, but we only have the variable name.
             raise parser.error(
-                f"{'WDL' if typ == 'cwl' else 'CWL'} options are not allowed on the command line."
+                f"{'WDL' if typ == 'cwl' else 'CWL'} options like those "
+                f"populating {', '.join(vars(other_options).keys())} are not "
+                f"allowed on the command line."
             )
 
     # if cwl is set, format the namespace for cwl and check that wdl options are not set on the command line

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -105,9 +105,10 @@ logger = logging.getLogger(__name__)
 
 class InconsistentConfigurationError(ValueError):
     """
-    Class representing an error due to a Toil configuration that cannot be used.
+    Represents when a Toil configuration is nonsensical and cannot be used.
 
-    Has an informative user-facing error message which can be logged before terminating the program.
+    Has an informative user-facing error message which can be logged before
+    terminating the program.
     """
     pass
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -99,7 +99,7 @@ from schema_salad.sourceline import SourceLine
 
 from toil.batchSystems.abstractBatchSystem import InsufficientSystemResources
 from toil.batchSystems.registry import DEFAULT_BATCH_SYSTEM
-from toil.common import Config, Toil, addOptions
+from toil.common import Config, Toil, addOptions, InconsistentConfigurationError
 from toil.cwl import check_cwltool_version
 from toil.lib.directory import DirectoryContents, decode_directory, encode_directory
 from toil.lib.misc import call_command
@@ -4716,6 +4716,7 @@ def main(args: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
         UnimplementedURLException,
         JobTooBigError,
         FileNotFoundError,
+        InconsistentConfigurationError,
     ) as err:
         logging.error(err)
         return 1

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -105,6 +105,7 @@ from toil.lib.directory import DirectoryContents, decode_directory, encode_direc
 from toil.lib.misc import call_command
 from toil.lib.trs import resolve_workflow
 from toil.provisioners.clusterScaler import JobTooBigError
+from toil.statsAndLogging import set_logging_from_options
 
 check_cwltool_version()
 from toil.cwl.utils import (
@@ -4313,6 +4314,10 @@ def main(args: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
         args = sys.argv[1:]
 
     options = get_options(args)
+
+    # As soon as practicable, set up logging.
+    # TODO: the Toil context manager will do this again.
+    set_logging_from_options(options)
 
     # Do cwltool setup
     cwltool.main.setup_schema(args=options, custom_schema_callback=None)

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -55,7 +55,7 @@ from toil.job import (
 from toil.jobStores.abstractJobStore import AbstractJobStore, NoSuchJobException
 from toil.lib.throttle import LocalThrottle
 from toil.provisioners.abstractProvisioner import AbstractProvisioner
-from toil.provisioners.clusterScaler import ScalerThread
+from toil.provisioners.clusterScaler import ScalerThread, NonScalableBatchSystemError
 from toil.serviceManager import ServiceManager
 from toil.statsAndLogging import StatsAndLogging
 from toil.toilState import ToilState
@@ -294,11 +294,20 @@ class Leader:
                         if self.clusterScaler is not None:
                             logger.debug("Waiting for workers to shutdown.")
                             startTime = time.time()
-                            self.clusterScaler.shutdown()
-                            logger.debug(
-                                "Worker shutdown complete in %s seconds.",
-                                time.time() - startTime,
-                            )
+                            try:
+                                self.clusterScaler.shutdown()
+                            except NonScalableBatchSystemError:
+                                logger.error(
+                                    "Could not shut down the cluster scaler because "
+                                    "we weren't supposed to use one with this batch "
+                                    "system in the first place. Attempting to complete "
+                                    "workflow anyway."
+                                )
+                            else:
+                                logger.debug(
+                                    "Worker shutdown complete in %s seconds.",
+                                    time.time() - startTime,
+                                )
 
                 finally:
                     # Ensure service manager thread is properly shutdown

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -192,9 +192,16 @@ class Leader:
         # using a statically defined cluster
         self.provisioner = provisioner
 
-        # Create cluster scaling thread if the provisioner is not None
+        # Create cluster scaling thread if we want to scale up and down 
         self.clusterScaler = None
         if self.provisioner is not None and self.provisioner.hasAutoscaledNodeTypes():
+            if not isinstance(self.batchSystem, AbstractScalableBatchSystem):
+                # We shouldn't be allowed to use this combination
+                raise RuntimeError(
+                    f"Cannot use in-workflow autoscaling with the {type(self.provisioner)} "
+                    f"provisioner when using a non-scalable {type(self.batchSystem)} "
+                    f"batch system; consider Kuberentes cluster-based autoscaling instead"
+                )
             self.clusterScaler = ScalerThread(self.provisioner, self, self.config)
 
         # A service manager thread to start and terminate services

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -68,7 +68,7 @@ class NonScalableBatchSystemError(NotImplementedError):
     in-workflow autoscaler is beiong used with it anyway.
     """
 
-    def __init__(message: str | None) -> None:
+    def __init__(self, message: str | None) -> None:
         """
         Make a new error with either the provided message or a default one.
         """

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -62,6 +62,18 @@ OS_SIZE = human2bytes("5G")
 # Consists of a resource name and a constraining value for that resource.
 FailedConstraint = tuple[str, Union[int, float, bool]]
 
+class NonScalableBatchSystemError(NotImplementedError):
+    """
+    Error to raise when a batch system that can't work with the Toil
+    in-workflow autoscaler is beiong used with it anyway.
+    """
+
+    def __init__(message: str | None) -> None:
+        """
+        Make a new error with either the provided message or a default one.
+        """
+        super().__init__(message or "Non-scalable batch system abusing a scalable-only function.")
+
 
 class BinPackedFit:
     """
@@ -947,9 +959,7 @@ class ClusterScaler:
                 actual cluster size at the time this method returns.
         """
         if not isinstance(self.leader.batchSystem, AbstractScalableBatchSystem):
-            raise RuntimeError(
-                "Non-scalable batch system abusing a scalable-only function."
-            )
+            raise NonScalableBatchSystemError()
         for attempt in old_retry(predicate=self.provisioner.retryPredicate):
             with attempt:
                 nodes = self.getNodes(preemptible)
@@ -1097,9 +1107,7 @@ class ClusterScaler:
         but which still have workers running.
         """
         if not isinstance(self.leader.batchSystem, AbstractScalableBatchSystem):
-            raise RuntimeError(
-                "Non-scalable batch system abusing a scalable-only function."
-            )
+            raise NonScalableBatchSystemError()
 
         # start with a dictionary of all nodes and filter down
         nodes = self.getNodes()
@@ -1170,9 +1178,7 @@ class ClusterScaler:
                If None, all nodes will be returned.
         """
         if not isinstance(self.leader.batchSystem, AbstractScalableBatchSystem):
-            raise RuntimeError(
-                "Non-scalable batch system abusing a scalable-only function."
-            )
+            raise NonScalableBatchSystemError()
         # nodes seen within the last 600 seconds (10 minutes)
         recent_nodes = self.leader.batchSystem.getNodes(preemptible, timeout=600)
         # all available nodes
@@ -1497,9 +1503,7 @@ class ClusterStats:
             logger.debug("Starting to gather statistics")
             stats: dict[str, list[dict[str, Any]]] = {}
             if not isinstance(self.batchSystem, AbstractScalableBatchSystem):
-                raise RuntimeError(
-                    "Non-scalable batch system abusing a scalable-only function."
-                )
+                raise NonScalableBatchSystemError()
             try:
                 while not self.stop:
                     nodeInfo = self.batchSystem.getNodes(preemptible)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -68,7 +68,7 @@ class NonScalableBatchSystemError(NotImplementedError):
     in-workflow autoscaler is beiong used with it anyway.
     """
 
-    def __init__(self, message: str | None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         """
         Make a new error with either the provided message or a default one.
         """

--- a/src/toil/test/src/commonTests.py
+++ b/src/toil/test/src/commonTests.py
@@ -31,13 +31,16 @@ class TestConfig:
         """
         Make sure we're not allowed to try and do autoscaling in the workflow with a batch system that can't handle it.
         """
+        # We need to only use modules we know will be installed, for the batch
+        # system side.
+        # Which means we can't use kubernetes.
         config = Config()
-        config.batchSystem = "kubernetes"
+        config.batchSystem = "single_machine"
         config.provisioner = "aws"
         with pytest.raises(InconsistentConfigurationError) as info:
             config.check_configuration_consistency()
         assert "provisioner" in str(info.value)
-        assert "kubernetes" in str(info.value)
+        assert "single_machine" in str(info.value)
         assert "aws" in str(info.value)
 
 

--- a/src/toil/test/src/commonTests.py
+++ b/src/toil/test/src/commonTests.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 Regents of the University of California
+# Copyright (C) 2015-2026 Regents of the University of California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/toil/test/src/commonTests.py
+++ b/src/toil/test/src/commonTests.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2015-2021 Regents of the University of California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import sys
+
+import pytest
+
+from toil.common import Config, InconsistentConfigurationError
+
+logger = logging.getLogger(__name__)
+logging.basicConfig()
+
+class TestConfig:
+    """
+    Tests for the Toil configuration object.
+    """
+
+    def test_check_configuration_consistency_disallows_bad_scaling_setup(self) -> None:
+        """
+        Make sure we're not allowed to try and do autoscaling in the workflow with a batch system that can't handle it.
+        """
+        config = Config()
+        config.batchSystem = "kubernetes"
+        config.provisioner = "aws"
+        with pytest.raises(InconsistentConfigurationError) as info:
+            config.check_configuration_consistency()
+        assert "provisioner" in str(info.value)
+        assert "kubernetes" in str(info.value)
+        assert "aws" in str(info.value)
+
+
+

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -63,6 +63,7 @@ def main() -> None:
     parser.add_argument(
         "--keyPairName",
         dest="keyPairName",
+        required=True,
         help="On AWS, the name of the AWS key pair to include on the instance."
         " On Google/GCE, this is the ssh key pair.",
     )
@@ -280,6 +281,7 @@ def main() -> None:
         enable_fuse=options.allowFuse,
     )
 
+    assert options.keyPairName is not None
     cluster.launchCluster(
         leaderNodeType=options.leaderNodeType,
         leaderStorage=options.leaderStorage,

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -74,7 +74,7 @@ from WDL.runtime.task_container import TaskContainer
 from WDL.Tree import ReadSourceResult
 
 from toil.batchSystems.abstractBatchSystem import InsufficientSystemResources
-from toil.common import Toil, addOptions
+from toil.common import Toil, addOptions, InconsistentConfigurationError
 from toil.exceptions import FailedJobsException
 from toil.fileStores import FileID
 from toil.fileStores.abstractFileStore import AbstractFileStore
@@ -6385,6 +6385,9 @@ def main() -> None:
     except FailedJobsException as e:
         logger.error("WDL job failed: %s", e)
         sys.exit(e.exit_code)
+    except InconsistentConfigurationError as e:
+        logging.error(err)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -6392,7 +6392,7 @@ def main() -> None:
         logger.error("WDL job failed: %s", e)
         sys.exit(e.exit_code)
     except InconsistentConfigurationError as e:
-        logging.error(err)
+        logging.error(e)
         sys.exit(1)
 
 

--- a/src/toil/wdl/wdltoil.py
+++ b/src/toil/wdl/wdltoil.py
@@ -126,6 +126,7 @@ from toil.lib.io import (
 from toil.lib.memoize import memoize
 from toil.lib.misc import get_user_name
 from toil.lib.resources import ResourceMonitor
+from toil.statsAndLogging import set_logging_from_options
 from toil.lib.threading import global_mutex
 from toil.lib.trs import resolve_workflow
 from toil.lib.url import URLAccess
@@ -6093,30 +6094,35 @@ def main() -> None:
 
     options = parser.parse_args(args)
 
-    # Make sure we have a jobStore
-    if options.jobStore is None:
-        # TODO: Move cwltoil's generate_default_job_store where we can use it
-        options.jobStore = os.path.join(mkdtemp(), "tree")
-
-    # Having an nargs=? option can put a None in our inputs list, so drop that.
-    input_sources = [x for x in options.inputs_uri if x is not None]
-    if len(input_sources) > 1:
-        raise RuntimeError(
-            f"Workflow inputs cannot be specified with both the -i/--input/--inputs flag "
-            f"and as a positional argument at the same time. Cannot use both "
-            f'"{input_sources[0]}" and "{input_sources[1]}".'
-        )
-
-    # Make sure we have an output directory (or URL prefix) and we don't need
-    # to ever worry about a None, and MyPy knows it.
-    # If we don't have a directory assigned, make one in the current directory.
-    output_directory: str = (
-        options.output_directory
-        if options.output_directory
-        else mkdtemp(prefix="wdl-out-", dir=os.getcwd())
-    )
+    # As soon as practicable, set up logging.
+    # TODO: the Toil context manager will do this again.
+    set_logging_from_options(options)
 
     try:
+        # Make sure we have a jobStore
+        if options.jobStore is None:
+            # TODO: Move cwltoil's generate_default_job_store where we can use it
+            options.jobStore = os.path.join(mkdtemp(), "tree")
+
+        # Having an nargs=? option can put a None in our inputs list, so drop that.
+        input_sources = [x for x in options.inputs_uri if x is not None]
+        if len(input_sources) > 1:
+            raise InconsistentConfigurationError(
+                f"Workflow inputs cannot be specified with both the -i/--input/--inputs flag "
+                f"and as a positional argument at the same time. Cannot use both "
+                f'"{input_sources[0]}" and "{input_sources[1]}".'
+            )
+
+        # Make sure we have an output directory (or URL prefix) and we don't need
+        # to ever worry about a None, and MyPy knows it.
+        # If we don't have a directory assigned, make one in the current directory.
+        output_directory: str = (
+            options.output_directory
+            if options.output_directory
+            else mkdtemp(prefix="wdl-out-", dir=os.getcwd())
+        )
+
+
         wdl_uri, trs_spec = resolve_workflow(
             options.wdl_uri, supported_languages={"WDL"}
         )


### PR DESCRIPTION
This will fix #5380 by preventing the workflow from starting up at all when given a provisioner and a batch system that shouldn't be used together.

It also revises some of the logging and error reporting to make the resulting message more human-readable.

I have several levels of errors now, some of which one *shouldn't* be able to reach unless one somehow sneaks past the previous levels. But I suppose it's possible someone is doing weird things in a Python workflow?

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

* Toil will no longer throw away workflow output when finishing a workflow that managed to start with both in-workflow autoscaling and a non-scalable batch system.
* Toil will now catch and prohibit starting a workflow with in-workflow autoscaling and a non-scalable batch system.
* CWL and WDL interpreters now set up fancy logging much earlier in startup
* Configuration inconsistency problems will now be reported as error messages rather than stack traces
* Kubernetes batch system will no longer log a method instead of a job count
* `toil launch-cluster` will no longer try and launch a cluster without a `--keyPairName`.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

