### PR TITLE
Make PID status test deterministic (resolves #5232)

### DIFF
--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -48,6 +48,12 @@ from toil.version import python
 logger = logging.getLogger(__name__)
 
 
+def wait_for_file(file_path: str) -> None:
+    """Wait until a file exists."""
+    while not os.path.exists(file_path):
+        time.sleep(0.1)
+
+
 @pytest.fixture(scope="function")
 def unsortedFile(tmp_path: Path) -> Generator[Path]:
     try:
@@ -390,19 +396,26 @@ class TestUtils:
                     current_status == status
                 ), "Waited {seconds} seconds without status reaching {status}; stuck at {current_status}"
 
-    def testGetPIDStatus(self, tmp_path: Path, unsortedFile: Path) -> None:
+    def testGetPIDStatus(self, tmp_path: Path) -> None:
         """Test that ToilStatus.getPIDStatus() behaves as expected."""
         jobstore = tmp_path / "jobstore"
-        outputFile = tmp_path / "someSortedStuff.txt"
+        release_file = tmp_path / "release-workflow"
+        workflow = """
+from toil.job import Job
+from toil.test.utils.utilsTest import wait_for_file
+import sys
+
+options = Job.Runner.getDefaultOptions(sys.argv[1])
+options.clean = "never"
+Job.Runner.startToil(Job.wrapFn(wait_for_file, sys.argv[2]), options)
+"""
         wf = subprocess.Popen(
             [
                 python,
-                "-m",
-                "toil.test.sort.sort",
-                jobstore.as_uri(),
-                f"--fileToSort={unsortedFile}",
-                f"--outputFile={outputFile}",
-                "--clean=never",
+                "-c",
+                workflow,
+                str(jobstore),
+                str(release_file),
             ]
         )
         self.check_status(
@@ -412,6 +425,7 @@ class TestUtils:
             process=wf,
             seconds=60,
         )
+        release_file.touch()
         wf.wait()
         self.check_status(
             jobstore,

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -406,12 +406,16 @@ class TestUtils:
         """Test that ToilStatus.getPIDStatus() behaves as expected."""
         jobstore = tmp_path / "jobstore"
         release_file = tmp_path / "release-workflow"
+        # Get the name of the module.
+        # The loader exists despite MyPy's protests; see
+        # <https://github.com/python/mypy/issues/4182>
+        module_name = __loader__.fullname # type: ignore
         # Run wait_for_file_workflow() as a child process.
         wf = subprocess.Popen(
             [
                 python,
                 "-c",
-                f"from {__loader__.fullname} import "
+                f"from {module_name} import "
                 f"wait_for_file_workflow as w; w()",
                 str(jobstore),
                 str(release_file),

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -53,6 +53,12 @@ def wait_for_file(file_path: str) -> None:
     while not os.path.exists(file_path):
         time.sleep(0.1)
 
+def wait_for_file_workflow() -> None:
+    """Toil workflow that waits for the file in argument 2 to exist."""
+    options = Job.Runner.getDefaultOptions(sys.argv[1])
+    options.clean = "never"
+    Job.Runner.startToil(Job.wrapFn(wait_for_file, sys.argv[2]), options)
+
 
 @pytest.fixture(scope="function")
 def unsortedFile(tmp_path: Path) -> Generator[Path]:
@@ -400,24 +406,18 @@ class TestUtils:
         """Test that ToilStatus.getPIDStatus() behaves as expected."""
         jobstore = tmp_path / "jobstore"
         release_file = tmp_path / "release-workflow"
-        workflow = """
-from toil.job import Job
-from toil.test.utils.utilsTest import wait_for_file
-import sys
-
-options = Job.Runner.getDefaultOptions(sys.argv[1])
-options.clean = "never"
-Job.Runner.startToil(Job.wrapFn(wait_for_file, sys.argv[2]), options)
-"""
+        # Run wait_for_file_workflow() as a child process.
         wf = subprocess.Popen(
             [
                 python,
                 "-c",
-                workflow,
+                f"from {__loader__.fullname} import "
+                f"wait_for_file_workflow as w; w()",
                 str(jobstore),
                 str(release_file),
             ]
         )
+        # Check the status by PID
         self.check_status(
             jobstore,
             "RUNNING",

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -406,16 +406,13 @@ class TestUtils:
         """Test that ToilStatus.getPIDStatus() behaves as expected."""
         jobstore = tmp_path / "jobstore"
         release_file = tmp_path / "release-workflow"
-        # Get the name of the module.
-        # The loader exists despite MyPy's protests; see
-        # <https://github.com/python/mypy/issues/4182>
-        module_name = __loader__.fullname # type: ignore
+        assert __name__ != "__main__"
         # Run wait_for_file_workflow() as a child process.
         wf = subprocess.Popen(
             [
                 python,
                 "-c",
-                f"from {module_name} import "
+                f"from {__name__} import "
                 f"wait_for_file_workflow as w; w()",
                 str(jobstore),
                 str(release_file),


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

* Make the PID status test wait on a controlled workflow instead of racing a short sort workflow. (#5232)

## Summary

I changed `testGetPIDStatus` to launch a workflow that waits for an explicit release file. This keeps the leader process alive until the test has observed the `RUNNING` state, then lets the workflow finish so the existing `COMPLETED` and missing-PID checks still run.

This removes the timing dependency on the small sort workflow finishing before an overloaded CI runner polls its status.

## Validation

- `python -m pytest src/toil/test/utils/utilsTest.py::TestUtils::testGetPIDStatus -q` (20 consecutive runs, plus a post-commit run)
- `python -m pytest src/toil/test/utils/utilsTest.py -q` (8 passed, 4 dependency/integration skips)
- Black check on the changed file
- Isort check on the changed file
- Repository-configured Flake8 check on the changed file
- `git diff --check`

The complete repository test suite is deferred to CI.

Fixes #5232
