### PR TITLE
docs: give the WDL quickstart example a version and test it

### DIFF
--- a/docs/gettingStarted/quickStart.rst
+++ b/docs/gettingStarted/quickStart.rst
@@ -91,22 +91,13 @@ Running WDL workflows using Toil is still in alpha, and currently experimental. 
 
    This installs the ``toil-wdl-runner`` executable.
 
-#. Copy and paste the following code block into ``wdl-helloworld.wdl``::
+#. Copy and paste the following code block into ``wdl-helloworld.wdl``:
 
-        workflow write_simple_file {
-          call write_file
-        }
-        task write_file {
-          String message
-          command { echo ${message} > wdl-helloworld-output.txt }
-          output { File test = "wdl-helloworld-output.txt" }
-        }
+   .. literalinclude:: ../../src/toil/test/docs/scripts/wdl-helloworld.wdl
 
-   and this code into ``wdl-helloworld.json``::
+   and this code into ``wdl-helloworld.json``:
 
-        {
-          "write_simple_file.write_file.message": "Hello world!"
-        }
+   .. literalinclude:: ../../src/toil/test/docs/scripts/wdl-helloworld.json
 
 #. To run the workflow simply enter ::
 

--- a/src/toil/test/docs/scripts/wdl-helloworld.json
+++ b/src/toil/test/docs/scripts/wdl-helloworld.json
@@ -1,0 +1,3 @@
+{
+  "write_simple_file.message": "Hello world!"
+}

--- a/src/toil/test/docs/scripts/wdl-helloworld.wdl
+++ b/src/toil/test/docs/scripts/wdl-helloworld.wdl
@@ -1,0 +1,16 @@
+version 1.0
+
+workflow write_simple_file {
+  input {
+    String message
+  }
+  call write_file { input: message = message }
+}
+
+task write_file {
+  input {
+    String message
+  }
+  command { echo ~{message} > wdl-helloworld-output.txt }
+  output { File test = "wdl-helloworld-output.txt" }
+}

--- a/src/toil/test/wdl/wdltoil_test.py
+++ b/src/toil/test/wdl/wdltoil_test.py
@@ -389,6 +389,30 @@ class TestWDL:
                 assert os.path.exists(result["ga4ghMd5.value"])
                 assert os.path.basename(result["ga4ghMd5.value"]) == "md5sum.txt"
 
+    @needs_singularity_or_docker
+    def test_documentation_quickstart(self, tmp_path: Path) -> None:
+        """Test the WDL quickstart example from the documentation."""
+        with get_data("test/docs/scripts/wdl-helloworld.wdl") as wdl:
+            with get_data("test/docs/scripts/wdl-helloworld.json") as json_file:
+                result_json = subprocess.check_output(
+                    self.base_command
+                    + [
+                        str(wdl),
+                        str(json_file),
+                        "-o",
+                        str(tmp_path),
+                        "--logDebug",
+                        "--retryCount=0",
+                    ]
+                )
+                result = json.loads(result_json)
+
+                assert "write_simple_file.write_file.test" in result
+                output_path = result["write_simple_file.write_file.test"]
+                assert os.path.exists(output_path)
+                with open(output_path) as f:
+                    assert f.read().strip() == "Hello world!"
+
     @needs_singularity
     def test_sif_image(self, tmp_path: Path) -> None:
         """Test if Toil can run a SIF image as a container"""


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * The WDL quickstart example now specifies a WDL version and is covered by a test.

## Description

Fixes #5534.

The WDL in the quickstart has no `version`, so it is parsed as draft-2 and `toil-wdl-runner` fails on it:

```
(Ln 1, Col 1) MissingVersion, document should declare WDL version; draft-2 assumed
WDL.Error.EvalError: Cannot evaluate no expression for message
```

The inputs JSON also addresses the task input directly (`write_simple_file.write_file.message`), which does not bind.

This ports the example to WDL 1.0 (`input` sections, `~{}` placeholder, the call passing `message` through), so the inputs file uses `write_simple_file.message`.

To keep the docs and a tested file from drifting apart, the example now lives in `src/toil/test/docs/scripts/` next to the other documentation examples and is pulled into `quickStart.rst` with `literalinclude`. `MANIFEST.in` already ships that directory. `test_documentation_quickstart` in `wdltoil_test.py` runs it the same way `test_MD5sum` runs its workflow.

Verified locally on an Apple Silicon macOS host with Docker:

```
$ toil-wdl-runner wdl-helloworld.wdl wdl-helloworld.json -o out --logDebug --retryCount=0
Workflow stopped. Success: True
{"write_simple_file.write_file.test": ".../out/write_simple_file.write_file/wdl-helloworld-output.txt"}
$ cat out/write_simple_file.write_file/wdl-helloworld-output.txt
Hello world!

$ pytest src/toil/test/wdl/wdltoil_test.py -k test_documentation_quickstart -x -q
1 passed, 35 deselected
```

I left `make format` alone: `black --check` already reports `wdltoil_test.py` as unformatted on unmodified `master` here, so running it would bury this change in unrelated reformatting.
