### PR TITLE
Call record_workflow_creation on every run

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1133,15 +1133,6 @@ class Toil(ContextManager["Toil"]):
         if not config.restart:
             config.prepare_start()
             jobStore.initialize(config)
-            assert config.workflowID is not None
-            # Record that there is a workflow beign run
-            HistoryManager.record_workflow_creation(
-                config.workflowID, self.canonical_locator(config.jobStore)
-            )
-            # And since we have all its metadata now, record that
-            HistoryManager.record_workflow_metadata(
-                config.workflowID, self._workflow_name, self._trs_spec
-            )
         else:
             jobStore.resume()
             # Merge configuration from job store with command line options
@@ -1149,6 +1140,16 @@ class Toil(ContextManager["Toil"]):
             config.prepare_restart()
             config.setOptions(self.options)
             jobStore.write_config()
+
+        assert config.workflowID is not None
+        # Record that there is a workflow being run, in case this history database doesn't know about it yet
+        if HistoryManager.record_workflow_creation(
+            config.workflowID, self.canonical_locator(config.jobStore)
+        ):
+            # And since we have all its metadata now, record that
+            HistoryManager.record_workflow_metadata(
+                config.workflowID, self._workflow_name, self._trs_spec
+            )
         self.config = config
         self._jobStore = jobStore
         self._start_time = time.time()

--- a/src/toil/lib/history.py
+++ b/src/toil/lib/history.py
@@ -366,14 +366,13 @@ class HistoryManager:
 
     @classmethod
     @db_retry
-    def record_workflow_creation(cls, workflow_id: str, job_store_spec: str) -> None:
+    def record_workflow_creation(cls, workflow_id: str, job_store_spec: str) -> bool:
         """
         Record that a workflow is being run.
 
         Takes the Toil config's workflow ID and the location of the job store.
 
-        Should only be called on the *first* attempt on a job store, not on a
-        restart.
+        Idempotent: safe to call again for a workflow ID that is already known.
 
         A workflow may have multiple attempts to run it, some of which succeed
         and others of which fail. Probably only the last one should succeed.
@@ -382,10 +381,13 @@ class HistoryManager:
             be canonical and always start with the type and a colon. If the
             job store is later moved by the user, the location will not be
             updated.
+
+        :return: True if this call created the workflow's record, or False if
+            a record for this workflow ID already existed.
         """
 
         if not cls.enabled():
-            return
+            return False
 
         logger.info(
             "Recording workflow creation of %s in %s", workflow_id, job_store_spec
@@ -396,9 +398,10 @@ class HistoryManager:
         try:
             cls.ensure_tables(con, cur)
             cur.execute(
-                "INSERT INTO workflows VALUES (?, ?, ?, NULL, NULL)",
+                "INSERT OR IGNORE INTO workflows VALUES (?, ?, ?, NULL, NULL)",
                 (workflow_id, job_store_spec, time.time()),
             )
+            created = cur.rowcount == 1
         except:
             con.rollback()
             con.close()
@@ -408,6 +411,7 @@ class HistoryManager:
             con.close()
 
         # If we raise out of here the connection goes away and the transaction rolls back.
+        return created
 
     @classmethod
     @db_retry

--- a/src/toil/lib/history.py
+++ b/src/toil/lib/history.py
@@ -269,6 +269,10 @@ class HistoryManager:
                     CREATE TABLE workflows (
                         id TEXT NOT NULL PRIMARY KEY,
                         job_store TEXT NOT NULL,
+                        /*
+                        creation_time is when the database record was created,
+                        not when the workflow was first run
+                        */
                         creation_time REAL NOT NULL,
                         name TEXT,
                         trs_spec TEXT

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -1406,10 +1406,18 @@ class TestCWLWorkflow:
             with subtests.test(msg=f"Testing input {in_file} for status {status}"):
                 with get_data(in_file) as jobfile:
                     args = [TRS_SPEC, str(jobfile), f"--outdir={str(tmp_path)}"]
-                    with patch("toil.common.HistoryManager.record_workflow_metadata") as mock_record:
+                    with patch(
+                        "toil.common.HistoryManager.record_workflow_creation",
+                        return_value=True,
+                    ), patch(
+                        "toil.common.HistoryManager.record_workflow_metadata"
+                    ) as mock_record:
                         # History tracking is off for the tests that aren't really
                         # history tests, so we check if the TRS ID goes into the
                         # history system and not really if it goes to Dockstore.
+                        # record_workflow_creation is also mocked to report that
+                        # it created a new record, since record_workflow_metadata
+                        # is only called when it does.
                         #
                         # We know that common.py is talking to the
                         # HistoryManager and that it imports it with as.

--- a/src/toil/test/lib/test_history.py
+++ b/src/toil/test/lib/test_history.py
@@ -239,19 +239,17 @@ class TestHistory:
     def test_history_workflow_creation_is_idempotent(self) -> None:
         """
         Make sure record_workflow_creation can be called more than once for
-        the same workflow without error, reports whether it actually created
-        the record, and doesn't clobber an already-recorded job store.
+        the same workflow without error, and only reports creating the
+        record the first time.
         """
         workflow_id = "999"
+        job_store_spec = "file:/tmp/tree"
 
-        assert HistoryManager.record_workflow_creation(workflow_id, "file:/tmp/first") is True
+        assert HistoryManager.record_workflow_creation(workflow_id, job_store_spec) is True
         assert HistoryManager.count_workflows() == 1
 
-        assert HistoryManager.record_workflow_creation(workflow_id, "file:/tmp/second") is False
+        assert HistoryManager.record_workflow_creation(workflow_id, job_store_spec) is False
         assert HistoryManager.count_workflows() == 1
-
-        [summary] = HistoryManager.summarize_workflows()
-        assert summary.job_store == "file:/tmp/first"
 
     def test_history_attempt_after_restart_backfill(self) -> None:
         """

--- a/src/toil/test/lib/test_history.py
+++ b/src/toil/test/lib/test_history.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import sqlite3
 import time
 from collections.abc import Generator
 from pathlib import Path
@@ -234,3 +235,41 @@ class TestHistory:
         remaining_workflows = HistoryManager.count_workflows()
         logger.info("Still have %s workflows", remaining_workflows)
         assert remaining_workflows > 0
+
+    def test_history_workflow_creation_is_idempotent(self) -> None:
+        """
+        Make sure record_workflow_creation can be called more than once for
+        the same workflow without error, reports whether it actually created
+        the record, and doesn't clobber an already-recorded job store.
+        """
+        workflow_id = "999"
+
+        assert HistoryManager.record_workflow_creation(workflow_id, "file:/tmp/first") is True
+        assert HistoryManager.count_workflows() == 1
+
+        assert HistoryManager.record_workflow_creation(workflow_id, "file:/tmp/second") is False
+        assert HistoryManager.count_workflows() == 1
+
+        [summary] = HistoryManager.summarize_workflows()
+        assert summary.job_store == "file:/tmp/first"
+
+    def test_history_attempt_after_restart_backfill(self) -> None:
+        """
+        Make sure that recording a workflow attempt works even when this
+        history database never saw the workflow's creation, as long as the
+        workflow is recorded first, as Toil now does on every restart and
+        not just the first attempt.
+        """
+        workflow_id = "1000"
+
+        # Recording an attempt for a workflow this database has never heard
+        # of fails, because of the foreign key relationship.
+        with pytest.raises(sqlite3.IntegrityError):
+            HistoryManager.record_workflow_attempt(workflow_id, 1, True, time.time(), 0.1)
+
+        # Recording the workflow first fixes that.
+        assert HistoryManager.record_workflow_creation(workflow_id, "file:/tmp/tree") is True
+        HistoryManager.record_workflow_attempt(workflow_id, 1, True, time.time(), 0.1)
+
+        assert HistoryManager.count_workflows() == 1
+        assert HistoryManager.count_workflow_attempts() == 1


### PR DESCRIPTION
Claude summarized that restarting a Toil workflow from a different container crashes at exit with a FOREIGN KEY constraint failed - the new container's local history database never recorded the workflow's creation, since that only happened on first attempts, not restarts.

Make record_workflow_creation idempotent, and call it on every run (not just first attempts) so a restart backfills the missing row before the workflow finishes.

We thought through whether this would cause trouble for Dockstore and decided it would not since Dockstore deals in attempts and not entire workflows.

Address #5544

## Changelog Entry

To be copied to the [draft changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog) by merger:
 * Toil no longer crashes when restarting a Toil workflow from a different machine

## Reviewer Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

 * [ ] Make sure it is coming from `issues/XXXX-fix-the-thing` in the Toil repo, or from an external repo.
    * [ ] If it is coming from an external repo, make sure to pull it in for CI with:
        ```
        contrib/admin/test-pr otheruser theirbranchname issues/XXXX-fix-the-thing
        ```
    * [ ] If there is no associated issue, [create one](https://github.com/DataBiosphere/toil/issues/new).
* [ ] Read through the code changes. Make sure that it doesn't have:
    * [ ] Addition of trailing whitespace.
    * [ ] New variable or member names in `camelCase` that want to be in `snake_case`.
    * [ ] New functions without [type hints](https://docs.python.org/3/library/typing.html).
    * [ ] New functions or classes without informative docstrings.
    * [ ] Changes to semantics not reflected in the relevant docstrings.
    * [ ] New or changed command line options for Toil workflows that are not reflected in `docs/running/{cliOptions,cwl,wdl}.rst` 
    * [ ] New features without tests.
* [ ] Comment on the lines of code where problems exist with a review comment. You can shift-click the line numbers in the diff to select multiple lines.
* [ ] Finish the review with an overall description of your opinion.

## Merger Checklist

<!-- To be kept in sync with docs/contributing/checklists.rst -->

* [ ] Make sure the PR passed tests, including the Gitlab tests, for the most recent commit in its branch.
* [ ] Make sure the PR has been reviewed. If not, review it. If it has been reviewed and any requested changes seem to have been addressed, proceed.
* [ ] Merge with the Github "Squash and merge" feature.
    * [ ] If there are multiple authors' commits, add [Co-authored-by](https://github.blog/2018-01-29-commit-together-with-co-authors/) to give credit to all contributing authors.
* [ ] Copy its recommended changelog entry to the [Draft Changelog](https://github.com/DataBiosphere/toil/wiki/Draft-Changelog).
* [ ] Append the issue number in parentheses to the changelog entry.

