### PR TITLE
Fix per-job log option name in docs

### DIFF
--- a/docs/cwl/running.rst
+++ b/docs/cwl/running.rst
@@ -187,7 +187,7 @@ See :ref:`cli_stats` for an explanation of what the different fields mean.
 
 **Understanding toil log files**
 
-There is a `worker_log.txt` file for each Toil job. This file is written to while the job is running, and uploaded at the end if the job finishes or if running at debug log level. If uploaded, the contents are printed to the main log file and transferred to a log file in the `--logDir` folder.
+There is a worker log for each Toil job. This log is written to a file on the node while the job is running, and uploaded to the job store at the end if the job fails or if running at debug log level. If uploaded, the contents are later printed to the main log file by the leader, and also transferred to a per-job log file in the ``--writeLogs`` directory, if used.
 
 The new log file will be named something like:
 ::


### PR DESCRIPTION
This should fix #5538 by using the right, somewhat unintuitive Toil option name for the directory where the per-job logs go.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Toil docs for running CWL workflows now properly talk about `--writeLogs` and not `--logDir`.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

