### PR TITLE
Evaluate CWL `when` conditionals before scheduling to avoid wasted batch-system submissions (#3990)

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -403,9 +403,9 @@ class Conditional:
         self.requirements = requirements or []
         self.container_engine = container_engine
 
-    def is_conditional(self) -> bool:
-        """Whether this has an expression to evaluate."""
-        return self.expression is not None
+    def is_empty(self) -> bool:
+        """Whether this is an empty Conditional."""
+        return self.expression is None
 
     def is_false(self, job: CWLObjectType) -> bool:
         """
@@ -3523,7 +3523,7 @@ def makeJob(
                         has_dynamic_resource_requirement = True
 
         if has_dynamic_resource_requirement or (
-            conditional is not None and conditional.is_conditional()
+            conditional is not None and not conditional.is_empty()
         ):
             # Resource requirements and the `when` conditional can depend on
             # promises from upstream steps that only resolve once the job

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -403,6 +403,10 @@ class Conditional:
         self.requirements = requirements or []
         self.container_engine = container_engine
 
+    def is_conditional(self) -> bool:
+        """Whether this has an expression to evaluate."""
+        return self.expression is not None
+
     def is_false(self, job: CWLObjectType) -> bool:
         """
         Determine if expression evaluates to False given completed step inputs.
@@ -2951,11 +2955,9 @@ class CWLJob(CWLNamedJob):
         cwljob: CWLObjectType,
         runtime_context: cwltool.context.RuntimeContext,
         parent_name: str | None = None,
-        conditional: Conditional | None = None,
     ):
         """Store the context for later execution."""
         self.cwltool = tool
-        self.conditional = conditional or Conditional()
 
         if runtime_context.builder:
             self.builder = runtime_context.builder
@@ -3159,9 +3161,6 @@ class CWLJob(CWLNamedJob):
 
         # Deletes duplicate listings
         remove_redundant_mounts(cwljob)
-
-        if self.conditional.is_false(cwljob):
-            return self.conditional.skipped_outputs()
 
         fill_in_defaults(
             self.step_inputs, cwljob, self.runtime_context.make_fs_access("")
@@ -3524,7 +3523,7 @@ def makeJob(
                         has_dynamic_resource_requirement = True
 
         if has_dynamic_resource_requirement or (
-            conditional is not None and conditional.expression is not None
+            conditional is not None and conditional.is_conditional()
         ):
             # Resource requirements and the `when` conditional can depend on
             # promises from upstream steps that only resolve once the job
@@ -3544,7 +3543,6 @@ def makeJob(
             jobobj,
             runtime_context,
             parent_name=parent_name,
-            conditional=conditional,
         )
         return job, job
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -2890,13 +2890,11 @@ class ResolveIndirect(CWLNamedJob):
 
 class CWLJobWrapper(CWLNamedJob):
     """
-    Wrap a CWL job that uses a dynamic resources requirement, or that may be
-    skipped by a `when` conditional that can't be safely evaluated until the
-    step's inputs are resolved.
+    Determines how and whether to run the wrapped CWL job.
 
-    When executed, this runs on the leader with minimal resources, resolves
-    the job's inputs, and then either reports the step as skipped or creates
-    a new child job which has the correct resource requirement set.
+    Wraps a CWL job that uses a dynamic resource requirement or has a
+    conditional. This job is responsible for creating a CWLJob child with
+    the right resource requirements, when the job should not be skipped.
     """
 
     def __init__(

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -2890,10 +2890,13 @@ class ResolveIndirect(CWLNamedJob):
 
 class CWLJobWrapper(CWLNamedJob):
     """
-    Wrap a CWL job that uses dynamic resources requirement.
+    Wrap a CWL job that uses a dynamic resources requirement, or that may be
+    skipped by a `when` conditional that can't be safely evaluated until the
+    step's inputs are resolved.
 
-    When executed, this creates a new child job which has the correct resource
-    requirement set.
+    When executed, this runs on the leader with minimal resources, resolves
+    the job's inputs, and then either reports the step as skipped or creates
+    a new child job which has the correct resource requirement set.
     """
 
     def __init__(
@@ -2921,7 +2924,7 @@ class CWLJobWrapper(CWLNamedJob):
         """Create a child job with the correct resource requirements set."""
         cwljob = resolve_dict_w_promises(self.cwljob, file_store)
 
-        # Check confitional to license full evaluation of job inputs.
+        # Check conditional to license full evaluation of job inputs.
         if self.conditional.is_false(cwljob):
             return self.conditional.skipped_outputs()
 
@@ -3507,11 +3510,12 @@ def makeJob(
         wfjob.addFollowOn(followOn)
         return wfjob, followOn
     else:
-        # Decied if we have any requirements we care about that are dynamic
+        # Decide if we have any requirements we care about that are dynamic
         REQUIREMENT_TYPES = [
             "ResourceRequirement",
             "http://commonwl.org/cwltool#CUDARequirement",
         ]
+        has_dynamic_resource_requirement = False
         for requirement_type in REQUIREMENT_TYPES:
             req, _ = tool.get_requirement(requirement_type)
             if req:
@@ -3519,17 +3523,24 @@ def makeJob(
                     if isinstance(r, str) and ("$(" in r or "${" in r):
                         # One of the keys in this requirement has a text substitution in it.
                         # TODO: This is not a real lex!
+                        has_dynamic_resource_requirement = True
 
-                        # Found a dynamic resource requirement so use a job wrapper
-                        job_wrapper = CWLJobWrapper(
-                            cast(ToilCommandLineTool, tool),
-                            jobobj,
-                            runtime_context,
-                            parent_name=parent_name,
-                            conditional=conditional,
-                        )
-                        return job_wrapper, job_wrapper
-        # Otherwise, all requirements are known now.
+        if has_dynamic_resource_requirement or (
+            conditional is not None and conditional.expression is not None
+        ):
+            # Resource requirements and the `when` conditional can depend on
+            # promises from upstream steps that only resolve once the job
+            # runs, so check them in a cheap local wrapper first.
+            job_wrapper = CWLJobWrapper(
+                cast(ToilCommandLineTool, tool),
+                jobobj,
+                runtime_context,
+                parent_name=parent_name,
+                conditional=conditional,
+            )
+            return job_wrapper, job_wrapper
+        # Otherwise, all requirements are known now, and the step is
+        # unconditional, so it can be scheduled directly.
         job = CWLJob(
             tool,
             jobobj,

--- a/src/toil/test/cwl/conditional_step_depends_on_step.cwl
+++ b/src/toil/test/cwl/conditional_step_depends_on_step.cwl
@@ -6,12 +6,12 @@ class: Workflow
 requirements:
   InlineJavascriptRequirement: {}
 inputs:
-  sleep: int
+  number: int
 outputs: []
 steps:
   produce:
     in:
-      sleep: sleep
+      number: number
     out: [result]
     run:
       cwlVersion: v1.2
@@ -19,10 +19,10 @@ steps:
       requirements:
         InlineJavascriptRequirement: {}
       inputs:
-        sleep: int
+        number: int
       outputs:
         result: int
-      expression: "$({'result': inputs.sleep})"
+      expression: "$({'result': inputs.number})"
   consume:
     in:
       result: produce/result

--- a/src/toil/test/cwl/conditional_step_depends_on_step.cwl
+++ b/src/toil/test/cwl/conditional_step_depends_on_step.cwl
@@ -1,0 +1,37 @@
+# `consume`'s `when` references `produce`'s output, so the condition can only
+# be evaluated once that output's promise has resolved.
+# See <https://github.com/DataBiosphere/toil/issues/3990>.
+cwlVersion: v1.2
+class: Workflow
+requirements:
+  InlineJavascriptRequirement: {}
+inputs:
+  sleep: int
+outputs: []
+steps:
+  produce:
+    in:
+      sleep: sleep
+    out: [result]
+    run:
+      cwlVersion: v1.2
+      class: ExpressionTool
+      requirements:
+        InlineJavascriptRequirement: {}
+      inputs:
+        sleep: int
+      outputs:
+        result: int
+      expression: "$({'result': inputs.sleep})"
+  consume:
+    in:
+      result: produce/result
+    when: $(inputs.result > 1)
+    run:
+      cwlVersion: v1.2
+      class: CommandLineTool
+      inputs:
+        result: int
+      baseCommand: "true"
+      outputs: []
+    out: []

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -2083,6 +2083,83 @@ def test_pick_value_with_one_null_value(
 @needs_cwl
 @pytest.mark.cwl
 @pytest.mark.cwl_small
+def test_skipped_step_runs_locally(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """
+    A step skipped by its `when` condition must only run the CWLJobWrapper not the CWLJob. See: #3990.
+    """
+    from toil.cwl import cwltoil
+
+    with get_data("test/cwl/conditional_wf.cwl") as cwl_file:
+        with get_data("test/cwl/conditional_wf.yaml") as job_file:
+            with caplog.at_level(logging.DEBUG, logger="toil.leader"):
+                cwltoil.main(
+                    ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), str(job_file), "--disableChaining=True"]
+                )
+                assert any(
+                    "Finished toil run successfully" in record.getMessage()
+                    for record in caplog.records
+                ), "Toil run didn't finish"
+                assert any(
+                        "Issued job 'CWLJobWrapper'" in record.getMessage()
+                        for record in caplog.records
+                ), "'CWLJobWrapper' not issued"
+                assert not any(
+                        "Issued job 'CWLJob'" in record.getMessage()
+                        for record in caplog.records
+                ), "'CWLJob' issued"
+
+
+@needs_cwl
+@pytest.mark.cwl
+@pytest.mark.cwl_small
+def test_when_depends_on_step_output(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """
+    A step's `when` can reference an upstream step's output, still an
+    unresolved promise at job-construction time. See: #3990.
+    """
+    from toil.cwl import cwltoil
+
+    with get_data("test/cwl/conditional_step_depends_on_step.cwl") as cwl_file:
+        with caplog.at_level(logging.DEBUG, logger="toil.leader"):
+            cwltoil.main(
+                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "10"]
+            )
+            assert any(
+                # Look for return values instead of a message
+                "Finished toil run successfully" in record.getMessage()
+                for record in caplog.records
+            )
+            """
+            for record in caplog.records:
+                if (
+                    record.name == "toil.leader"
+                    and "Issued job" in record.getMessage()
+                    and "consume" in record.getMessage()
+                ):
+                    assert record.levelno == logging.DEBUG
+
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="toil.leader"):
+            cwltoil.main(
+                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "2"]
+            )
+            issuances = [
+                record
+                for record in caplog.records
+                if record.name == "toil.leader"
+                and "Issued job" in record.getMessage()
+                and "consume" in record.getMessage()
+            ]
+            assert any(record.levelno == logging.INFO for record in issuances)"""
+
+
+@needs_cwl
+@pytest.mark.cwl
+@pytest.mark.cwl_small
 def test_workflow_echo_string(tmp_path: Path) -> None:
     with get_data("test/cwl/echo_string.cwl") as cwl_file:
         cmd = [

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -2128,7 +2128,7 @@ def test_when_on_step_output_scheduled(
         # CWLJobWrapper should run.
         with caplog.at_level(logging.DEBUG, logger="toil.leader"):
             cwltoil.main(
-                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "1", "--disableChaining=True"]
+                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--number", "1", "--disableChaining=True"]
             )
             assert any(
                 "Finished toil run successfully" in record.getMessage()
@@ -2150,7 +2150,7 @@ def test_when_on_step_output_scheduled(
         # produce/result (2) is > 1: consume should actually run.
         with caplog.at_level(logging.DEBUG, logger="toil.leader"):
             cwltoil.main(
-                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "2", "--disableChaining=True"]
+                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--number", "2", "--disableChaining=True"]
             )
             assert any(
                 "Finished toil run successfully" in record.getMessage()

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -2083,7 +2083,7 @@ def test_pick_value_with_one_null_value(
 @needs_cwl
 @pytest.mark.cwl
 @pytest.mark.cwl_small
-def test_skipped_step_runs_locally(
+def test_when_false_not_scheduled(
     caplog: pytest.LogCaptureFixture, tmp_path: Path
 ) -> None:
     """
@@ -2114,47 +2114,53 @@ def test_skipped_step_runs_locally(
 @needs_cwl
 @pytest.mark.cwl
 @pytest.mark.cwl_small
-def test_when_depends_on_step_output(
+def test_when_on_step_output_scheduled(
     caplog: pytest.LogCaptureFixture, tmp_path: Path
 ) -> None:
     """
-    A step's `when` can reference an upstream step's output, still an
-    unresolved promise at job-construction time. See: #3990.
+    A step whose `when` references an upstream step's output must still only
+    run the CWLJobWrapper when skipped, and the CWLJob when not. See: #3990.
     """
     from toil.cwl import cwltoil
 
     with get_data("test/cwl/conditional_step_depends_on_step.cwl") as cwl_file:
+        # produce/result (1) is not > 1: consume is skipped and only its
+        # CWLJobWrapper should run.
         with caplog.at_level(logging.DEBUG, logger="toil.leader"):
             cwltoil.main(
-                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "10"]
+                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "1", "--disableChaining=True"]
             )
             assert any(
-                # Look for return values instead of a message
                 "Finished toil run successfully" in record.getMessage()
                 for record in caplog.records
-            )
-            """
-            for record in caplog.records:
-                if (
-                    record.name == "toil.leader"
-                    and "Issued job" in record.getMessage()
-                    and "consume" in record.getMessage()
-                ):
-                    assert record.levelno == logging.DEBUG
+            ), "Toil run didn't finish"
+            assert any(
+                "Issued job 'CWLJobWrapper'" in record.getMessage()
+                and "consume" in record.getMessage()
+                for record in caplog.records
+            ), "consume's 'CWLJobWrapper' not issued"
+            assert not any(
+                "Issued job 'CWLJob'" in record.getMessage()
+                and "consume" in record.getMessage()
+                for record in caplog.records
+            ), "consume's real 'CWLJob' issued despite being skipped"
 
         caplog.clear()
+
+        # produce/result (2) is > 1: consume should actually run.
         with caplog.at_level(logging.DEBUG, logger="toil.leader"):
             cwltoil.main(
-                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "2"]
+                ["--logDebug", f"--outdir={tmp_path}", str(cwl_file), "--sleep", "2", "--disableChaining=True"]
             )
-            issuances = [
-                record
+            assert any(
+                "Finished toil run successfully" in record.getMessage()
                 for record in caplog.records
-                if record.name == "toil.leader"
-                and "Issued job" in record.getMessage()
+            ), "Toil run didn't finish"
+            assert any(
+                "Issued job 'CWLJob'" in record.getMessage()
                 and "consume" in record.getMessage()
-            ]
-            assert any(record.levelno == logging.INFO for record in issuances)"""
+                for record in caplog.records
+            ), "consume's real 'CWLJob' not issued"
 
 
 @needs_cwl


### PR DESCRIPTION
Steps with a `when` conditional were always scheduled onto the real batch system as a fully-resourced job, even when the condition evaluated false and the step would be skipped. On a busy HPC system, a skipped step that requests large resources can sit queued for hours before discovering it had nothing to do.

`CWLJobWrapper` already solves this for dynamic resource requirements: it runs as a cheap local job that resolves inputs before spawning the real job. This routes `when`-conditional steps through the same wrapper, so the condition is checked with fully-resolved inputs — including promises from upstream step outputs — before the real job is ever created. Skipped steps never touch the batch system.

Resolves #3990 

## Changelog Entry
To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:

 * Toil now checks CWL `when` conditionals on the leader before scheduling, so steps that evaluate false are never submitted to the real batch system.

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

