### PR TITLE
Inspect missing cache files and fix lock races

### DIFF
--- a/src/toil/deferred.py
+++ b/src/toil/deferred.py
@@ -23,7 +23,7 @@ from typing_extensions import ParamSpec
 import dill
 
 from toil.lib.io import robust_rmtree
-from toil.lib.threading import safe_lock, safe_unlock_and_close
+from toil.lib.threading import safe_lock, locked_file_is, safe_unlock_and_close
 from toil.realtimeLogger import RealtimeLogger
 from toil.resource import ModuleDescriptor
 
@@ -150,6 +150,8 @@ class DeferredFunctionManager:
             else:
                 # Something else went wrong
                 raise
+        if not locked_file_is(self.stateFD, self.stateFileName):
+            raise RuntimeError(f"Someone tampered with our state file during setup: {self.stateFileName}")
 
         # Rename it to remove the suffix
         os.rename(self.stateFileName, self.stateFileName[: -len(self.WIP_SUFFIX)])
@@ -173,6 +175,7 @@ class DeferredFunctionManager:
         # Hide the state from other processes
         if os.path.exists(self.stateFileName):
             os.unlink(self.stateFileName)
+            logger.debug("Removed own state file %s", self.stateFileName)
 
         # Unlock it
         safe_unlock_and_close(self.stateFD)
@@ -274,7 +277,7 @@ class DeferredFunctionManager:
         Run all of the deferred functions that were registered.
         """
 
-        logger.debug("Running own deferred functions")
+        logger.debug("Running own deferred functions in %s", self.stateFileName)
 
         # Seek back to the start of our file
         self.stateFileIn.seek(0)
@@ -352,10 +355,18 @@ class DeferredFunctionManager:
 
                 logger.debug("Locked file %s" % fullFilename)
 
+                if not loacke_file_is(fd, fullFilename):
+                    # File was removed between open and lock.
+                    safe_unlock_and_close(fd)
+                    logger.debug("Skipping unlinked file %s" % fullFilename)
+                    continue
+
+
                 # File is locked successfully. Our problem now.
                 foundFiles = True
 
-                # Actually run all the stored deferred functions
+                # Actually run all the stored deferred functions.
+                # We re-open the file here, so it had better still be linked.
                 fileObj = open(fullFilename, "rb")
                 self._runAllDeferredFunctions(fileObj)
                 states_handled += 1

--- a/src/toil/deferred.py
+++ b/src/toil/deferred.py
@@ -355,7 +355,7 @@ class DeferredFunctionManager:
 
                 logger.debug("Locked file %s" % fullFilename)
 
-                if not loacke_file_is(fd, fullFilename):
+                if not locked_file_is(fd, fullFilename):
                     # File was removed between open and lock.
                     safe_unlock_and_close(fd)
                     logger.debug("Skipping unlinked file %s" % fullFilename)

--- a/src/toil/fileStores/cachingFileStore.py
+++ b/src/toil/fileStores/cachingFileStore.py
@@ -1472,6 +1472,10 @@ class CachingFileStore(AbstractFileStore):
             # Link or maybe copy
             self.jobStore.read_file(fileStoreID, cachedPath, symlink=False)
 
+        assert os.path.exists(cachedPath), (
+            "Downloaded file vanished: %s" % cachedPath
+        )
+
     def _readGlobalFileMutablyWithCache(self, fileStoreID, localFilePath, readerID):
         """
         Read a mutable copy of a file, putting it into the cache if possible.
@@ -1748,6 +1752,7 @@ class CachingFileStore(AbstractFileStore):
                 "SELECT COUNT(*) FROM files WHERE id = ? AND state = ? AND owner = ?",
                 (fileStoreID, "downloading", me),
             )
+
             if self.cur.fetchone()[0] > 0:
                 # Now we have exclusive control of the cached copy of the file, so we can give it away.
 
@@ -1789,9 +1794,46 @@ class CachingFileStore(AbstractFileStore):
         :rtype: bool
         """
 
-        assert os.path.exists(cachedPath), (
-            "Cannot create link to missing cache file %s" % cachedPath
-        )
+        if not os.path.exists(cachedPath):
+            # This file should exist; nobody should be calling this function
+            # without a ref. So complain the database is bad.
+
+            logger.critical(
+                "Cannot create link to missing cache file %s", cachedPath
+            )
+
+            # Dump relevant bits of the database
+            self._read(
+                "SELECT * FROM files WHERE path = ?",
+                (cachedPath,)
+            )
+            file_id = None
+            row = cur.fetchone()
+            while row is not None:
+                logger.critical("File row: %s", row)
+                file_id = row[0]
+                row = cur.fetchone()
+            self._read(
+                "SELECT * FROM refs WHERE path = ?",
+                (localFilePath,)
+            )
+            row = cur.fetchone()
+            while row is not None:
+                logger.critical("Our ref row: %s", row)
+                row = cur.fetchone()
+            if file_id is not None:
+                self._read(
+                    "SELECT * FROM refs WHERE file_id = ?",
+                    (file_id,)
+                )
+                row = cur.fetchone()
+                while row is not None:
+                    logger.critical("Cache ref row: %s", row)
+                    row = cur.fetchone()
+            else:
+                logger.critical("Cached file not found in database either")
+
+            raise RuntimeError(f"Missing cache file: {cachedPath}")
 
         try:
             # Try and make the hard link.

--- a/src/toil/fileStores/nonCachingFileStore.py
+++ b/src/toil/fileStores/nonCachingFileStore.py
@@ -32,6 +32,7 @@ from toil.lib.io import make_public_dir, robust_rmtree
 from toil.lib.retry import ErrorCondition, retry
 from toil.lib.threading import (
     get_process_name,
+    locked_file_is,
     process_name_exists,
     safe_lock,
     safe_unlock_and_close,
@@ -289,23 +290,28 @@ class NonCachingFileStore(AbstractFileStore):
                         raise
                     # Otherwise, we lost the race. Someone else is alive and
                     # has it locked. So loop around again.
-                else:
-                    # We got it
-                    logger.warning(
-                        "Detected that job (%s) prematurely terminated.  Fixing the "
-                        "state of the job on disk.",
-                        jobState["jobName"],
-                    )
+                    continue
 
-                    try:
-                        if not batchSystemShutdown:
-                            logger.debug("Deleting the stale working directory.")
-                            # Delete the old work directory if it still exists.  Do this only during
-                            # the life of the program and dont' do it during the batch system
-                            # cleanup. Leave that to the batch system cleanup code.
-                            robust_rmtree(jobState["jobDir"])
-                    finally:
-                        safe_unlock_and_close(dirFD)
+                if not locked_file_is(dirFD, jobState["jobDir"]):
+                    # We locked something other than what's on disk right now.
+                    continue
+
+                # Otherwise, we got it
+                logger.warning(
+                    "Detected that job (%s) prematurely terminated.  Fixing the "
+                    "state of the job on disk.",
+                    jobState["jobName"],
+                )
+
+                try:
+                    if not batchSystemShutdown:
+                        logger.debug("Deleting the stale working directory.")
+                        # Delete the old work directory if it still exists.  Do this only during
+                        # the life of the program and dont' do it during the batch system
+                        # cleanup. Leave that to the batch system cleanup code.
+                        robust_rmtree(jobState["jobDir"])
+                finally:
+                    safe_unlock_and_close(dirFD)
 
     @classmethod
     def _getAllJobStates(cls, coordination_dir: str) -> Iterator[dict[str, str]]:

--- a/src/toil/lib/threading.py
+++ b/src/toil/lib/threading.py
@@ -640,7 +640,7 @@ def global_mutex(base_dir: StrPath, mutex: str) -> Iterator[None]:
                 break
             else:
                 # The file we have a lock on is not the file linked to the name
-                # (if any). This usually happens, because before someone
+                # (if any). This usually happens because before someone
                 # releases a lock, they delete the file. Go back and contend
                 # again. TODO: This allows a lot of queue jumping on our mutex.
                 safe_unlock_and_close(fd)

--- a/src/toil/lib/threading.py
+++ b/src/toil/lib/threading.py
@@ -120,6 +120,10 @@ def safe_lock(fd: int, block: bool = True, shared: bool = False) -> None:
     """
     Get an fcntl lock, while retrying on IO errors.
 
+    If the file might be removed or replaced, make sure to use
+    :meth:`locked_file_is` to be sure the thing you locked is still at that
+    path once you've locked it.
+
     Raises OSError with EACCES or EAGAIN when a nonblocking lock is not
     immediately available.
     """
@@ -172,6 +176,49 @@ def safe_lock(fd: int, block: bool = True, shared: bool = False) -> None:
             else:
                 raise
 
+def locked_file_is(fd: int, path: str) -> bool:
+    """
+    Return True if the open file fd is on disk at the given path.
+
+    After locking a file that might get removed, renamed, or replaced, you
+    should check this while holding the lock, to make sure no two people can
+    both think they have the lock when really one has locked an unlinked file.
+
+    The file fd should be locked with :meth:`safe_lock`, or else the returned
+    answer might not be true anymore by the time the function returns.
+    """
+
+    try:
+        # Get the stats from the open file
+        fd_stats = os.fstat(fd)
+    except OSError as e:
+        if e.errno == errno.ESTALE:
+            # The file handle has gone stale, because somebody removed the
+            # file.
+            # So we aren't locking this file on disk right now.
+            return False
+        else:
+            # Something else broke
+            raise
+
+    try:
+        # And get the stats for the name in the directory
+        path_stats: os.stat_result | None = os.stat(path)
+    except FileNotFoundError:
+        path_stats = None
+
+    if (
+        path_stats is None
+        or fd_stats.st_dev != path_stats.st_dev
+        or fd_stats.st_ino != path_stats.st_ino
+    ):
+        # The file we have a lock on is not the file linked to the name (if
+        # any).
+        return False
+    else:
+        # We have a lock on the file that the name points to.
+        return True
+
 
 def safe_unlock_and_close(fd: int) -> None:
     """
@@ -181,11 +228,12 @@ def safe_unlock_and_close(fd: int) -> None:
         fcntl.flock(fd, fcntl.LOCK_UN)
     except OSError as e:
         if e.errno in (errno.EIO, errno.ENOLCK):
-            # We don't need to retry then because we're going to close the FD 
+            # We don't need to retry then because we're going to close the FD
             # and after that the file can't remain locked by us.
+            logger.debug("Observed errno %s when unlocking", e.errno)
             pass
         else:
-            raise  
+            raise
     os.close(fd)
 
 
@@ -457,6 +505,11 @@ def get_process_name(base_dir: str) -> str:
             else:
                 # Something else is wrong
                 raise
+        if not locked_file_is(nameFD, nameFileName):
+            # Someone deleted our name file
+            raise RuntimeError(
+                    f"Someone deleted our process name file at {nameFileName}"
+            )
 
         # Save the basename
         current_process_name_for[base_dir] = os.path.basename(nameFileName)
@@ -514,11 +567,14 @@ def process_name_exists(base_dir: str, name: str) -> bool:
                 raise
         else:
             # Could lock. Process is dead.
-            # Remove the file. We race to be the first to do so.
-            try:
-                os.remove(nameFileName)
-            except:
-                pass
+            if locked_file_is(nameFD, nameFileName):
+                # Remove the file.
+                try:
+                    os.remove(nameFileName)
+                except:
+                    # If someone broke the lock, ignore it. We just want the
+                    # file gone.
+                    pass
             safe_unlock_and_close(nameFD)
             nameFD = None
             # Report process death
@@ -574,49 +630,25 @@ def global_mutex(base_dir: StrPath, mutex: str) -> Iterator[None]:
         try:
             # Wait until we can exclusively lock it, handling error retry.
             safe_lock(fd)
+
+            # Holding the lock, make sure we are looking at the same file on
+            # disk still.
+            if locked_file_is(fd, lock_filename):
+                # We have a lock on the file that the name points to. Since we
+                # hold the lock, nobody will be deleting it or can be in the
+                # process of deleting it. Stop contending; we have the mutex.
+                break
+            else:
+                # The file we have a lock on is not the file linked to the name
+                # (if any). This usually happens, because before someone
+                # releases a lock, they delete the file. Go back and contend
+                # again. TODO: This allows a lot of queue jumping on our mutex.
+                safe_unlock_and_close(fd)
+                continue
         except:
             # Something went wrong
             os.close(fd)
             raise
-
-        # Holding the lock, make sure we are looking at the same file on disk still.
-        try:
-            # So get the stats from the open file
-            fd_stats = os.fstat(fd)
-        except OSError as e:
-            if e.errno == errno.ESTALE:
-                # The file handle has gone stale, because somebody removed the
-                # file.
-                # Try again.
-                safe_unlock_and_close(fd)
-                continue
-            else:
-                # Something else broke
-                os.close(fd)
-                raise
-
-        try:
-            # And get the stats for the name in the directory
-            path_stats: os.stat_result | None = os.stat(lock_filename)
-        except FileNotFoundError:
-            path_stats = None
-
-        if (
-            path_stats is None
-            or fd_stats.st_dev != path_stats.st_dev
-            or fd_stats.st_ino != path_stats.st_ino
-        ):
-            # The file we have a lock on is not the file linked to the name (if
-            # any). This usually happens, because before someone releases a
-            # lock, they delete the file. Go back and contend again. TODO: This
-            # allows a lot of queue jumping on our mutex.
-            safe_unlock_and_close(fd)
-            continue
-        else:
-            # We have a lock on the file that the name points to. Since we
-            # hold the lock, nobody will be deleting it or can be in the
-            # process of deleting it. Stop contending; we have the mutex.
-            break
 
     try:
         # When we have it, do the thing we are protecting.
@@ -670,8 +702,8 @@ def global_mutex(base_dir: StrPath, mutex: str) -> Iterator[None]:
 
         # Note that we are unlinking it and then unlocking it; a lot of people
         # might have opened it before we unlinked it and will wake up when they
-        # get the worthless lock on the now-unlinked file. We have to do some
-        # stat gymnastics above to work around this.
+        # get the worthless lock on the now-unlinked file. We use
+        # locked_file_is() above to get around this.
         safe_unlock_and_close(fd)
 
 
@@ -815,6 +847,12 @@ class LastProcessStandingArena:
                         # Something else is wrong
                         os.close(fd)
                         raise
+
+                if not locked_file_is(fd, full_path):
+                    # We locked a removed file. Whoever was here just left.
+                    safe_unlock_and_close(fd)
+                    continue
+
                 else:
                     # Could lock. Process is dead.
                     try:

--- a/src/toil/lib/threading.py
+++ b/src/toil/lib/threading.py
@@ -668,34 +668,27 @@ def global_mutex(base_dir: StrPath, mutex: str) -> Iterator[None]:
         # complain loudly if something is tampering with our locks or not
         # really enforcing locks on the filesystem, so we will notice if it is
         # the cause of further problems.
-        try:
-            path_stats = os.stat(lock_filename)
-        except FileNotFoundError:
-            path_stats = None
-
-        # Check to make sure it still looks locked before we unlink.
-        if path_stats is None:
-            logger.error(
-                "PID %d had mutex %s disappear while locked! Mutex system is not working!",
-                os.getpid(),
-                lock_filename,
-            )
-        elif (
-            fd_stats.st_dev != path_stats.st_dev or fd_stats.st_ino != path_stats.st_ino
-        ):
-            logger.error(
-                "PID %d had mutex %s get replaced while locked! Mutex system is not working!",
-                os.getpid(),
-                lock_filename,
-            )
-
-        if path_stats is not None:
+        if not locked_file_is(fd, lock_filename):
+            if not os.path.exists(lock_filename):
+                logger.error(
+                    "PID %d had mutex %s disappear while locked! Mutex system is not working!",
+                    os.getpid(),
+                    lock_filename,
+                )
+            else: 
+                logger.error(
+                    "PID %d had mutex %s get replaced while locked! Mutex system is not working!",
+                    os.getpid(),
+                    lock_filename,
+                )
+        else:
+            # File we have is the one there
             try:
                 # Unlink the file
                 os.unlink(lock_filename)
             except FileNotFoundError:
                 logger.error(
-                    "PID %d had mutex %s disappear between stat and unlink while unlocking! Mutex system is not working!",
+                    "PID %d had mutex %s disappear between poll and unlink while unlocking! Mutex system is not working!",
                     os.getpid(),
                     lock_filename,
                 )

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -434,7 +434,7 @@ class hidden:
             job: Job,
             isLocalFile: bool,
             nonLocalDir: str | None = None,
-            fileMB: int = 1, 
+            fileMB: int = 1,
             hints: list[str] | None = None,
         ):
             """
@@ -447,7 +447,7 @@ class hidden:
             :param nonLocalDir: A dir to write the file to.  If unspecified, a local directory
                                     is created.
             :param fileMB: Size of the created file in MB
-            :param hints: Hints to tell the file store when writing the file 
+            :param hints: Hints to tell the file store when writing the file
             """
             if isLocalFile:
                 work_dir = job.fileStore.getLocalTempDir()
@@ -671,7 +671,7 @@ class hidden:
             job: Job,
             isLocalFile: bool,
             nonLocalDir: str | None =None,
-            fileMB: int = 1, 
+            fileMB: int = 1,
             hints: list[str] | None = None,
             expectAsyncUpload: bool = True,
         ):


### PR DESCRIPTION
This adds code for dumping information about the cache database state if #5084 happens.

I tried to trigger it somehow by running the caching filestore tests locally, and I found a *different* bug, which is a race in a bunch of places we use `safe_lock()`, because `safe_lock()` makes no guarantees that the file you locked is still the one at the path you opened. We already handled this in the mutex implementation, but we didn't handle this in other places where the file might be going away or being replaced.

So this fixes *that* problem. I still haven't been able to actually trigger #5084 on my machine though.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Fix lock-vs-unlink race in `safe_lock()`
 * Log more about cache database state if files appear to be missing

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

