### PR TITLE
Revert "Pin back binfmt"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ before_script:
   # where buildx can't use a bearer token from a kube config and falls back to anonymous instead
   # of using the system's service account.
   - if [[ "${CI_BUILDKIT_DRIVER}" == "kubernetes" ]] ; then KUBECONFIG=/dev/null docker buildx create --use --name=buildkit --platform=linux/amd64,linux/arm64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64" ; else cat buildkitd.toml ; docker buildx create --use --name=container-builder --driver=docker-container --config ./buildkitd.toml ; fi
-  - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt:qemu-v8.0.4-33 --install all || true; fi
+  - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1-65 --install all || true; fi
   # Report on the builders, and make sure they exist.
   - docker buildx inspect --bootstrap || (echo "Docker builder deployment can't be found! Are we on the right Gitlab runner?" && exit 1)
   # This will hang if we can't talk to the builder


### PR DESCRIPTION
Reverts DataBiosphere/toil#5536

We're going back to the newer version for vg, and since CI hosts are now shared between jobs and this is scoped to the host, we need to match vg's version.

We probably should kick this out of the project altogether and just make the CI runners responsible for it.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

* Toil no longer uses the old version of the multi-arch support container because it causes compiler crashes for other projects on our CI (#5540)